### PR TITLE
Do not download the file if its already there

### DIFF
--- a/drop-transfer/src/protocol/v3.rs
+++ b/drop-transfer/src/protocol/v3.rs
@@ -13,6 +13,8 @@
 //! * client (sender)   -> server (receiver): `Chunk (file)`
 //! * server (receiver) ->   client (sender): `Progress (file)`
 //!
+//! This message indicate that the file is downloaded. Can be sent without
+//! `Start` in case the downloaded file is already there
 //! * server (receiver) ->   client (sender): `Done (file)`
 
 use std::{collections::HashMap, net::IpAddr};

--- a/drop-transfer/src/protocol/v3.rs
+++ b/drop-transfer/src/protocol/v3.rs
@@ -2,10 +2,10 @@
 //!
 //! * client (sender)   -> server (receiver): `TransferRequest`
 //!
-//! * server (receiver) ->   client (sender): `Init (file)`
-//!
-//! If the server has the file or a part of it, the `Init` request contains
-//! the `checksum` field. In that case sender mut reqport the checksum
+//! If the server has the file or a part of it, the server can request checksum
+//! from the client. In that case sender mut reqport the checksum. The request
+//! can be repeated
+//! * server (receiver) ->   client (sender): `ReqChsum (file)`
 //! * client (sender)   -> server (receiver): `ReportChsum (file)`
 //!
 //! If the server needs to download something:
