### PR TITLE
Shared crate for types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,10 +507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "drop-config"
-version = "1.0.0"
-
-[[package]]
 name = "drop-storage"
 version = "1.0.0"
 dependencies = [
@@ -529,8 +525,8 @@ dependencies = [
  "core-foundation",
  "drop-analytics",
  "drop-auth",
- "drop-config",
  "drop-storage",
+ "drop-types",
  "futures",
  "futures-util",
  "hex",
@@ -554,6 +550,10 @@ dependencies = [
  "uuid",
  "warp",
 ]
+
+[[package]]
+name = "drop-types"
+version = "1.0.0"
 
 [[package]]
 name = "either"
@@ -1140,9 +1140,9 @@ dependencies = [
  "cc",
  "drop-analytics",
  "drop-auth",
- "drop-config",
  "drop-storage",
  "drop-transfer",
+ "drop-types",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,10 @@ dependencies = [
 [[package]]
 name = "drop-types"
 version = "1.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = [
     "drop-analytics",
     "drop-transfer",
     "drop-auth",
-    "drop-config",
     "drop-storage",
+    "drop-types",
     "norddrop",
 ]
 

--- a/drop-config/Cargo.toml
+++ b/drop-config/Cargo.toml
@@ -1,6 +1,0 @@
-[package]
-name = "drop-config"
-version = "1.0.0"
-authors = ["Lukas Pukenis"]
-edition = "2021"
-

--- a/drop-transfer/Cargo.toml
+++ b/drop-transfer/Cargo.toml
@@ -19,7 +19,7 @@ tempfile = "3.5.0"
 anyhow = "1.0.70"
 async-trait = { workspace = true }
 drop-analytics = { version = "1.0.0", path = "../drop-analytics" }
-drop-config = { version = "1.0.0", path = "../drop-config" }
+drop-types = { version = "1.0.0", path = "../drop-types" }
 drop-auth = { path = "../drop-auth" }
 drop-storage = { version = "1.0.0", path = "../drop-storage" }
 futures = "0.3"

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -11,8 +11,8 @@ use std::{
 use anyhow::Context;
 use clap::{arg, command, value_parser, ArgAction, Command};
 use drop_auth::{PUBLIC_KEY_LENGTH, SECRET_KEY_LENGTH};
-use drop_config::DropConfig;
 use drop_transfer::{auth, Event, File, Service, Transfer};
+use drop_types::config::DropConfig;
 use slog::{o, Drain, Logger};
 use slog_scope::{info, warn};
 use tokio::sync::{mpsc, watch, Mutex};

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use drop_analytics::FileInfo;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 pub use id::FileId;
 pub use reader::FileReader;
 use sha2::Digest;
@@ -311,7 +311,7 @@ mod tests {
     fn file_checksum() {
         use std::io::Write;
 
-        use drop_config::DropConfig;
+        use drop_types::config::DropConfig;
 
         let csum = {
             let mut tmp = tempfile::NamedTempFile::new().expect("Failed to create tmp file");

--- a/drop-transfer/src/protocol/v1.rs
+++ b/drop-transfer/src/protocol/v1.rs
@@ -10,7 +10,7 @@
 
 use std::{net::IpAddr, sync::Arc};
 
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 pub use super::v3::{Chunk, Error, File, Progress};

--- a/drop-transfer/src/protocol/v3.rs
+++ b/drop-transfer/src/protocol/v3.rs
@@ -20,7 +20,7 @@
 use std::{collections::HashMap, net::IpAddr, sync::Arc};
 
 use anyhow::Context;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use drop_analytics::Moose;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use slog::{debug, error, warn, Logger};
 use tokio::{
     sync::{mpsc, Mutex},

--- a/drop-transfer/src/transfer.rs
+++ b/drop-transfer/src/transfer.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, net::IpAddr};
 
 use drop_analytics::TransferInfo;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use uuid::Uuid;
 
 use crate::{file::FileId, utils::Hidden, Error, File};

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -138,7 +138,7 @@ async fn make_request(
     auth: &auth::Context,
     logger: &slog::Logger,
 ) -> Result<(), tungstenite::Error> {
-    let url = format!("ws://{ip}:{}/drop/{version}", drop_config::PORT);
+    let url = format!("ws://{ip}:{}/drop/{version}", drop_types::config::PORT);
 
     let err = match tokio_tungstenite::client_async(&url, &mut *socket).await {
         Ok(_) => {
@@ -191,7 +191,7 @@ async fn tcp_connect(state: &State, ip: IpAddr, logger: &Logger) -> TcpStream {
     let mut sleep_time = Duration::from_millis(200);
 
     loop {
-        match TcpStream::connect((ip, drop_config::PORT)).await {
+        match TcpStream::connect((ip, drop_types::config::PORT)).await {
             Ok(sock) => break sock,
             Err(err) => {
                 debug!(

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -194,7 +194,7 @@ pub(crate) fn start(
     };
 
     let future = match warp::serve(service)
-        .try_bind_with_graceful_shutdown((addr, drop_config::PORT), async move {
+        .try_bind_with_graceful_shutdown((addr, drop_types::config::PORT), async move {
             stop.cancelled().await
         }) {
         Ok((_, future)) => future,
@@ -211,7 +211,7 @@ pub(crate) fn start(
                         "Found that the address {}:{} is already used, while trying to bind the \
                          WS server: {}",
                         addr,
-                        drop_config::PORT,
+                        drop_types::config::PORT,
                         ioerr
                     );
                     return Err(Error::AddrInUse);

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::Context;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use futures::{SinkExt, StreamExt};
 use sha1::Digest;
 use slog::{debug, error, warn};

--- a/drop-transfer/src/ws/server/v3.rs
+++ b/drop-transfer/src/ws/server/v3.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use anyhow::Context;
-use drop_config::DropConfig;
+use drop_types::config::DropConfig;
 use futures::{SinkExt, StreamExt};
 use slog::{debug, error, info, warn};
 use tokio::{

--- a/drop-types/Cargo.toml
+++ b/drop-types/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "drop-types"
+version = "1.0.0"
+edition = "2021"
+
+[dependencies]

--- a/drop-types/Cargo.toml
+++ b/drop-types/Cargo.toml
@@ -4,3 +4,5 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/drop-types/src/config.rs
+++ b/drop-types/src/config.rs
@@ -18,6 +18,12 @@ pub struct DropConfig {
     pub storage_path: String,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct MooseConfig {
+    pub event_path: String,
+    pub prod: bool,
+}
+
 impl Default for DropConfig {
     fn default() -> Self {
         Self {
@@ -29,12 +35,6 @@ impl Default for DropConfig {
             storage_path: "libdrop.sqlite".to_string(),
         }
     }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct MooseConfig {
-    pub event_path: String,
-    pub prod: bool,
 }
 
 impl DropConfig {

--- a/drop-types/src/config.rs
+++ b/drop-types/src/config.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+pub const PORT: u16 = 49111;
+
 #[derive(Debug, Clone, Default)]
 pub struct Config {
     pub drop: DropConfig,
@@ -34,8 +36,6 @@ pub struct MooseConfig {
     pub event_path: String,
     pub prod: bool,
 }
-
-pub const PORT: u16 = 49111;
 
 impl DropConfig {
     pub fn ping_interval(&self) -> Duration {

--- a/drop-types/src/ffi.rs
+++ b/drop-types/src/ffi.rs
@@ -1,0 +1,113 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct Config {
+    pub dir_depth_limit: usize,
+    pub transfer_file_limit: usize,
+    pub req_connection_timeout_ms: u64,
+    #[serde(default = "default_connection_max_retry_interval_ms")]
+    pub connection_max_retry_interval_ms: u64,
+    pub transfer_idle_lifetime_ms: u64,
+    pub moose_event_path: String,
+    pub moose_prod: bool,
+    pub storage_path: String,
+}
+
+const fn default_connection_max_retry_interval_ms() -> u64 {
+    10000
+}
+
+impl From<Config> for crate::config::Config {
+    fn from(val: Config) -> Self {
+        let Config {
+            dir_depth_limit,
+            transfer_file_limit,
+            req_connection_timeout_ms,
+            connection_max_retry_interval_ms,
+            transfer_idle_lifetime_ms,
+            moose_event_path,
+            moose_prod,
+            storage_path,
+        } = val;
+
+        crate::config::Config {
+            drop: crate::config::DropConfig {
+                dir_depth_limit,
+                transfer_file_limit,
+                req_connection_timeout: Duration::from_millis(req_connection_timeout_ms),
+                connection_max_retry_interval: Duration::from_millis(
+                    connection_max_retry_interval_ms,
+                ),
+                transfer_idle_lifetime: Duration::from_millis(transfer_idle_lifetime_ms),
+                storage_path,
+            },
+            moose: crate::config::MooseConfig {
+                event_path: moose_event_path,
+                prod: moose_prod,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_config() {
+        // Without `connection_max_retry_interval_ms`
+        let json = r#"
+        {
+          "dir_depth_limit": 10,
+          "transfer_file_limit": 100,
+          "req_connection_timeout_ms": 1000,
+          "transfer_idle_lifetime_ms": 2000,
+          "moose_event_path": "test/path",
+          "moose_prod": true,
+          "storage_path": ":memory:"
+        }
+        "#;
+
+        let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
+        assert_eq!(cfg.connection_max_retry_interval_ms, 10000);
+
+        let json = r#"
+        {
+          "dir_depth_limit": 10,
+          "transfer_file_limit": 100,
+          "req_connection_timeout_ms": 1000,
+          "transfer_idle_lifetime_ms": 2000,
+          "connection_max_retry_interval_ms": 500,
+          "moose_event_path": "test/path",
+          "moose_prod": true,
+          "storage_path": ":memory:"
+        }
+        "#;
+
+        let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
+
+        let crate::config::Config {
+            drop:
+                crate::config::DropConfig {
+                    dir_depth_limit,
+                    transfer_file_limit,
+                    req_connection_timeout,
+                    transfer_idle_lifetime,
+                    connection_max_retry_interval,
+                    storage_path,
+                },
+            moose: crate::config::MooseConfig { event_path, prod },
+        } = cfg.into();
+
+        assert_eq!(dir_depth_limit, 10);
+        assert_eq!(transfer_file_limit, 100);
+        assert_eq!(req_connection_timeout, Duration::from_millis(1000));
+        assert_eq!(connection_max_retry_interval, Duration::from_millis(500));
+        assert_eq!(transfer_idle_lifetime, Duration::from_millis(2000));
+        assert_eq!(event_path, "test/path");
+        assert_eq!(storage_path, ":memory:");
+        assert!(prod);
+    }
+}

--- a/drop-types/src/lib.rs
+++ b/drop-types/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod config;

--- a/drop-types/src/lib.rs
+++ b/drop-types/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod config;
+pub mod ffi;

--- a/norddrop/Cargo.toml
+++ b/norddrop/Cargo.toml
@@ -17,7 +17,7 @@ tokio = { workspace = true }
 async-trait = { workspace = true }
 
 drop-transfer = { version = "1.0", path = "../drop-transfer" }
-drop-config = { version = "1.0", path = "../drop-config" }
+drop-types = { version = "1.0", path = "../drop-types" }
 drop-analytics = { version = "1.0", path = "../drop-analytics" }
 drop-auth = { path = "../drop-auth" }
 drop-storage = { version = "1.0", path = "../drop-storage" }

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use drop_auth::{PublicKey, SecretKey, PUBLIC_KEY_LENGTH};
-use drop_config::Config;
 use drop_transfer::{auth, utils::Hidden, File, Service, Transfer};
+use drop_types::config::Config;
 use slog::{debug, error, trace, warn, Logger};
 use tokio::sync::{mpsc, Mutex};
 
@@ -213,7 +213,7 @@ impl NordDropFFI {
             }
         };
 
-        let peer = (peer, drop_config::PORT)
+        let peer = (peer, drop_types::config::PORT)
             .to_socket_addrs()
             .map_err(|err| {
                 error!(self.logger, "Failed to perform lookup of address: {err}");

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -78,7 +78,7 @@ impl NordDropFFI {
 
         trace!(logger, "norddrop_start() listen address: {:?}", listen_addr,);
 
-        let config: types::Config = match serde_json::from_str(config_json) {
+        let config: drop_types::ffi::Config = match serde_json::from_str(config_json) {
             Ok(cfg) => {
                 debug!(logger, "start() called with config:\n{:#?}", cfg,);
                 cfg

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
 
 use drop_transfer::utils::Hidden;
 use serde::{Deserialize, Serialize};
@@ -76,23 +76,6 @@ pub enum Event {
         #[serde(flatten)]
         data: FinishEvent,
     },
-}
-
-#[derive(Deserialize, Clone, Debug)]
-pub struct Config {
-    pub dir_depth_limit: usize,
-    pub transfer_file_limit: usize,
-    pub req_connection_timeout_ms: u64,
-    #[serde(default = "default_connection_max_retry_interval_ms")]
-    pub connection_max_retry_interval_ms: u64,
-    pub transfer_idle_lifetime_ms: u64,
-    pub moose_event_path: String,
-    pub moose_prod: bool,
-    pub storage_path: String,
-}
-
-const fn default_connection_max_retry_interval_ms() -> u64 {
-    10000
 }
 
 impl From<drop_transfer::Event> for Event {
@@ -222,98 +205,5 @@ impl From<drop_transfer::Transfer> for EventRequestQueued {
             transfer: t.id().to_string(),
             files: t.files().iter().map(|(_, v)| v.into()).collect(),
         }
-    }
-}
-
-impl From<Config> for drop_types::config::Config {
-    fn from(val: Config) -> Self {
-        let Config {
-            dir_depth_limit,
-            transfer_file_limit,
-            req_connection_timeout_ms,
-            connection_max_retry_interval_ms,
-            transfer_idle_lifetime_ms,
-            moose_event_path,
-            moose_prod,
-            storage_path,
-        } = val;
-
-        drop_types::config::Config {
-            drop: drop_types::config::DropConfig {
-                dir_depth_limit,
-                transfer_file_limit,
-                req_connection_timeout: Duration::from_millis(req_connection_timeout_ms),
-                connection_max_retry_interval: Duration::from_millis(
-                    connection_max_retry_interval_ms,
-                ),
-                transfer_idle_lifetime: Duration::from_millis(transfer_idle_lifetime_ms),
-                storage_path,
-            },
-            moose: drop_types::config::MooseConfig {
-                event_path: moose_event_path,
-                prod: moose_prod,
-            },
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn deserialize_config() {
-        // Without `connection_max_retry_interval_ms`
-        let json = r#"
-        {
-          "dir_depth_limit": 10,
-          "transfer_file_limit": 100,
-          "req_connection_timeout_ms": 1000,
-          "transfer_idle_lifetime_ms": 2000,
-          "moose_event_path": "test/path",
-          "moose_prod": true,
-          "storage_path": ":memory:"
-        }
-        "#;
-
-        let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
-        assert_eq!(cfg.connection_max_retry_interval_ms, 10000);
-
-        let json = r#"
-        {
-          "dir_depth_limit": 10,
-          "transfer_file_limit": 100,
-          "req_connection_timeout_ms": 1000,
-          "transfer_idle_lifetime_ms": 2000,
-          "connection_max_retry_interval_ms": 500,
-          "moose_event_path": "test/path",
-          "moose_prod": true,
-          "storage_path": ":memory:"
-        }
-        "#;
-
-        let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
-
-        let drop_types::config::Config {
-            drop:
-                drop_types::config::DropConfig {
-                    dir_depth_limit,
-                    transfer_file_limit,
-                    req_connection_timeout,
-                    transfer_idle_lifetime,
-                    connection_max_retry_interval,
-                    storage_path,
-                },
-            moose: drop_types::config::MooseConfig { event_path, prod },
-        } = cfg.into();
-
-        assert_eq!(dir_depth_limit, 10);
-        assert_eq!(transfer_file_limit, 100);
-        assert_eq!(req_connection_timeout, Duration::from_millis(1000));
-        assert_eq!(connection_max_retry_interval, Duration::from_millis(500));
-        assert_eq!(transfer_idle_lifetime, Duration::from_millis(2000));
-        assert_eq!(event_path, "test/path");
-        assert_eq!(storage_path, ":memory:");
-        assert!(prod);
     }
 }

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -225,7 +225,7 @@ impl From<drop_transfer::Transfer> for EventRequestQueued {
     }
 }
 
-impl From<Config> for drop_config::Config {
+impl From<Config> for drop_types::config::Config {
     fn from(val: Config) -> Self {
         let Config {
             dir_depth_limit,
@@ -238,8 +238,8 @@ impl From<Config> for drop_config::Config {
             storage_path,
         } = val;
 
-        drop_config::Config {
-            drop: drop_config::DropConfig {
+        drop_types::config::Config {
+            drop: drop_types::config::DropConfig {
                 dir_depth_limit,
                 transfer_file_limit,
                 req_connection_timeout: Duration::from_millis(req_connection_timeout_ms),
@@ -249,7 +249,7 @@ impl From<Config> for drop_config::Config {
                 transfer_idle_lifetime: Duration::from_millis(transfer_idle_lifetime_ms),
                 storage_path,
             },
-            moose: drop_config::MooseConfig {
+            moose: drop_types::config::MooseConfig {
                 event_path: moose_event_path,
                 prod: moose_prod,
             },
@@ -294,9 +294,9 @@ mod tests {
 
         let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
 
-        let drop_config::Config {
+        let drop_types::config::Config {
             drop:
-                drop_config::DropConfig {
+                drop_types::config::DropConfig {
                     dir_depth_limit,
                     transfer_file_limit,
                     req_connection_timeout,
@@ -304,7 +304,7 @@ mod tests {
                     connection_max_retry_interval,
                     storage_path,
                 },
-            moose: drop_config::MooseConfig { event_path, prod },
+            moose: drop_types::config::MooseConfig { event_path, prod },
         } = cfg.into();
 
         assert_eq!(dir_depth_limit, 10);


### PR DESCRIPTION
It's becoming more and more painful to share common types between all of the crates we have, so before the circular dependencies get out of hand, we should move everything out to a separate crate