### PR TITLE
Fix C# pubkey callback bindings

### DIFF
--- a/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
+++ b/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
@@ -75,7 +75,7 @@ public class Norddrop : global::System.IDisposable {
 
   public delegate void EventDelegate(string message);
   public delegate void LoggerDelegate(NorddropLogLevel level, string message);
-  public delegate int PubkeyDelegate(string ip, out byte[] pubkey);
+  public delegate int PubkeyDelegate(string ip, byte* pubkey);
 
   public Norddrop(EventDelegate events, NorddropLogLevel level, LoggerDelegate logger, PubkeyDelegate pubkeyCb, string privkey) : this(libnorddropPINVOKE.new_Norddrop(events, (int)level, logger, pubkeyCb, privkey), true) {
     if (libnorddropPINVOKE.SWIGPendingException.Pending) throw libnorddropPINVOKE.SWIGPendingException.Retrieve();

--- a/norddrop/ffi/norddropcs.i
+++ b/norddrop/ffi/norddropcs.i
@@ -30,7 +30,7 @@ int call_norddrop_pubkey_cb(void *ctx, const char* ip, char* privkey) {
 %typemap(cscode) norddrop %{
   public delegate void EventDelegate(string message);
   public delegate void LoggerDelegate(NorddropLogLevel level, string message);
-  public delegate int PubkeyDelegate(string ip, out byte[] pubkey);
+  public delegate int PubkeyDelegate(string ip, byte* pubkey);
 %}
 
 %typemap(cstype) norddrop_event_cb "EventDelegate";


### PR DESCRIPTION
Current declaration was
```
out byte[]
```
Which in C# meant that it must be overwritten
The proper fix is to have
```
byte*
```

This is not as nice however it solves the problem as C# now is able to directly write data to this buffer