### PR TITLE
norddrop: Add lib crate type back

### DIFF
--- a/norddrop/Cargo.toml
+++ b/norddrop/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Lukas Pukenis"]
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
 uuid = { version = "1.3", features = ["serde", "v4"] }


### PR DESCRIPTION
Since the platforms builds now specify their own crate types in the command line, we can bring back the lib type for Linux builds.