### PR TITLE
Moose init error only on non-prod

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Fix not receiving `FileUploadStarted` and `FileUploadSuccess` events before the transfer is canceled
 * Fix java public key callback related errors
 * Fix the wrong `by_peer` field in `FileCanceled` event when the sender cancels the file upload
+* Return moose init error only on non-prod
 
 ---
 <br>

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -104,7 +104,12 @@ impl NordDropFFI {
             Ok(moose) => moose,
             Err(err) => {
                 error!(logger, "Failed to init moose: {:?}", err);
-                return Err(ffi::types::NORDDROP_RES_ERROR);
+
+                if self.config.moose.prod == false {
+                    return Err(ffi::types::NORDDROP_RES_ERROR);
+                }
+
+                drop_analytics::moose_mock()
             }
         };
 

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -109,6 +109,7 @@ impl NordDropFFI {
                     return Err(ffi::types::NORDDROP_RES_ERROR);
                 }
 
+                warn!(logger, "Falling back to mock moose implementation");
                 drop_analytics::moose_mock()
             }
         };

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -105,7 +105,7 @@ impl NordDropFFI {
             Err(err) => {
                 error!(logger, "Failed to init moose: {:?}", err);
 
-                if self.config.moose.prod == false {
+                if !self.config.moose.prod {
                     return Err(ffi::types::NORDDROP_RES_ERROR);
                 }
 


### PR DESCRIPTION
Return moose error only when on non-prod, otherwise just use the mock implementation