@@ -40,13 +40,8 @@ pub struct TransferRequest {
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-pub struct Init {
-    pub file: FileId,
-    pub checksum: Option<ReqChsum>,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
 pub struct ReqChsum {
+    pub file: FileId,
     // Up to which point calculate checksum
     pub limit: u64,
 }
@@ -93,7 +88,7 @@ pub enum ServerMsg {
     Progress(Progress),
     Done(Done),
     Error(Error),
-    Init(Init),
+    ReqChsum(ReqChsum),
     Start(Start),
     Cancel(Cancel),
 }

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -223,14 +223,13 @@ impl Service {
 
         let task = moose_try_file!(
             self.state.moose,
-            FileXferTask::new(file, xfer, location),
+            FileXferTask::new(file, file_id, xfer, location),
             uuid,
             file_info
         );
 
         channel
             .send(ServerReq::Download {
-                file: file_id,
                 task: Box::new(task),
             })
             .map_err(|_| Error::BadTransfer)?;

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -36,6 +36,7 @@ pub trait HandlerLoop {
 pub trait Uploader: Send + 'static {
     async fn chunk(&mut self, chunk: &[u8]) -> crate::Result<()>;
     async fn error(&mut self, msg: String);
-    /// Initalizes the file transfer and return an offset from where to start
-    async fn init(&mut self, xfile: &crate::File) -> crate::Result<u64>;
+
+    // File stream offset
+    fn offset(&self) -> u64;
 }

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -293,9 +293,7 @@ fn start_upload(
                 .start(Event::FileUploadStarted(xfer.clone(), file_id.clone()))
                 .await;
 
-            let offset = uploader.init(&xfile).await?;
-
-            let mut iofile = match xfile.open(offset) {
+            let mut iofile = match xfile.open(uploader.offset()) {
                 Ok(f) => f,
                 Err(err) => {
                     error!(

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -356,8 +356,8 @@ impl handler::Uploader for Uploader {
         let _ = self.sink.send(Message::from(&msg)).await;
     }
 
-    async fn init(&mut self, _: &crate::File) -> crate::Result<u64> {
-        Ok(0)
+    fn offset(&self) -> u64 {
+        0
     }
 }
 

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -40,18 +40,18 @@ pub trait Request {
 
 #[derive(Debug, Clone)]
 pub enum DownloadInit {
-    Stream { offset: u64 },
-    AlreadyDone { destination: Hidden<PathBuf> },
+    Stream {
+        offset: u64,
+        tmp_location: Hidden<PathBuf>,
+    },
+    AlreadyDone {
+        destination: Hidden<PathBuf>,
+    },
 }
 
 #[async_trait::async_trait]
 pub trait Downloader {
-    async fn eval_tmp_location(
-        &mut self,
-        task: &super::FileXferTask,
-    ) -> crate::Result<Hidden<PathBuf>>;
-
-    async fn init(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<DownloadInit>;
+    async fn init(&mut self, task: &super::FileXferTask) -> crate::Result<DownloadInit>;
     async fn open(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<fs::File>;
     async fn progress(&mut self, bytes: u64) -> crate::Result<()>;
     async fn done(&mut self, bytes: u64) -> crate::Result<()>;

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -38,6 +38,12 @@ pub trait Request {
     fn parse(self) -> anyhow::Result<crate::Transfer>;
 }
 
+#[derive(Debug, Clone)]
+pub enum DownloadInit {
+    Stream { offset: u64 },
+    AlreadyDone { destination: Hidden<PathBuf> },
+}
+
 #[async_trait::async_trait]
 pub trait Downloader {
     async fn eval_tmp_location(
@@ -45,7 +51,7 @@ pub trait Downloader {
         task: &super::FileXferTask,
     ) -> crate::Result<Hidden<PathBuf>>;
 
-    async fn init(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<()>;
+    async fn init(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<DownloadInit>;
     async fn open(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<fs::File>;
     async fn progress(&mut self, bytes: u64) -> crate::Result<()>;
     async fn done(&mut self, bytes: u64) -> crate::Result<()>;

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -123,27 +123,26 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
     fn issue_download(
         &mut self,
         _: &mut WebSocket,
-        file: FileId,
-        task: Box<super::FileXferTask>,
+        task: super::FileXferTask,
     ) -> anyhow::Result<()> {
         let is_running = self
             .jobs
-            .get(&file)
+            .get(&task.file_id)
             .map_or(false, |state| !state.job.is_finished());
 
         if is_running {
             return Ok(());
         }
 
+        let file_id = task.file_id.clone();
         let state = FileTask::start(
             self.msg_tx.clone(),
             self.state.clone(),
-            file.clone(),
             task,
             self.logger.clone(),
         );
 
-        self.jobs.insert(file, state);
+        self.jobs.insert(file_id, state);
 
         Ok(())
     }
@@ -242,7 +241,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
 impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
     async fn on_req(&mut self, ws: &mut WebSocket, req: ServerReq) -> anyhow::Result<()> {
         match req {
-            ServerReq::Download { file, task } => self.issue_download(ws, file, task)?,
+            ServerReq::Download { task } => self.issue_download(ws, *task)?,
             ServerReq::Cancel { file } => self.issue_cancel(ws, file).await?,
         }
 
@@ -419,11 +418,13 @@ impl handler::Downloader for Downloader {
         Ok(Hidden(tmp_location))
     }
 
-    async fn init(&mut self, _: &Hidden<PathBuf>) -> crate::Result<()> {
+    async fn init(&mut self, _: &Hidden<PathBuf>) -> crate::Result<handler::DownloadInit> {
         let msg = v2::ServerMsg::Start(v2::Download {
             file: self.file_id.clone(),
         });
-        self.send(Message::from(&msg)).await
+        self.send(Message::from(&msg)).await?;
+
+        Ok(handler::DownloadInit::Stream { offset: 0 })
     }
 
     async fn open(&mut self, path: &Hidden<PathBuf>) -> crate::Result<fs::File> {
@@ -460,25 +461,18 @@ impl FileTask {
     fn start(
         msg_tx: Sender<Message>,
         state: Arc<State>,
-        file_id: FileId,
-        task: Box<super::FileXferTask>,
+        task: super::FileXferTask,
         logger: slog::Logger,
     ) -> Self {
         let events = Arc::new(FileEventTx::new(&state));
         let (chunks_tx, chunks_rx) = mpsc::unbounded_channel();
 
-        let job = tokio::spawn(task.run(
-            state,
-            Arc::clone(&events),
-            Downloader {
-                file_id: file_id.clone(),
-                msg_tx,
-                tmp_loc: None,
-            },
-            chunks_rx,
-            file_id,
-            logger,
-        ));
+        let downloader = Downloader {
+            file_id: task.file_id.clone(),
+            msg_tx,
+            tmp_loc: None,
+        };
+        let job = tokio::spawn(task.run(state, Arc::clone(&events), downloader, chunks_rx, logger));
 
         Self {
             job,

--- a/test/run.py
+++ b/test/run.py
@@ -107,6 +107,8 @@ async def main():
         "nested/big/testfile-02": 10 * 1024,
         "testfile.small.with.complicated.extension": 1 * 1024,
         "with-illegal-char-\x0A-": 1 * 1024,
+        "duplicate/testfile-small": 1 * 1024,
+        "duplicate/testfile.small.with.complicated.extension": 1 * 1024,
     }
 
     symlinks = {


### PR DESCRIPTION
Added the check if the file to be downloaded is already there.
Needed to change the V3 protocol a bit because previous iteration didn't allow for multiple checksum requests.

There is still a caveat here. I'm not able to resume and check for existence the directory transfer, because it's really hard do deal with it and I don't even know how. I'm leaving the issue behind since with the use of transfers DB the issue might disappear magically 