### PR TITLE
Configure Android SONAME

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Return more status codes from the ffi layer methods
 * The `FileDownloaded` event reports the full file path
 * Improve moose error handling
+* Configure Android SONAME
 
 ---
 <br>

--- a/norddrop/build.rs
+++ b/norddrop/build.rs
@@ -126,6 +126,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     if target_os == "windows" {
         create_winres(&version)?;
     }
+    if target_os == "android" {
+        let pkg_name = env!("CARGO_PKG_NAME");
+        let soname = format!("lib{}.so", pkg_name);
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{}", soname);
+    }
 
     Ok(())
 }


### PR DESCRIPTION
SONAME should be provided by Android libs and is enforced with newer API https://android.googlesource.com/platform/bionic/+/master/android-changes-for-ndk-developers.md#missing-soname-enforced-for-api-level-23

Similar change has been introduced to libnudler and is on its way to libtelio.