### PR TITLE
fix not receiving `FileUploadStarted` and `FileUploadSuccess` events …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+### UNRELEASED
+### **UNRELEASED**
+---
+* Fix not receiving `FileUploadStarted` and `FileUploadSuccess` events before the transfer is canceled
+
+---
+<br>
+
 ### v2.0.0
 ### **Brzęczyszczykiewicz**
 ---

--- a/drop-transfer/src/ws/client/v3.rs
+++ b/drop-transfer/src/ws/client/v3.rs
@@ -184,7 +184,7 @@ impl HandlerLoop<'_> {
         file_id: FileId,
         offset: u64,
     ) -> anyhow::Result<()> {
-        let mut f = || {
+        let start = async {
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
                     let task = o.into_mut();
@@ -197,7 +197,8 @@ impl HandlerLoop<'_> {
                             self.xfer.clone(),
                             file_id.clone(),
                             offset,
-                        )?;
+                        )
+                        .await?;
                     } else {
                         anyhow::bail!("Transfer already in progress");
                     }
@@ -210,7 +211,8 @@ impl HandlerLoop<'_> {
                         self.xfer.clone(),
                         file_id.clone(),
                         offset,
-                    )?;
+                    )
+                    .await?;
 
                     v.insert(task);
                 }
@@ -220,7 +222,7 @@ impl HandlerLoop<'_> {
             anyhow::Ok(())
         };
 
-        if let Err(err) = f() {
+        if let Err(err) = start.await {
             error!(self.logger, "Failed to start upload: {:?}", err);
 
             let msg = v3::Error {
@@ -309,6 +311,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 
         match msg {
             Message::Text(json) => {
+                debug!(self.logger, "Received:\n\t{json}");
+
                 let msg: v3::ServerMsg =
                     serde_json::from_str(&json).context("Failed to deserialize server message")?;
 
@@ -428,7 +432,7 @@ impl handler::Uploader for Uploader {
 }
 
 impl FileTask {
-    fn start(
+    async fn start(
         state: Arc<State>,
         logger: &slog::Logger,
         sink: Sender<Message>,
@@ -451,7 +455,8 @@ impl FileTask {
             uploader,
             xfer,
             file_id,
-        )?;
+        )
+        .await?;
 
         Ok(Self { job, events })
     }

--- a/drop-transfer/src/ws/server/v3.rs
+++ b/drop-transfer/src/ws/server/v3.rs
@@ -295,6 +295,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         self.last_recv = Instant::now();
 
         if let Ok(json) = msg.to_str() {
+            debug!(self.logger, "Received:\n\t{json}");
+
             let msg: v3::ClientMsg =
                 serde_json::from_str(json).context("Failed to deserialize json")?;
 

--- a/test/run.py
+++ b/test/run.py
@@ -109,6 +109,7 @@ async def main():
         "with-illegal-char-\x0A-": 1 * 1024,
         "duplicate/testfile-small": 1 * 1024,
         "duplicate/testfile.small.with.complicated.extension": 1 * 1024,
+        "zero-sized-file": 0,
     }
 
     symlinks = {

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3351,4 +3351,69 @@ scenarios = [
             ),
         },
     ),
+    Scenario(
+        "scenario22",
+        "Send one zero sized file to a peer, expect it to be transferred",
+        {
+            "ren": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/zero-sized-file"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File("zero-sized-file", 0),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, "zero-sized-file")),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            0,
+                            "zero-sized-file",
+                        )
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File("zero-sized-file", 0),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        "zero-sized-file",
+                        "/tmp/received/22",
+                    ),
+                    action.Wait(event.Start(0, "zero-sized-file")),
+                    action.Wait(
+                        event.FinishFileDownloaded(
+                            0,
+                            "zero-sized-file",
+                            "/tmp/received/22/zero-sized-file",
+                        )
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            event.File("/tmp/received/22/zero-sized-file", 0),
+                        ],
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]


### PR DESCRIPTION
…before the transfer is canceled

As it turned out, the `FileUploadStart` event (which blocks all other events) was emitted in the async thread, so for small files sometimes it lagged after the transfer cancelation. This resulted in no events being emitted about a particular file upload, despite it being fully transferred.

Emitting the `FileUploadStart` on the same thread as WS message handling should fix the problem.

I managed to reproduce the problem with `udrop`. After applying the fix, the problem seems to be gone