### PR TITLE
Implement file id as hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "uuid",
+ "walkdir",
  "warp",
 ]
 
@@ -1381,6 +1382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2139,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.21.0",
  "clap",
  "core-foundation",
  "drop-analytics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ members = [
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros"] }
 slog = { version = "2.7.0", features = ["release_max_level_info"] }
 async-trait = "0.1.68"
+base64 = "0.21.0"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ cargo run --example udrop -- -l 0.0.0.0 transfer $DROP_SERVER <path>
 
 You can verify the transfer by checking the file system in the server container under `/root/<path>`
 
+## Generating file ids from shell
+```bash
+echo -n "<absolute file path>" | sha256sum  | cut -d " " -f1 | xxd -ps -r | basenc --base64url | tr -d '='
+```
+
 # Contributing
 [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/drop-auth/Cargo.toml
+++ b/drop-auth/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = "0.21.0"
+base64 = { workspace = true }
 rand = "0.8.5"
 hmac = "0.12.1"
 x25519-dalek = "1.2.0"

--- a/drop-transfer/Cargo.toml
+++ b/drop-transfer/Cargo.toml
@@ -18,6 +18,7 @@ tempfile = "3.5.0"
 [dependencies]
 anyhow = "1.0.70"
 async-trait = { workspace = true }
+base64 = { workspace = true }
 drop-analytics = { version = "1.0.0", path = "../drop-analytics" }
 drop-config = { version = "1.0.0", path = "../drop-config" }
 drop-auth = { path = "../drop-auth" }

--- a/drop-transfer/Cargo.toml
+++ b/drop-transfer/Cargo.toml
@@ -41,6 +41,7 @@ tokio-tungstenite = "0.18.0"
 tokio-util = "0.7.7"
 uuid = { version = "1.3", features = ["v4", "serde"] }
 warp = { version = "0.3.4", default-features = false, features = ["websocket"] }
+walkdir = "2.3.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -73,11 +73,11 @@ async fn listen(
                     service
                         .lock()
                         .await
-                        .download(xfid, file.subpath().clone(), out_dir)
+                        .download(xfid, file.id(), out_dir)
                         .await
                         .context("Cannot issue download call")?;
 
-                    file_set.insert(file.subpath().clone());
+                    file_set.insert(file.id().clone());
                 }
 
                 if file_set.is_empty() {

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -69,15 +69,15 @@ async fn listen(
                     .entry(xfid)
                     .or_insert_with(HashSet::new);
 
-                for (file_id, _) in xfer.flat_file_list() {
+                for file in xfer.files().values() {
                     service
                         .lock()
                         .await
-                        .download(xfid, file_id.clone(), out_dir)
+                        .download(xfid, file.subpath().clone(), out_dir)
                         .await
                         .context("Cannot issue download call")?;
 
-                    file_set.insert(file_id);
+                    file_set.insert(file.subpath().clone());
                 }
 
                 if file_set.is_empty() {
@@ -317,18 +317,18 @@ async fn main() -> anyhow::Result<()> {
 
         info!("Sending transfer request to {}", addr);
 
-        let xfer = Transfer::new(
-            *addr,
-            matches
-                .get_many::<String>("FILE")
-                .expect("Missing transfer `FILE` field")
-                .map(|p| File::from_path(p, None, &config))
-                .collect::<Result<Vec<File>, _>>()
-                .context("Cannot build transfer from the files provided")?,
-            &config,
-        )?;
+        let mut files = Vec::new();
+        for path in matches
+            .get_many::<String>("FILE")
+            .context("Missing path list")?
+        {
+            files.extend(
+                File::from_path(path, None, &config)
+                    .context("Cannot build transfer from the files provided")?,
+            );
+        }
 
-        Some(xfer)
+        Some(Transfer::new(*addr, files, &config)?)
     } else {
         None
     };
@@ -365,6 +365,7 @@ async fn main() -> anyhow::Result<()> {
     .context("Failed to start service")?;
 
     if let Some(xfer) = xfer {
+        info!("Transfer:\n{xfer:#?}");
         service.send_request(xfer);
     }
 

--- a/drop-transfer/src/error.rs
+++ b/drop-transfer/src/error.rs
@@ -86,3 +86,12 @@ impl<T> ResultExt for super::Result<T> {
         }
     }
 }
+
+impl From<walkdir::Error> for Error {
+    fn from(value: walkdir::Error) -> Self {
+        value
+            .into_io_error()
+            .map(Into::into)
+            .unwrap_or(Error::BadPath)
+    }
+}

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use crate::{file::FileSubPath, utils::Hidden, Error, Transfer};
+use crate::{file::FileId, utils::Hidden, Error, Transfer};
 
 #[derive(Debug)]
 pub struct DownloadSuccess {
-    pub id: FileSubPath,
+    pub id: FileId,
     pub final_path: Hidden<Box<Path>>,
 }
 
@@ -13,20 +13,20 @@ pub enum Event {
     RequestReceived(Transfer),
     RequestQueued(Transfer),
 
-    FileUploadStarted(Transfer, FileSubPath),
-    FileDownloadStarted(Transfer, FileSubPath),
+    FileUploadStarted(Transfer, FileId),
+    FileDownloadStarted(Transfer, FileId),
 
-    FileUploadProgress(Transfer, FileSubPath, u64),
-    FileDownloadProgress(Transfer, FileSubPath, u64),
+    FileUploadProgress(Transfer, FileId, u64),
+    FileDownloadProgress(Transfer, FileId, u64),
 
-    FileUploadSuccess(Transfer, FileSubPath),
+    FileUploadSuccess(Transfer, FileId),
     FileDownloadSuccess(Transfer, DownloadSuccess),
 
-    FileUploadCancelled(Transfer, FileSubPath, bool),
-    FileDownloadCancelled(Transfer, FileSubPath, bool),
+    FileUploadCancelled(Transfer, FileId, bool),
+    FileDownloadCancelled(Transfer, FileId, bool),
 
-    FileUploadFailed(Transfer, FileSubPath, Error),
-    FileDownloadFailed(Transfer, FileSubPath, Error),
+    FileUploadFailed(Transfer, FileId, Error),
+    FileDownloadFailed(Transfer, FileId, Error),
 
     TransferCanceled(Transfer, bool),
 

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
-use crate::{file::FileId, utils::Hidden, Error, Transfer};
+use crate::{file::FileSubPath, utils::Hidden, Error, Transfer};
 
 #[derive(Debug)]
 pub struct DownloadSuccess {
-    pub id: FileId,
+    pub id: FileSubPath,
     pub final_path: Hidden<Box<Path>>,
 }
 
@@ -13,20 +13,20 @@ pub enum Event {
     RequestReceived(Transfer),
     RequestQueued(Transfer),
 
-    FileUploadStarted(Transfer, FileId),
-    FileDownloadStarted(Transfer, FileId),
+    FileUploadStarted(Transfer, FileSubPath),
+    FileDownloadStarted(Transfer, FileSubPath),
 
-    FileUploadProgress(Transfer, FileId, u64),
-    FileDownloadProgress(Transfer, FileId, u64),
+    FileUploadProgress(Transfer, FileSubPath, u64),
+    FileDownloadProgress(Transfer, FileSubPath, u64),
 
-    FileUploadSuccess(Transfer, FileId),
+    FileUploadSuccess(Transfer, FileSubPath),
     FileDownloadSuccess(Transfer, DownloadSuccess),
 
-    FileUploadCancelled(Transfer, FileId, bool),
-    FileDownloadCancelled(Transfer, FileId, bool),
+    FileUploadCancelled(Transfer, FileSubPath, bool),
+    FileDownloadCancelled(Transfer, FileSubPath, bool),
 
-    FileUploadFailed(Transfer, FileId, Error),
-    FileDownloadFailed(Transfer, FileId, Error),
+    FileUploadFailed(Transfer, FileSubPath, Error),
+    FileDownloadFailed(Transfer, FileSubPath, Error),
 
     TransferCanceled(Transfer, bool),
 

--- a/drop-transfer/src/file/id.rs
+++ b/drop-transfer/src/file/id.rs
@@ -1,26 +1,88 @@
 use std::{
     fmt,
+    hash::Hash,
+    io,
     path::{Path, PathBuf},
 };
 
-use crate::utils::Hidden;
+use base64::prelude::*;
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+
+use crate::utils::{self, Hidden};
 
 #[derive(Hash, Clone, PartialEq, Eq)]
 pub struct FileSubPath(Vec<String>);
 
+#[derive(Hash, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FileId(String);
+
 const SEPARATOR: &str = "/";
 
+impl TryFrom<&Path> for FileId {
+    type Error = io::Error;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        let abs = utils::make_path_absolute(value)?;
+        let out = sha2::Sha256::digest(abs.to_string_lossy().as_bytes());
+        let id = BASE64_URL_SAFE_NO_PAD.encode(out);
+        Ok(Self(id))
+    }
+}
+
+impl From<&FileSubPath> for FileId {
+    fn from(value: &FileSubPath) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl ToString for FileId {
+    fn to_string(&self) -> String {
+        self.0.clone()
+    }
+}
+
+impl fmt::Debug for FileId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("FileId").field(&Hidden(&self.0)).finish()
+    }
+}
+
 impl FileSubPath {
-    pub fn from_name(name: String) -> Self {
-        Self(vec![name])
+    pub fn from_file_name(path: impl AsRef<Path>) -> crate::Result<Self> {
+        let name = path
+            .as_ref()
+            .file_name()
+            .ok_or(crate::Error::BadPath)?
+            .to_str()
+            .ok_or(crate::Error::BadPath)?;
+
+        Ok(Self(vec![name.to_owned()]))
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &String> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &String> {
         self.0.iter()
     }
 
     pub fn append(&mut self, name: String) {
         self.0.push(name);
+    }
+
+    pub fn append_file_name(mut self, path: impl AsRef<Path>) -> crate::Result<Self> {
+        let name = path
+            .as_ref()
+            .file_name()
+            .ok_or(crate::Error::BadPath)?
+            .to_str()
+            .ok_or(crate::Error::BadPath)?;
+
+        self.0.push(name.to_owned());
+        Ok(self)
+    }
+
+    pub fn name(&self) -> &str {
+        self.0.last().expect("Missing last path component")
     }
 }
 
@@ -70,7 +132,7 @@ impl ToString for FileSubPath {
 
 impl fmt::Debug for FileSubPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("FileId")
+        f.debug_tuple("FileSubPath")
             .field(&Hidden(self.to_string()))
             .finish()
     }

--- a/drop-transfer/src/file/id.rs
+++ b/drop-transfer/src/file/id.rs
@@ -6,11 +6,11 @@ use std::{
 use crate::utils::Hidden;
 
 #[derive(Hash, Clone, PartialEq, Eq)]
-pub struct FileId(Vec<String>);
+pub struct FileSubPath(Vec<String>);
 
 const SEPARATOR: &str = "/";
 
-impl FileId {
+impl FileSubPath {
     pub fn from_name(name: String) -> Self {
         Self(vec![name])
     }
@@ -24,7 +24,7 @@ impl FileId {
     }
 }
 
-impl<T> From<T> for FileId
+impl<T> From<T> for FileSubPath
 where
     T: AsRef<str>,
 {
@@ -38,37 +38,37 @@ where
     }
 }
 
-impl From<FileId> for PathBuf {
-    fn from(FileId(value): FileId) -> Self {
+impl From<FileSubPath> for PathBuf {
+    fn from(FileSubPath(value): FileSubPath) -> Self {
         value.into_iter().collect()
     }
 }
 
-impl From<&FileId> for PathBuf {
-    fn from(value: &FileId) -> Self {
+impl From<&FileSubPath> for PathBuf {
+    fn from(value: &FileSubPath) -> Self {
         value.0.iter().collect()
     }
 }
 
-impl From<FileId> for Box<Path> {
-    fn from(value: FileId) -> Self {
+impl From<FileSubPath> for Box<Path> {
+    fn from(value: FileSubPath) -> Self {
         PathBuf::from(value).into_boxed_path()
     }
 }
 
-impl From<&FileId> for Box<Path> {
-    fn from(value: &FileId) -> Self {
+impl From<&FileSubPath> for Box<Path> {
+    fn from(value: &FileSubPath) -> Self {
         PathBuf::from(value).into_boxed_path()
     }
 }
 
-impl ToString for FileId {
+impl ToString for FileSubPath {
     fn to_string(&self) -> String {
         self.0.join(SEPARATOR)
     }
 }
 
-impl fmt::Debug for FileId {
+impl fmt::Debug for FileSubPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("FileId")
             .field(&Hidden(self.to_string()))
@@ -76,7 +76,7 @@ impl fmt::Debug for FileId {
     }
 }
 
-impl serde::Serialize for FileId {
+impl serde::Serialize for FileSubPath {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -85,7 +85,7 @@ impl serde::Serialize for FileId {
     }
 }
 
-impl<'de> serde::Deserialize<'de> for FileId {
+impl<'de> serde::Deserialize<'de> for FileSubPath {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,

--- a/drop-transfer/src/file/id.rs
+++ b/drop-transfer/src/file/id.rs
@@ -31,6 +31,12 @@ impl TryFrom<&Path> for FileId {
     }
 }
 
+impl From<String> for FileId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
 impl From<&FileSubPath> for FileId {
     fn from(value: &FileSubPath) -> Self {
         Self(value.to_string())

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -15,7 +15,7 @@ use std::{
 
 use drop_analytics::FileInfo;
 use drop_config::DropConfig;
-pub use id::FileId;
+pub use id::FileSubPath;
 pub use reader::FileReader;
 use sha2::Digest;
 

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -13,10 +13,9 @@ use std::{
 
 use drop_analytics::FileInfo;
 use drop_config::DropConfig;
-use sha2::Digest;
-
 pub use id::{FileId, FileSubPath};
 pub use reader::FileReader;
+use sha2::Digest;
 use walkdir::WalkDir;
 
 use crate::{utils::Hidden, Error};

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -4,30 +4,27 @@ mod reader;
 #[cfg(unix)]
 use std::os::unix::prelude::*;
 use std::{
-    collections::HashMap,
     fs::{
         OpenOptions, {self},
     },
     io::{self, Read},
-    iter,
     path::{Path, PathBuf},
 };
 
 use drop_analytics::FileInfo;
 use drop_config::DropConfig;
-pub use id::FileSubPath;
-pub use reader::FileReader;
 use sha2::Digest;
+
+pub use id::{FileId, FileSubPath};
+pub use reader::FileReader;
 
 use crate::{utils::Hidden, Error};
 
 const HEADER_SIZE: usize = 1024;
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum FileKind {
-    Dir {
-        children: HashMap<Hidden<String>, File>,
-    },
     FileToSend {
         meta: Hidden<fs::Metadata>,
         source: FileSource,
@@ -47,47 +44,49 @@ pub enum FileSource {
 
 #[derive(Clone, Debug)]
 pub struct File {
-    pub(crate) name: Hidden<String>,
+    pub(crate) file_id: FileId,
+    pub(crate) subpath: FileSubPath,
     pub(crate) kind: FileKind,
 }
 
 impl File {
-    fn walk(path: &Path, config: &DropConfig) -> Result<Self, Error> {
+    fn walk(path: &Path, config: &DropConfig) -> Result<Vec<Self>, Error> {
         fn walk(
             path: &Path,
             depth: &mut usize,
             breadth: &mut usize,
+            files: &mut Vec<File>,
+            subpath: FileSubPath,
             config: &DropConfig,
-        ) -> Result<File, Error> {
-            let name = path
-                .file_name()
-                .ok_or(crate::Error::BadPath)?
-                .to_string_lossy()
-                .to_string();
-
-            let mut children = HashMap::new();
-
+        ) -> Result<(), Error> {
             for entry in fs::read_dir(path)? {
                 let entry = entry?;
                 let ft = entry.file_type()?;
 
-                let child = if ft.is_dir() {
+                if ft.is_dir() {
                     *depth += 1;
                     if *depth > config.dir_depth_limit {
                         return Err(Error::TransferLimitsExceeded);
                     }
 
-                    let subdir = walk(&entry.path(), depth, breadth, config)?;
+                    let path = entry.path();
+                    walk(
+                        &path,
+                        depth,
+                        breadth,
+                        files,
+                        subpath.clone().append_file_name(&path)?,
+                        config,
+                    )?;
                     *depth -= 1;
-
-                    subdir
                 } else if ft.is_file() {
-                    File::new(entry.path(), entry.metadata()?)?
+                    let path = entry.path();
+                    let subpath = subpath.clone().append_file_name(&path)?;
+                    let file = File::new(subpath, path, entry.metadata()?)?;
+                    files.push(file);
                 } else {
                     continue;
                 };
-
-                children.insert(child.name.clone(), child);
 
                 *breadth += 1;
                 if *breadth > config.transfer_file_limit {
@@ -95,65 +94,58 @@ impl File {
                 }
             }
 
-            Ok(File {
-                name: Hidden(name),
-                kind: FileKind::Dir { children },
-            })
+            Ok(())
         }
 
+        let mut files = Vec::new();
         let mut depth = 1;
         let mut breadth = 0;
-        walk(path, &mut depth, &mut breadth, config)
-    }
+        walk(
+            path,
+            &mut depth,
+            &mut breadth,
+            &mut files,
+            FileSubPath::from_file_name(path)?,
+            config,
+        )?;
 
-    pub fn child(&self, name: &String) -> Option<&Self> {
-        self.children_inner()?.get(name)
-    }
-
-    pub fn children(&self) -> impl Iterator<Item = &File> {
-        self.children_inner().into_iter().flat_map(|hm| hm.values())
-    }
-
-    fn children_inner(&self) -> Option<&HashMap<Hidden<String>, Self>> {
-        match &self.kind {
-            FileKind::Dir { children } => Some(children),
-            _ => None,
-        }
+        Ok(files)
     }
 
     pub fn from_path(
         path: impl Into<PathBuf>,
         fd: Option<i32>,
         config: &DropConfig,
-    ) -> Result<Self, Error> {
+    ) -> Result<Vec<Self>, Error> {
         let path = path.into();
 
         #[allow(unused_variables)]
-        if let Some(fd) = fd {
+        let files = if let Some(fd) = fd {
             #[cfg(target_os = "windows")]
             return Err(Error::InvalidArgument);
+
             #[cfg(not(target_os = "windows"))]
-            File::new_with_fd(&path, fd).or(Err(Error::BadFile))
+            vec![File::new_with_fd(
+                FileSubPath::from_file_name(&path)?,
+                &path,
+                fd,
+            )?]
         } else {
             let meta = fs::symlink_metadata(&path)?;
 
             if meta.is_dir() {
-                File::walk(&path, config)
+                File::walk(&path, config)?
             } else {
-                File::new(path, meta)
+                let file = File::new(FileSubPath::from_file_name(&path)?, path, meta)?;
+                vec![file]
             }
-        }
+        };
+
+        Ok(files)
     }
 
-    fn new(path: PathBuf, meta: fs::Metadata) -> Result<Self, Error> {
+    fn new(subpath: FileSubPath, path: PathBuf, meta: fs::Metadata) -> Result<Self, Error> {
         assert!(!meta.is_dir(), "Did not expect directory metadata");
-
-        let name = path
-            .file_name()
-            .ok_or(crate::Error::BadPath)?
-            .to_str()
-            .ok_or(crate::Error::BadPath)?
-            .to_string();
 
         let mut options = OpenOptions::new();
         options.read(true);
@@ -169,7 +161,8 @@ impl File {
             .to_string();
 
         Ok(Self {
-            name: Hidden(name),
+            file_id: FileId::try_from(path.as_path())?,
+            subpath,
             kind: FileKind::FileToSend {
                 meta: Hidden(meta),
                 source: FileSource::Path(Hidden(path)),
@@ -179,14 +172,7 @@ impl File {
     }
 
     #[cfg(unix)]
-    fn new_with_fd(path: &Path, fd: RawFd) -> Result<Self, Error> {
-        let name = path
-            .file_name()
-            .ok_or(crate::Error::BadPath)?
-            .to_str()
-            .ok_or(crate::Error::BadPath)?
-            .to_string();
-
+    fn new_with_fd(subpath: FileSubPath, path: &Path, fd: RawFd) -> Result<Self, Error> {
         let f = unsafe { fs::File::from_raw_fd(fd) };
 
         let create_file = || {
@@ -203,7 +189,8 @@ impl File {
                 .to_string();
 
             Ok(Self {
-                name: Hidden(name),
+                file_id: FileId::try_from(path)?,
+                subpath,
                 kind: FileKind::FileToSend {
                     meta: Hidden(meta),
                     source: FileSource::Fd(fd),
@@ -219,16 +206,19 @@ impl File {
         result
     }
 
-    pub fn name(&self) -> &str {
-        &self.name
+    pub fn size(&self) -> u64 {
+        match &self.kind {
+            FileKind::FileToSend { meta, .. } => meta.len(),
+            FileKind::FileToRecv { size } => *size,
+        }
     }
 
-    pub fn size(&self) -> Option<u64> {
-        match &self.kind {
-            FileKind::FileToSend { meta, .. } => Some(meta.len()),
-            FileKind::FileToRecv { size } => Some(*size),
-            _ => None,
-        }
+    pub fn id(&self) -> &FileId {
+        &self.file_id
+    }
+
+    pub fn subpath(&self) -> &FileSubPath {
+        &self.subpath
     }
 
     pub fn info(&self) -> Option<FileInfo> {
@@ -238,14 +228,11 @@ impl File {
                     .as_deref()
                     .cloned()
                     .unwrap_or_else(|| "unknown".to_string()),
-                extension: AsRef::<Path>::as_ref(self.name.as_str())
+                extension: AsRef::<Path>::as_ref(self.subpath.name())
                     .extension()
                     .map(|e| e.to_string_lossy().to_string())
                     .unwrap_or_else(|| "unknown".to_string()),
-                size_kb: self
-                    .size()
-                    .map(|s| (s as f64 / 1024.0).ceil() as i32)
-                    .unwrap_or_default(),
+                size_kb: (self.size() as f64 / 1024.0).ceil() as i32,
             }),
             _ => None,
         }
@@ -274,19 +261,6 @@ impl File {
         let mut reader = io::BufReader::new(reader).take(limit);
         let csum = checksum(&mut reader)?;
         Ok(csum)
-    }
-
-    pub fn is_dir(&self) -> bool {
-        self.children_inner().is_some()
-    }
-
-    pub fn iter(&self) -> Box<dyn Iterator<Item = &File> + '_> {
-        Box::new(
-            self.children_inner()
-                .into_iter()
-                .flat_map(|hm| hm.values())
-                .flat_map(|c| iter::once(c).chain(c.iter())),
-        )
     }
 }
 
@@ -317,8 +291,9 @@ mod tests {
             let mut tmp = tempfile::NamedTempFile::new().expect("Failed to create tmp file");
             tmp.write_all(TEST).unwrap();
 
-            let file = super::File::from_path(tmp.path(), None, &DropConfig::default()).unwrap();
-            let size = file.size().unwrap();
+            let file =
+                &super::File::from_path(tmp.path(), None, &DropConfig::default()).unwrap()[0];
+            let size = file.size();
 
             assert_eq!(size, TEST.len() as u64);
 

--- a/drop-transfer/src/lib.rs
+++ b/drop-transfer/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) use crate::manager::TransferManager;
 pub use crate::{
     error::Error,
     event::Event,
-    file::{File, FileSubPath},
+    file::{File, FileId},
     service::Service,
     transfer::Transfer,
 };

--- a/drop-transfer/src/lib.rs
+++ b/drop-transfer/src/lib.rs
@@ -14,7 +14,7 @@ pub(crate) use crate::manager::TransferManager;
 pub use crate::{
     error::Error,
     event::Event,
-    file::{File, FileId},
+    file::{File, FileSubPath},
     service::Service,
     transfer::Transfer,
 };

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -53,20 +53,6 @@ impl TransferManager {
             storage,
         }
     }
-    /// Get ALL of the ongoing file transfers for a given transfer ID
-    /// returns None if a transfer does not exist
-    pub(crate) fn get_transfer_files(&self, transfer_id: Uuid) -> Option<Vec<FileSubPath>> {
-        let state = self.transfers.get(&transfer_id)?;
-
-        let ids = state
-            .xfer
-            .flat_file_list()
-            .into_iter()
-            .map(|(id, _)| id)
-            .collect();
-
-        Some(ids)
-    }
 
     /// Cancel ALL of the ongoing file transfers for a given transfer ID    
     pub(crate) fn cancel_transfer(&mut self, transfer_id: Uuid) -> Result<(), Error> {

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
 use crate::{
-    file::FileId,
+    file::FileSubPath,
     service::State,
     ws::{client::ClientReq, server::ServerReq},
     Error, Transfer,
@@ -55,7 +55,7 @@ impl TransferManager {
     }
     /// Get ALL of the ongoing file transfers for a given transfer ID
     /// returns None if a transfer does not exist
-    pub(crate) fn get_transfer_files(&self, transfer_id: Uuid) -> Option<Vec<FileId>> {
+    pub(crate) fn get_transfer_files(&self, transfer_id: Uuid) -> Option<Vec<FileSubPath>> {
         let state = self.transfers.get(&transfer_id)?;
 
         let ids = state
@@ -103,7 +103,7 @@ impl TransferManager {
         &mut self,
         id: Uuid,
         dest_dir: &Path,
-        file_id: &FileId,
+        file_id: &FileSubPath,
     ) -> crate::Result<PathBuf> {
         let state = self
             .transfers

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -9,10 +9,9 @@ use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
 use crate::{
-    file::FileSubPath,
     service::State,
     ws::{client::ClientReq, server::ServerReq},
-    Error, Transfer,
+    Error, FileId, Transfer,
 };
 
 #[derive(Clone)]
@@ -89,14 +88,20 @@ impl TransferManager {
         &mut self,
         id: Uuid,
         dest_dir: &Path,
-        file_id: &FileSubPath,
+        file_id: &FileId,
     ) -> crate::Result<PathBuf> {
         let state = self
             .transfers
             .get_mut(&id)
             .ok_or(crate::Error::BadTransfer)?;
 
-        let mut iter = file_id.iter().map(crate::utils::normalize_filename);
+        let file = state
+            .xfer
+            .files()
+            .get(file_id)
+            .ok_or(crate::Error::BadFileId)?;
+
+        let mut iter = file.subpath().iter().map(crate::utils::normalize_filename);
 
         let probe = iter.next().ok_or(crate::Error::BadPath)?;
         let next = iter.next();

--- a/drop-transfer/src/protocol/v1.rs
+++ b/drop-transfer/src/protocol/v1.rs
@@ -14,10 +14,7 @@ use drop_config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 pub use super::v3::{Chunk, Error, File, Progress};
-use crate::{
-    file::{FileId, FileKind},
-    FileSubPath,
-};
+use crate::file::{FileId, FileKind, FileSubPath};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TransferRequest {

--- a/drop-transfer/src/protocol/v1.rs
+++ b/drop-transfer/src/protocol/v1.rs
@@ -14,7 +14,7 @@ use drop_config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 pub use super::v3::{Chunk, Error, File, Progress};
-use crate::FileId;
+use crate::FileSubPath;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TransferRequest {
@@ -23,7 +23,7 @@ pub struct TransferRequest {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Download {
-    pub file: FileId,
+    pub file: FileSubPath,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/drop-transfer/src/protocol/v1.rs
+++ b/drop-transfer/src/protocol/v1.rs
@@ -14,7 +14,10 @@ use drop_config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 pub use super::v3::{Chunk, Error, File, Progress};
-use crate::FileSubPath;
+use crate::{
+    file::{FileId, FileKind},
+    FileSubPath,
+};
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct TransferRequest {
@@ -49,14 +52,43 @@ impl TryFrom<(TransferRequest, IpAddr, Arc<DropConfig>)> for crate::Transfer {
     fn try_from(
         (TransferRequest { files }, peer, config): (TransferRequest, IpAddr, Arc<DropConfig>),
     ) -> Result<Self, Self::Error> {
-        Self::new(
-            peer,
-            files
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<_, crate::Error>>()?,
-            &config,
-        )
+        fn process_file(
+            in_files: &mut Vec<crate::File>,
+            subpath: FileSubPath,
+            File { size, children, .. }: File,
+        ) -> crate::Result<()> {
+            match size {
+                Some(size) => {
+                    in_files.push(crate::File {
+                        file_id: FileId::from(&subpath),
+                        subpath,
+                        kind: FileKind::FileToRecv { size },
+                    });
+                }
+                None => {
+                    for file in children {
+                        process_file(
+                            in_files,
+                            subpath.clone().append_file_name(&file.name)?,
+                            file,
+                        )?;
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        let mut in_files = Vec::new();
+        for file in files {
+            process_file(
+                &mut in_files,
+                FileSubPath::from_file_name(&file.name)?,
+                file,
+            )?;
+        }
+
+        Self::new(peer, in_files, &config)
     }
 }
 
@@ -64,13 +96,41 @@ impl TryFrom<&crate::Transfer> for TransferRequest {
     type Error = crate::Error;
 
     fn try_from(value: &crate::Transfer) -> Result<Self, Self::Error> {
-        Ok(Self {
-            files: value
-                .files()
-                .values()
-                .map(TryFrom::try_from)
-                .collect::<Result<_, crate::Error>>()?,
-        })
+        let mut files: Vec<File> = Vec::new();
+
+        for file in value.files().values() {
+            let mut parents = file.subpath.iter();
+            let mut files = &mut files;
+            let name = if let Some(name) = parents.next_back() {
+                name.clone()
+            } else {
+                continue;
+            };
+
+            for parent_name in parents {
+                if files.iter().all(|file| file.name != *parent_name) {
+                    files.push(File {
+                        name: parent_name.clone(),
+                        size: None,
+                        children: Vec::new(),
+                    });
+                }
+
+                files = &mut files
+                    .iter_mut()
+                    .find(|file| file.name == *parent_name)
+                    .expect("The parent was just inserted")
+                    .children;
+            }
+
+            files.push(File {
+                name,
+                size: Some(file.size()),
+                children: Vec::new(),
+            });
+        }
+
+        Ok(Self { files })
     }
 }
 

--- a/drop-transfer/src/protocol/v3.rs
+++ b/drop-transfer/src/protocol/v3.rs
@@ -24,7 +24,7 @@ use drop_config::DropConfig;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    file::{FileId, FileKind},
+    file::{FileKind, FileSubPath},
     utils::Hidden,
 };
 
@@ -43,14 +43,14 @@ pub struct TransferRequest {
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ReqChsum {
-    pub file: FileId,
+    pub file: FileSubPath,
     // Up to which point calculate checksum
     pub limit: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct ReportChsum {
-    pub file: FileId,
+    pub file: FileSubPath,
     pub limit: u64,
     #[serde(serialize_with = "hex::serialize")]
     #[serde(deserialize_with = "hex::deserialize")]
@@ -59,31 +59,31 @@ pub struct ReportChsum {
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Progress {
-    pub file: FileId,
+    pub file: FileSubPath,
     pub bytes_transfered: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Done {
-    pub file: FileId,
+    pub file: FileSubPath,
     pub bytes_transfered: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Error {
-    pub file: Option<FileId>,
+    pub file: Option<FileSubPath>,
     pub msg: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Start {
-    pub file: FileId,
+    pub file: FileSubPath,
     pub offset: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub struct Cancel {
-    pub file: FileId,
+    pub file: FileSubPath,
 }
 
 #[derive(Serialize, Deserialize, Clone, Eq, PartialEq)]
@@ -121,7 +121,7 @@ impl From<&ClientMsg> for tokio_tungstenite::tungstenite::Message {
 
 #[derive(Clone)]
 pub struct Chunk {
-    pub file: FileId,
+    pub file: FileSubPath,
     pub data: Vec<u8>,
 }
 
@@ -272,7 +272,7 @@ mod tests {
         const CHUNK_MSG: &[u8] = b"\x0D\x00\x00\x00test/file.exttest file content";
 
         let msg = Chunk {
-            file: FileId::from(FILE_ID),
+            file: FileSubPath::from(FILE_ID),
             data: FILE_CONTNET.to_vec(),
         }
         .encode();
@@ -282,7 +282,7 @@ mod tests {
         let Chunk { file, data } =
             Chunk::decode(CHUNK_MSG.to_vec()).expect("Failed to decode chunk");
 
-        assert_eq!(file, FileId::from(FILE_ID));
+        assert_eq!(file, FileSubPath::from(FILE_ID));
         assert_eq!(data, FILE_CONTNET);
     }
 
@@ -344,7 +344,7 @@ mod tests {
 
         test_json(
             ClientMsg::ReportChsum(ReportChsum {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
                 limit: 41,
                 checksum: [
                     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
@@ -363,7 +363,7 @@ mod tests {
 
         test_json(
             ClientMsg::Error(Error {
-                file: Some(FileId::from("test/file.ext")),
+                file: Some(FileSubPath::from("test/file.ext")),
                 msg: "test message".to_string(),
             }),
             r#"
@@ -391,7 +391,7 @@ mod tests {
 
         test_json(
             ClientMsg::Cancel(Cancel {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
             }),
             r#"
             {
@@ -406,7 +406,7 @@ mod tests {
     fn server_json_messages() {
         test_json(
             ServerMsg::Progress(Progress {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
                 bytes_transfered: 41,
             }),
             r#"
@@ -419,7 +419,7 @@ mod tests {
 
         test_json(
             ServerMsg::Done(Done {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
                 bytes_transfered: 41,
             }),
             r#"
@@ -432,7 +432,7 @@ mod tests {
 
         test_json(
             ServerMsg::Error(Error {
-                file: Some(FileId::from("test/file.ext")),
+                file: Some(FileSubPath::from("test/file.ext")),
                 msg: "test message".to_string(),
             }),
             r#"
@@ -458,7 +458,7 @@ mod tests {
 
         test_json(
             ServerMsg::ReqChsum(ReqChsum {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
                 limit: 41,
             }),
             r#"
@@ -471,7 +471,7 @@ mod tests {
 
         test_json(
             ServerMsg::Start(Start {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
                 offset: 41,
             }),
             r#"
@@ -484,7 +484,7 @@ mod tests {
 
         test_json(
             ServerMsg::Cancel(Cancel {
-                file: FileId::from("test/file.ext"),
+                file: FileSubPath::from("test/file.ext"),
             }),
             r#"
             {

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use crate::{
     auth,
     error::ResultExt,
-    file::FileId,
+    file::FileSubPath,
     manager::TransferConnection,
     ws::{
         self,
@@ -157,7 +157,7 @@ impl Service {
     pub async fn download(
         &mut self,
         uuid: Uuid,
-        file_id: FileId,
+        file_id: FileSubPath,
         parent_dir: &Path,
     ) -> crate::Result<()> {
         debug!(
@@ -244,7 +244,7 @@ impl Service {
     }
 
     /// Cancel a single file in a transfer
-    pub async fn cancel(&mut self, xfer_uuid: Uuid, file: FileId) -> crate::Result<()> {
+    pub async fn cancel(&mut self, xfer_uuid: Uuid, file: FileSubPath) -> crate::Result<()> {
         let lock = self.state.transfer_manager.lock().await;
 
         let conn = lock.connection(xfer_uuid).ok_or(Error::BadTransfer)?;

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -18,7 +18,6 @@ use uuid::Uuid;
 use crate::{
     auth,
     error::ResultExt,
-    file::FileSubPath,
     manager::TransferConnection,
     ws::{
         self,
@@ -244,7 +243,7 @@ impl Service {
     }
 
     /// Cancel a single file in a transfer
-    pub async fn cancel(&mut self, xfer_uuid: Uuid, file: FileSubPath) -> crate::Result<()> {
+    pub async fn cancel(&mut self, xfer_uuid: Uuid, file: FileId) -> crate::Result<()> {
         let lock = self.state.transfer_manager.lock().await;
 
         let conn = lock.connection(xfer_uuid).ok_or(Error::BadTransfer)?;

--- a/drop-transfer/src/transfer.rs
+++ b/drop-transfer/src/transfer.rs
@@ -4,7 +4,7 @@ use drop_analytics::TransferInfo;
 use drop_config::DropConfig;
 use uuid::Uuid;
 
-use crate::{file::FileId, utils::Hidden, Error, File};
+use crate::{file::FileSubPath, utils::Hidden, Error, File};
 
 type Result<T> = std::result::Result<T, Error>;
 
@@ -38,7 +38,7 @@ impl Transfer {
         Ok(Self { peer, uuid, files })
     }
 
-    pub(crate) fn file(&self, file_id: &FileId) -> Option<&File> {
+    pub(crate) fn file(&self, file_id: &FileSubPath) -> Option<&File> {
         let mut components = file_id.iter();
 
         let first = components.next()?;
@@ -56,8 +56,12 @@ impl Transfer {
     }
 
     // Gathers all files into a flat list
-    pub fn flat_file_list(&self) -> Vec<(FileId, &File)> {
-        fn push_children<'a>(file: &'a File, file_id: &FileId, out: &mut Vec<(FileId, &'a File)>) {
+    pub fn flat_file_list(&self) -> Vec<(FileSubPath, &File)> {
+        fn push_children<'a>(
+            file: &'a File,
+            file_id: &FileSubPath,
+            out: &mut Vec<(FileSubPath, &'a File)>,
+        ) {
             if file.is_dir() {
                 for file in file.children() {
                     let mut file_id = file_id.clone();
@@ -72,7 +76,7 @@ impl Transfer {
         let mut out = Vec::new();
 
         for file in self.files().values() {
-            let file_id = FileId::from_name(file.name().to_string());
+            let file_id = FileSubPath::from_name(file.name().to_string());
             push_children(file, &file_id, &mut out);
         }
 

--- a/drop-transfer/src/utils.rs
+++ b/drop-transfer/src/utils.rs
@@ -136,6 +136,18 @@ pub fn normalize_filename(filename: impl AsRef<str>) -> String {
     check_illegal_filename(name)
 }
 
+pub fn make_path_absolute(path: impl AsRef<Path>) -> crate::Result<PathBuf> {
+    let path = path.as_ref();
+
+    let abs = if path.is_absolute() {
+        path.canonicalize()?
+    } else {
+        std::env::current_dir()?.join(path).canonicalize()?
+    };
+
+    Ok(abs)
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/drop-transfer/src/utils.rs
+++ b/drop-transfer/src/utils.rs
@@ -136,7 +136,7 @@ pub fn normalize_filename(filename: impl AsRef<str>) -> String {
     check_illegal_filename(name)
 }
 
-pub fn make_path_absolute(path: impl AsRef<Path>) -> crate::Result<PathBuf> {
+pub fn make_path_absolute(path: impl AsRef<Path>) -> io::Result<PathBuf> {
     let path = path.as_ref();
 
     let abs = if path.is_absolute() {

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -335,7 +335,10 @@ async fn start_upload(
     xfer: crate::Transfer,
     file_id: FileSubPath,
 ) -> anyhow::Result<JoinHandle<()>> {
-    let xfile = xfer.file(&file_id).context("File not found")?.clone();
+    let xfile = xfer
+        .file_by_subpath(&file_id)
+        .context("File not found")?
+        .clone();
 
     events
         .start(Event::FileUploadStarted(xfer.clone(), file_id.clone()))

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -28,7 +28,7 @@ use super::events::FileEventTx;
 use crate::{
     auth,
     error::ResultExt,
-    file::FileId,
+    file::FileSubPath,
     manager::{TransferConnection, TransferGuard},
     protocol,
     service::State,
@@ -39,7 +39,7 @@ use crate::{
 pub type WebSocket = WebSocketStream<TcpStream>;
 
 pub enum ClientReq {
-    Cancel { file: FileId },
+    Cancel { file: FileSubPath },
 }
 
 struct RunContext<'a> {
@@ -333,7 +333,7 @@ async fn start_upload(
     events: Arc<FileEventTx>,
     mut uploader: impl Uploader,
     xfer: crate::Transfer,
-    file_id: FileId,
+    file_id: FileSubPath,
 ) -> anyhow::Result<JoinHandle<()>> {
     let xfile = xfer.file(&file_id).context("File not found")?.clone();
 

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -28,7 +28,7 @@ use super::events::FileEventTx;
 use crate::{
     auth,
     error::ResultExt,
-    file::FileSubPath,
+    file::{FileId, FileSubPath},
     manager::{TransferConnection, TransferGuard},
     protocol,
     service::State,
@@ -333,15 +333,16 @@ async fn start_upload(
     events: Arc<FileEventTx>,
     mut uploader: impl Uploader,
     xfer: crate::Transfer,
-    file_id: FileSubPath,
+    file_id: FileId,
 ) -> anyhow::Result<JoinHandle<()>> {
     let xfile = xfer
-        .file_by_subpath(&file_id)
+        .files()
+        .get(&file_id)
         .context("File not found")?
         .clone();
 
     events
-        .start(Event::FileUploadStarted(xfer.clone(), file_id.clone()))
+        .start(Event::FileUploadStarted(xfer.clone(), xfile.id().clone()))
         .await;
 
     let upload_job = async move {

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -28,7 +28,7 @@ use super::events::FileEventTx;
 use crate::{
     auth,
     error::ResultExt,
-    file::{FileId, FileSubPath},
+    file::FileId,
     manager::{TransferConnection, TransferGuard},
     protocol,
     service::State,
@@ -39,7 +39,7 @@ use crate::{
 pub type WebSocket = WebSocketStream<TcpStream>;
 
 pub enum ClientReq {
-    Cancel { file: FileSubPath },
+    Cancel { file: FileId },
 }
 
 struct RunContext<'a> {

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -12,7 +12,7 @@ use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tokio_tungstenite::tungstenite::{self, Message};
 
 use super::{handler, ClientReq, WebSocket};
-use crate::{protocol::v2, service::State, utils::Hidden, ws, FileId};
+use crate::{protocol::v2, service::State, utils::Hidden, ws, FileSubPath};
 
 pub struct HandlerInit<'a, const PING: bool = true> {
     state: &'a Arc<State>,
@@ -23,14 +23,14 @@ pub struct HandlerLoop<'a, const PING: bool> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
     upload_tx: Sender<Message>,
-    tasks: HashMap<FileId, FileTask>,
+    tasks: HashMap<FileSubPath, FileTask>,
     last_recv: Instant,
     xfer: crate::Transfer,
 }
 
 struct Uploader {
     sink: Sender<Message>,
-    file_id: FileId,
+    file_id: FileSubPath,
 }
 
 struct FileTask {
@@ -74,7 +74,11 @@ impl<'a, const PING: bool> handler::HandlerInit for HandlerInit<'a, PING> {
 }
 
 impl<const PING: bool> HandlerLoop<'_, PING> {
-    async fn issue_cancel(&mut self, socket: &mut WebSocket, file: FileId) -> anyhow::Result<()> {
+    async fn issue_cancel(
+        &mut self,
+        socket: &mut WebSocket,
+        file: FileSubPath,
+    ) -> anyhow::Result<()> {
         let msg = v2::ClientMsg::Cancel(v2::Download { file: file.clone() });
         socket.send(Message::from(&msg)).await?;
 
@@ -83,7 +87,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         Ok(())
     }
 
-    async fn on_cancel(&mut self, file: FileId, by_peer: bool) {
+    async fn on_cancel(&mut self, file: FileSubPath, by_peer: bool) {
         if let Some(task) = self.tasks.remove(&file) {
             if !task.job.is_finished() {
                 task.job.abort();
@@ -110,7 +114,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         }
     }
 
-    async fn on_progress(&self, file: FileId, transfered: u64) {
+    async fn on_progress(&self, file: FileSubPath, transfered: u64) {
         if let Some(task) = self.tasks.get(&file) {
             task.events
                 .emit(crate::Event::FileUploadProgress(
@@ -122,7 +126,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         }
     }
 
-    async fn on_done(&mut self, file: FileId) {
+    async fn on_done(&mut self, file: FileSubPath) {
         if let Some(task) = self.tasks.remove(&file) {
             task.events
                 .stop(crate::Event::FileUploadSuccess(self.xfer.clone(), file))
@@ -130,7 +134,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         }
     }
 
-    async fn on_download(&mut self, file_id: FileId) {
+    async fn on_download(&mut self, file_id: FileSubPath) {
         let start = async {
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
@@ -177,7 +181,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         }
     }
 
-    async fn on_error(&mut self, file: Option<FileId>, msg: String) {
+    async fn on_error(&mut self, file: Option<FileSubPath>, msg: String) {
         error!(
             self.logger,
             "Server reported and error: file: {:?}, message: {}",
@@ -374,7 +378,7 @@ impl FileTask {
         state: &Arc<State>,
         uploader: Uploader,
         xfer: crate::Transfer,
-        file: FileId,
+        file: FileSubPath,
         logger: &slog::Logger,
     ) -> anyhow::Result<Self> {
         let events = Arc::new(ws::events::FileEventTx::new(state));

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -98,7 +98,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                     self.xfer.id().to_string(),
                     0,
                     self.xfer
-                        .file(&file)
+                        .file_by_subpath(&file)
                         .expect("File should exist since we have a transfer task running")
                         .info(),
                 );
@@ -219,14 +219,14 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         debug!(self.logger, "ClientHandler::on_close(by_peer: {})", by_peer);
 
         self.xfer
-            .flat_file_list()
-            .iter()
-            .filter(|(file_id, _)| {
+            .files()
+            .values()
+            .filter(|file| {
                 self.tasks
-                    .get(file_id)
+                    .get(&file.subpath)
                     .map_or(false, |task| !task.job.is_finished())
             })
-            .for_each(|(_, file)| {
+            .for_each(|file| {
                 self.state.moose.service_quality_transfer_file(
                     Err(u32::from(&crate::Error::Canceled) as i32),
                     drop_analytics::Phase::End,

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -418,7 +418,7 @@ impl FileXferTask {
             .to_string_lossy()
             .to_string();
 
-        let size = file.size().ok_or(crate::Error::DirectoryNotExpected)?;
+        let size = file.size();
 
         Ok(Self {
             file,

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -56,7 +56,6 @@ pub enum ServerReq {
 
 pub struct FileXferTask {
     pub file: crate::File,
-    pub file_id: crate::FileSubPath,
     pub location: Hidden<PathBuf>,
     pub filename: String,
     pub size: u64,
@@ -406,12 +405,7 @@ async fn handle_client(
 }
 
 impl FileXferTask {
-    pub fn new(
-        file: crate::File,
-        file_id: crate::FileSubPath,
-        xfer: crate::Transfer,
-        location: PathBuf,
-    ) -> crate::Result<Self> {
+    pub fn new(file: crate::File, xfer: crate::Transfer, location: PathBuf) -> crate::Result<Self> {
         let filename = location
             .file_stem()
             .ok_or(crate::Error::BadFile)?
@@ -422,7 +416,6 @@ impl FileXferTask {
 
         Ok(Self {
             file,
-            file_id,
             xfer,
             location: Hidden(location),
             filename,
@@ -476,7 +469,7 @@ impl FileXferTask {
             events
                 .emit(crate::Event::FileDownloadProgress(
                     self.xfer.clone(),
-                    self.file_id.clone(),
+                    self.file.id().clone(),
                     bytes_received,
                 ))
                 .await;
@@ -499,7 +492,7 @@ impl FileXferTask {
                     events
                         .emit(crate::Event::FileDownloadProgress(
                             self.xfer.clone(),
-                            self.file_id.clone(),
+                            self.file.id().clone(),
                             bytes_received,
                         ))
                         .await;
@@ -563,7 +556,7 @@ impl FileXferTask {
                 events
                     .emit_force(crate::Event::FileDownloadFailed(
                         self.xfer.clone(),
-                        self.file_id,
+                        self.file.id().clone(),
                         err,
                     ))
                     .await;
@@ -589,7 +582,7 @@ impl FileXferTask {
                 events
                     .start(crate::Event::FileDownloadStarted(
                         self.xfer.clone(),
-                        self.file_id.clone(),
+                        self.file.id().clone(),
                     ))
                     .await;
 
@@ -616,7 +609,7 @@ impl FileXferTask {
                     Ok(dst_location) => Some(Event::FileDownloadSuccess(
                         self.xfer.clone(),
                         DownloadSuccess {
-                            id: self.file_id,
+                            id: self.file.id().clone(),
                             final_path: Hidden(dst_location.into_boxed_path()),
                         },
                     )),
@@ -625,7 +618,7 @@ impl FileXferTask {
                         let _ = downloader.error(err.to_string()).await;
                         Some(Event::FileDownloadFailed(
                             self.xfer.clone(),
-                            self.file_id,
+                            self.file.id().clone(),
                             err,
                         ))
                     }
@@ -640,7 +633,7 @@ impl FileXferTask {
                     .emit_force(crate::Event::FileDownloadSuccess(
                         self.xfer.clone(),
                         DownloadSuccess {
-                            id: self.file_id,
+                            id: self.file.id().clone(),
                             final_path: Hidden(destination.0.into_boxed_path()),
                         },
                     ))

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -36,14 +36,14 @@ use crate::{
     auth,
     error::ResultExt,
     event::DownloadSuccess,
-    file::{self, FileSubPath},
+    file::{self},
     manager::{TransferConnection, TransferGuard},
     protocol,
     quarantine::PathExt,
     service::State,
     utils::Hidden,
     ws::Pinger,
-    Error, Event,
+    Error, Event, FileId,
 };
 
 const MAX_FILENAME_LENGTH: usize = 255;
@@ -51,7 +51,7 @@ const REPORT_PROGRESS_THRESHOLD: u64 = 1024 * 64;
 
 pub enum ServerReq {
     Download { task: Box<FileXferTask> },
-    Cancel { file: FileSubPath },
+    Cancel { file: FileId },
 }
 
 pub struct FileXferTask {

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     auth,
     error::ResultExt,
     event::DownloadSuccess,
-    file::{self, FileId},
+    file::{self, FileSubPath},
     manager::{TransferConnection, TransferGuard},
     protocol,
     quarantine::PathExt,
@@ -51,12 +51,12 @@ const REPORT_PROGRESS_THRESHOLD: u64 = 1024 * 64;
 
 pub enum ServerReq {
     Download { task: Box<FileXferTask> },
-    Cancel { file: FileId },
+    Cancel { file: FileSubPath },
 }
 
 pub struct FileXferTask {
     pub file: crate::File,
-    pub file_id: crate::FileId,
+    pub file_id: crate::FileSubPath,
     pub location: Hidden<PathBuf>,
     pub filename: String,
     pub size: u64,
@@ -408,7 +408,7 @@ async fn handle_client(
 impl FileXferTask {
     pub fn new(
         file: crate::File,
-        file_id: crate::FileId,
+        file_id: crate::FileSubPath,
         xfer: crate::Transfer,
         location: PathBuf,
     ) -> crate::Result<Self> {

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -200,7 +200,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                     self.xfer.id().to_string(),
                     0,
                     self.xfer
-                        .file(&file)
+                        .file_by_subpath(&file)
                         .expect("File should exists since we have a transfer task running")
                         .info(),
                 );
@@ -260,14 +260,14 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         debug!(self.logger, "ServerHandler::on_close(by_peer: {})", by_peer);
 
         self.xfer
-            .flat_file_list()
-            .iter()
-            .filter(|(file_id, _)| {
+            .files()
+            .values()
+            .filter(|file| {
                 self.jobs
-                    .get(file_id)
+                    .get(&file.subpath)
                     .map_or(false, |state| !state.job.is_finished())
             })
-            .for_each(|(_, file)| {
+            .for_each(|file| {
                 self.state.moose.service_quality_transfer_file(
                     Err(u32::from(&crate::Error::Canceled) as i32),
                     drop_analytics::Phase::End,

--- a/drop-transfer/src/ws/server/v3.rs
+++ b/drop-transfer/src/ws/server/v3.rs
@@ -77,6 +77,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             .context("Failed to receive transfer request")?;
 
         let msg = msg.to_str().ok().context("Expected JOSN message")?;
+        debug!(self.logger, "Request received:\n\t{msg}");
 
         let req = serde_json::from_str(msg).context("Failed to deserialize transfer request")?;
 
@@ -199,7 +200,7 @@ impl HandlerLoop<'_> {
                     self.xfer.id().to_string(),
                     0,
                     self.xfer
-                        .file(&file)
+                        .file_by_subpath(&file)
                         .expect("File should exists since we have a transfer task running")
                         .info(),
                 );
@@ -271,14 +272,14 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         debug!(self.logger, "ServerHandler::on_close(by_peer: {})", by_peer);
 
         self.xfer
-            .flat_file_list()
-            .iter()
-            .filter(|(file_id, _)| {
+            .files()
+            .values()
+            .filter(|file| {
                 self.jobs
-                    .get(file_id)
+                    .get(&file.subpath)
                     .map_or(false, |state| !state.job.is_finished())
             })
-            .for_each(|(_, file)| {
+            .for_each(|file| {
                 self.state.moose.service_quality_transfer_file(
                     Err(u32::from(&crate::Error::Canceled) as i32),
                     drop_analytics::Phase::End,

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -264,8 +264,8 @@ impl NordDropFFI {
 
         debug!(
             self.logger,
-            "Created transfer with files: {:?}",
-            xfer.files()
+            "Created transfer with files:\n{:#?}",
+            xfer.files().values()
         );
 
         let xfid = xfer.id();

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -231,7 +231,7 @@ impl NordDropFFI {
                         error!(
                             self.logger,
                             "Specifying file descriptors in transfers is not supported under \
-                                 Windows"
+                             Windows"
                         );
                         return Err(ffi::types::NORDDROP_RES_BAD_INPUT);
                     }
@@ -377,7 +377,7 @@ impl NordDropFFI {
             let mut locked_inst = instance.lock().await;
             let inst = locked_inst.as_mut().expect("Instance not initialized");
 
-            if let Err(e) = inst.cancel(xfid, (&file).into()).await {
+            if let Err(e) = inst.cancel(xfid, file.clone().into()).await {
                 error!(
                     logger,
                     "Failed to cancel a file with xfid: {}, file: {:?}, error: {:?}",

--- a/test/drop_test/config.py
+++ b/test/drop_test/config.py
@@ -24,3 +24,84 @@ RUNNERS = {
     ),
 }
 # fmt: on
+
+
+class File:
+    def __init__(self, size: int, id: str):
+        # in kilobytes
+        self.size = size
+        self.id = id
+
+
+FILES = {
+    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt": File(
+        size=1 * 1024, id="p3cYEJWds51Uqb174hrbHxfE6ASz_ioErmh39jLsiWU"
+    ),
+    "testfile-small": File(
+        size=1 * 1024, id="BzgNijPq2HAy4UH75K3kqXou9sTVT7AbSWRGUrU7oGI"
+    ),
+    "testfile-big": File(
+        size=10 * 1024, id="ESDW8PFTBoD8UYaqxMSWp6FBCZN3SKnhyHFqlhrdMzU"
+    ),
+    "deep/path/file1.ext1": File(
+        size=1 * 1024, id="CKVHseb1gM6DuUGwQU9D25GTTyehos44Si282V5Ut_E"
+    ),
+    "deep/path/file2.ext2": File(
+        size=1 * 1024, id="AP62vXu2WAmIOwxYUs_oL7U_YjeOe8ixrhNKKuAwHNs"
+    ),
+    "deep/another-path/file3.ext3": File(
+        size=1 * 1024, id="mTtUD_megD0_UiyhRmVjYefqycu1lkG9hH62e646Llw"
+    ),
+    "deep/another-path/file4.ext4": File(
+        size=1 * 1024, id="FFiT0wxJnodvDGZNYAX_jUojoYLKLpeIccyWQBzapfE"
+    ),
+    "testfile-bulk-01": File(
+        size=10 * 1024, id="cO4I0umdTfN9bZvQoYI-7z3XvJUcA4b2Atw8CFDOHjg"
+    ),
+    "testfile-bulk-02": File(
+        size=10 * 1024, id="4-Dt2b89ubTwW8GF0-n1wJo5Iq-Zj74d4pBiKaD7t3s"
+    ),
+    "testfile-bulk-03": File(
+        size=10 * 1024, id="DOmO7NCdwBNb5ES6KnLt_s4KuLW6tGDYDhIbTZEgaao"
+    ),
+    "testfile-bulk-04": File(
+        size=10 * 1024, id="ZqICxNTPq3Mss9lE1KWARaP-2myx2-aNR7LtYmJmCD0"
+    ),
+    "testfile-bulk-05": File(
+        size=10 * 1024, id="TZ8p7dXbUhvbB3oMQj_5rQes6Hn_kBBiSsD_v_y5cCg"
+    ),
+    "testfile-bulk-06": File(
+        size=10 * 1024, id="TDcRO-4urGbJsmsCAdoAtTQQjvcXWKD8IDm9J_qg0i4"
+    ),
+    "testfile-bulk-07": File(
+        size=10 * 1024, id="21vkb4qcrSRmN49QZuN_8A-Yzexfqtm7_m2RNEVkyMU"
+    ),
+    "testfile-bulk-08": File(
+        size=10 * 1024, id="0wjysbL9CZu6qGJEddKozpCsVsK2f_W7xQLi4dUrCFg"
+    ),
+    "testfile-bulk-09": File(
+        size=10 * 1024, id="yqHoVs1jXFdsJBfHOMdjR63NVt4tXvigLn7bMWXNKa0"
+    ),
+    "testfile-bulk-10": File(
+        size=10 * 1024, id="0rHKOnFZFo6kNnwkDfaMDE8luAqfFWqUJjtdB7IIqVA"
+    ),
+    "nested/big/testfile-01": File(
+        size=10 * 1024, id="KKzrrYLyKL54hNit9g748Q2TMi4hLA-pPeoqspNlBOA"
+    ),
+    "nested/big/testfile-02": File(
+        size=10 * 1024, id="7uo62xhQBZK-6z-ndyFzRCPpzWPO2sJTgnu5D2t1Zbw"
+    ),
+    "testfile.small.with.complicated.extension": File(
+        size=1 * 1024, id="tHK8wmpZjD1mtQeIzigO7qZfRemEk4oSQu0IocoiCmE"
+    ),
+    "with-illegal-char-\x0A-": File(
+        size=1 * 1024, id="a8vdPYj-41hoFD2OCJqrf4x9SZuqibscR9XPUPijTuY"
+    ),
+    "duplicate/testfile-small": File(
+        size=1 * 1024, id="IY3xuWiT4zBQ3tyxKvmBHoikxfRvyFPfHTNNPIMQoL4"
+    ),
+    "duplicate/testfile.small.with.complicated.extension": File(
+        size=1 * 1024, id="9CvPHrjnPOQa_2Y-x2yUBESKcTmbj-RdYEs3VKww5Ys"
+    ),
+    "zero-sized-file": File(size=0, id="d5d4ohM4nRb8b6-Ob19WnSAr_uTtGoUXjT-L575CCMY"),
+}

--- a/test/drop_test/config.py
+++ b/test/drop_test/config.py
@@ -26,7 +26,7 @@ RUNNERS = {
 # fmt: on
 
 
-class File:
+class TestFile:
     def __init__(self, size: int, id: str):
         # in kilobytes
         self.size = size
@@ -34,74 +34,76 @@ class File:
 
 
 FILES = {
-    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt": File(
+    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt": TestFile(
         size=1 * 1024, id="p3cYEJWds51Uqb174hrbHxfE6ASz_ioErmh39jLsiWU"
     ),
-    "testfile-small": File(
+    "testfile-small": TestFile(
         size=1 * 1024, id="BzgNijPq2HAy4UH75K3kqXou9sTVT7AbSWRGUrU7oGI"
     ),
-    "testfile-big": File(
+    "testfile-big": TestFile(
         size=10 * 1024, id="ESDW8PFTBoD8UYaqxMSWp6FBCZN3SKnhyHFqlhrdMzU"
     ),
-    "deep/path/file1.ext1": File(
+    "deep/path/file1.ext1": TestFile(
         size=1 * 1024, id="CKVHseb1gM6DuUGwQU9D25GTTyehos44Si282V5Ut_E"
     ),
-    "deep/path/file2.ext2": File(
+    "deep/path/file2.ext2": TestFile(
         size=1 * 1024, id="AP62vXu2WAmIOwxYUs_oL7U_YjeOe8ixrhNKKuAwHNs"
     ),
-    "deep/another-path/file3.ext3": File(
+    "deep/another-path/file3.ext3": TestFile(
         size=1 * 1024, id="mTtUD_megD0_UiyhRmVjYefqycu1lkG9hH62e646Llw"
     ),
-    "deep/another-path/file4.ext4": File(
+    "deep/another-path/file4.ext4": TestFile(
         size=1 * 1024, id="FFiT0wxJnodvDGZNYAX_jUojoYLKLpeIccyWQBzapfE"
     ),
-    "testfile-bulk-01": File(
+    "testfile-bulk-01": TestFile(
         size=10 * 1024, id="cO4I0umdTfN9bZvQoYI-7z3XvJUcA4b2Atw8CFDOHjg"
     ),
-    "testfile-bulk-02": File(
+    "testfile-bulk-02": TestFile(
         size=10 * 1024, id="4-Dt2b89ubTwW8GF0-n1wJo5Iq-Zj74d4pBiKaD7t3s"
     ),
-    "testfile-bulk-03": File(
+    "testfile-bulk-03": TestFile(
         size=10 * 1024, id="DOmO7NCdwBNb5ES6KnLt_s4KuLW6tGDYDhIbTZEgaao"
     ),
-    "testfile-bulk-04": File(
+    "testfile-bulk-04": TestFile(
         size=10 * 1024, id="ZqICxNTPq3Mss9lE1KWARaP-2myx2-aNR7LtYmJmCD0"
     ),
-    "testfile-bulk-05": File(
+    "testfile-bulk-05": TestFile(
         size=10 * 1024, id="TZ8p7dXbUhvbB3oMQj_5rQes6Hn_kBBiSsD_v_y5cCg"
     ),
-    "testfile-bulk-06": File(
+    "testfile-bulk-06": TestFile(
         size=10 * 1024, id="TDcRO-4urGbJsmsCAdoAtTQQjvcXWKD8IDm9J_qg0i4"
     ),
-    "testfile-bulk-07": File(
+    "testfile-bulk-07": TestFile(
         size=10 * 1024, id="21vkb4qcrSRmN49QZuN_8A-Yzexfqtm7_m2RNEVkyMU"
     ),
-    "testfile-bulk-08": File(
+    "testfile-bulk-08": TestFile(
         size=10 * 1024, id="0wjysbL9CZu6qGJEddKozpCsVsK2f_W7xQLi4dUrCFg"
     ),
-    "testfile-bulk-09": File(
+    "testfile-bulk-09": TestFile(
         size=10 * 1024, id="yqHoVs1jXFdsJBfHOMdjR63NVt4tXvigLn7bMWXNKa0"
     ),
-    "testfile-bulk-10": File(
+    "testfile-bulk-10": TestFile(
         size=10 * 1024, id="0rHKOnFZFo6kNnwkDfaMDE8luAqfFWqUJjtdB7IIqVA"
     ),
-    "nested/big/testfile-01": File(
+    "nested/big/testfile-01": TestFile(
         size=10 * 1024, id="KKzrrYLyKL54hNit9g748Q2TMi4hLA-pPeoqspNlBOA"
     ),
-    "nested/big/testfile-02": File(
+    "nested/big/testfile-02": TestFile(
         size=10 * 1024, id="7uo62xhQBZK-6z-ndyFzRCPpzWPO2sJTgnu5D2t1Zbw"
     ),
-    "testfile.small.with.complicated.extension": File(
+    "testfile.small.with.complicated.extension": TestFile(
         size=1 * 1024, id="tHK8wmpZjD1mtQeIzigO7qZfRemEk4oSQu0IocoiCmE"
     ),
-    "with-illegal-char-\x0A-": File(
+    "with-illegal-char-\x0A-": TestFile(
         size=1 * 1024, id="a8vdPYj-41hoFD2OCJqrf4x9SZuqibscR9XPUPijTuY"
     ),
-    "duplicate/testfile-small": File(
+    "duplicate/testfile-small": TestFile(
         size=1 * 1024, id="IY3xuWiT4zBQ3tyxKvmBHoikxfRvyFPfHTNNPIMQoL4"
     ),
-    "duplicate/testfile.small.with.complicated.extension": File(
+    "duplicate/testfile.small.with.complicated.extension": TestFile(
         size=1 * 1024, id="9CvPHrjnPOQa_2Y-x2yUBESKcTmbj-RdYEs3VKww5Ys"
     ),
-    "zero-sized-file": File(size=0, id="d5d4ohM4nRb8b6-Ob19WnSAr_uTtGoUXjT-L575CCMY"),
+    "zero-sized-file": TestFile(
+        size=0, id="d5d4ohM4nRb8b6-Ob19WnSAr_uTtGoUXjT-L575CCMY"
+    ),
 }

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -29,33 +29,22 @@ class Event:
 
 
 class File:
-    def __init__(self, path: str, size: int, children: typing.Set[File] = set()):
+    def __init__(self, id: str, path: str, size: int):
+        self._id = id
         self._path = path
         self._size = size
-        self._children = children
 
     def __eq__(lhs, rhs):
         if not isinstance(rhs, File):
             return NotImplemented
 
-        return set(lhs.flatten()) == set(rhs.flatten())
-
-    def flatten(self, parent="", collection=None):
-        if collection is None:
-            collection = []
-
-        collection.append((parent, self._path, self._size))
-
-        for child in self._children:
-            child.flatten(self._path, collection)
-
-        return collection
+        return lhs._id == rhs._id and lhs._path == rhs._path and lhs._size == rhs._size
 
     def __hash__(self):
-        return hash(str(self._path))
+        return hash(str(self._id))
 
     def __repr__(self):
-        return f"File(path={self._path}, size={self._size}, children={self._children})"
+        return f"File(id={self._id}, path={self._path}, size={self._size})"
 
 
 class Queued(Event):

--- a/test/run.py
+++ b/test/run.py
@@ -11,14 +11,14 @@ import typing
 from drop_test.logger import logger
 from scenarios import scenarios
 
-from drop_test import ffi
+from drop_test import ffi, config
 
 
 def prepare_files(files: typing.Dict, symlinks: typing.Dict):
     os.mkdir("/tmp/received")
 
     for name in files:
-        size: int = files[name]
+        size: int = files[name].size
 
         fullpath = f"/tmp/{name}"
         os.makedirs(os.path.dirname(fullpath), exist_ok=True)
@@ -83,41 +83,12 @@ async def main():
     if script is None:
         raise Exception("unrecognized scenario", scenario)
 
-    # in kilobytes
-    test_files = {
-        "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt": 1
-        * 1024,
-        "testfile-small": 1 * 1024,
-        "testfile-big": 10 * 1024,
-        "deep/path/file1.ext1": 1 * 1024,
-        "deep/path/file2.ext2": 1 * 1024,
-        "deep/another-path/file3.ext3": 1 * 1024,
-        "deep/another-path/file4.ext4": 1 * 1024,
-        "testfile-bulk-01": 10 * 1024,
-        "testfile-bulk-02": 10 * 1024,
-        "testfile-bulk-03": 10 * 1024,
-        "testfile-bulk-04": 10 * 1024,
-        "testfile-bulk-05": 10 * 1024,
-        "testfile-bulk-06": 10 * 1024,
-        "testfile-bulk-07": 10 * 1024,
-        "testfile-bulk-08": 10 * 1024,
-        "testfile-bulk-09": 10 * 1024,
-        "testfile-bulk-10": 10 * 1024,
-        "nested/big/testfile-01": 10 * 1024,
-        "nested/big/testfile-02": 10 * 1024,
-        "testfile.small.with.complicated.extension": 1 * 1024,
-        "with-illegal-char-\x0A-": 1 * 1024,
-        "duplicate/testfile-small": 1 * 1024,
-        "duplicate/testfile.small.with.complicated.extension": 1 * 1024,
-        "zero-sized-file": 0,
-    }
-
     symlinks = {
         "received/symtest-files/testfile-small": "this-file-does-not-exists.ext",
         "received/symtest-dir": "this-dir-does-not-exists",
     }
 
-    prepare_files(test_files, symlinks)
+    prepare_files(config.FILES, symlinks)
 
     drop = ffi.Drop(lib, ffi.KeysCtx(runner))
     logger.info(f"NordDrop version: {drop.version}")
@@ -126,11 +97,11 @@ async def main():
     try:
         await script.run(runner, drop)
         logger.info("Action completed properly")
-        cleanup_files(test_files)
+        cleanup_files(config.FILES)
         sys.exit(0)
     except Exception as e:
         logger.critical(f"Action didn't complete as expected: {e}")
-        cleanup_files(test_files)
+        cleanup_files(config.FILES)
         sys.exit(1)
 
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -1,6 +1,7 @@
 from drop_test import action, event
 from drop_test.scenario import Scenario, ActionList
 from drop_test.error import Error
+from drop_test.config import FILES
 
 from pathlib import Path
 from tempfile import gettempdir
@@ -21,15 +22,17 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-big",
+                            FILES["testfile-big"].id,
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -44,7 +47,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -63,7 +66,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-big", 10485760),
+                            action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -86,15 +89,19 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         )
                     ),
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
@@ -102,15 +109,17 @@ scenarios = [
                         event.Queued(
                             1,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(1, "testfile-big")),
+                    action.Wait(event.Start(1, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             1,
-                            "testfile-big",
+                            FILES["testfile-big"].id,
                         )
                     ),
                     action.ExpectCancel([0, 1], True),
@@ -125,7 +134,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         )
                     ),
@@ -147,7 +156,7 @@ scenarios = [
                             1,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -166,8 +175,8 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1048576),
-                            event.File("/tmp/received/testfile-big", 10485760),
+                            action.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -191,7 +200,9 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         ),
                     ),
@@ -200,34 +211,33 @@ scenarios = [
                         event.Queued(
                             1,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         ),
                     ),
                     action.WaitRacy(
-                        sum(
-                            [
-                                [
-                                    event.Start(
-                                        0,
-                                        "testfile-big",
-                                    ),
-                                    event.Start(
-                                        1,
-                                        "testfile-small",
-                                    ),
-                                    event.FinishFileUploaded(
-                                        0,
-                                        "testfile-big",
-                                    ),
-                                    event.FinishFileUploaded(
-                                        1,
-                                        "testfile-small",
-                                    ),
-                                ],
-                            ],
-                            [],
-                        )
+                        [
+                            event.Start(
+                                0,
+                                FILES["testfile-big"].id,
+                            ),
+                            event.Start(
+                                1,
+                                FILES["testfile-small"].id,
+                            ),
+                            event.FinishFileUploaded(
+                                0,
+                                FILES["testfile-big"].id,
+                            ),
+                            event.FinishFileUploaded(
+                                1,
+                                FILES["testfile-small"].id,
+                            ),
+                        ],
                     ),
                     action.ExpectCancel([0, 1], True),
                     action.NoEvent(),
@@ -242,14 +252,18 @@ scenarios = [
                                 0,
                                 "172.20.0.5",
                                 {
-                                    event.File("testfile-big", 10485760),
+                                    event.File(
+                                        "testfile-big", "testfile-big", 10485760
+                                    ),
                                 },
                             ),
                             event.Receive(
                                 1,
                                 "172.20.0.5",
                                 {
-                                    event.File("testfile-small", 1048576),
+                                    event.File(
+                                        "testfile-small", "testfile-small", 1048576
+                                    ),
                                 },
                             ),
                         ]
@@ -265,36 +279,31 @@ scenarios = [
                         "/tmp/received",
                     ),
                     action.WaitRacy(
-                        sum(
-                            [
-                                [
-                                    event.Start(
-                                        0,
-                                        "testfile-big",
-                                    ),
-                                    event.FinishFileDownloaded(
-                                        0,
-                                        "testfile-big",
-                                        "/tmp/received/testfile-big",
-                                    ),
-                                    event.Start(
-                                        1,
-                                        "testfile-small",
-                                    ),
-                                    event.FinishFileDownloaded(
-                                        1,
-                                        "testfile-small",
-                                        "/tmp/received/testfile-small",
-                                    ),
-                                ],
-                            ],
-                            [],
-                        )
+                        [
+                            event.Start(
+                                0,
+                                "testfile-big",
+                            ),
+                            event.FinishFileDownloaded(
+                                0,
+                                "testfile-big",
+                                "/tmp/received/testfile-big",
+                            ),
+                            event.Start(
+                                1,
+                                "testfile-small",
+                            ),
+                            event.FinishFileDownloaded(
+                                1,
+                                "testfile-small",
+                                "/tmp/received/testfile-small",
+                            ),
+                        ],
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1048576),
-                            event.File("/tmp/received/testfile-big", 10485760),
+                            action.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -320,11 +329,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.CancelTransferRequest(0),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
@@ -339,7 +350,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -370,7 +381,9 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
@@ -388,7 +401,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -415,11 +428,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishTransferCanceled(0, True),
                     ),
@@ -435,7 +450,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -469,7 +484,9 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
@@ -486,7 +503,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -513,7 +530,9 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
@@ -530,7 +549,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -560,12 +579,16 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
-                    action.Wait(event.FinishFileCanceled(0, "testfile-big", True)),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, True)
+                    ),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -579,7 +602,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -618,13 +641,17 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
-                    action.CancelTransferFile(0, "testfile-big"),
-                    action.Wait(event.FinishFileCanceled(0, "testfile-big", False)),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.CancelTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, False)
+                    ),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -638,7 +665,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -676,15 +703,19 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1024 * 1024,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -700,7 +731,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -719,7 +752,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1024 * 1024),
+                            action.File("/tmp/received/testfile-small", 1024 * 1024),
                         ],
                     ),
                     action.CancelTransferFile(0, "testfile-small"),
@@ -744,18 +777,22 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1024 * 1024,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         )
                     ),
-                    action.CancelTransferFile(0, "testfile-small"),
+                    action.CancelTransferFile(0, FILES["testfile-small"].id),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -768,7 +805,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -787,7 +826,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1024 * 1024),
+                            action.File("/tmp/received/testfile-small", 1024 * 1024),
                         ],
                     ),
                     action.NoEvent(),
@@ -813,13 +852,15 @@ scenarios = [
                             0,
                             {
                                 event.File(
-                                    "big",
-                                    0,
-                                    {
-                                        event.File("testfile-01", 10485760),
-                                        event.File("testfile-02", 10485760),
-                                    },
-                                )
+                                    FILES["nested/big/testfile-01"].id,
+                                    "big/testfile-01",
+                                    10485760,
+                                ),
+                                event.File(
+                                    FILES["nested/big/testfile-02"].id,
+                                    "big/testfile-02",
+                                    10485760,
+                                ),
                             },
                         )
                     ),
@@ -827,11 +868,11 @@ scenarios = [
                         [
                             event.Start(
                                 0,
-                                "big/testfile-01",
+                                FILES["nested/big/testfile-01"].id,
                             ),
                             event.Start(
                                 0,
-                                "big/testfile-02",
+                                FILES["nested/big/testfile-02"].id,
                             ),
                         ]
                     ),
@@ -851,13 +892,11 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "big",
-                                    0,
-                                    {
-                                        event.File("testfile-01", 10485760),
-                                        event.File("testfile-02", 10485760),
-                                    },
-                                )
+                                    "big/testfile-01", "big/testfile-01", 10485760
+                                ),
+                                event.File(
+                                    "big/testfile-02", "big/testfile-02", 10485760
+                                ),
                             },
                         )
                     ),
@@ -935,26 +974,24 @@ scenarios = [
                             0,
                             {
                                 event.File(
-                                    "deep",
-                                    0,
-                                    {
-                                        event.File(
-                                            "another-path",
-                                            0,
-                                            {
-                                                event.File("file3.ext3", 1048576),
-                                                event.File("file4.ext4", 1048576),
-                                            },
-                                        ),
-                                        event.File(
-                                            "path",
-                                            0,
-                                            {
-                                                event.File("file1.ext1", 1048576),
-                                                event.File("file2.ext2", 1048576),
-                                            },
-                                        ),
-                                    },
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "deep/path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/path/file2.ext2"].id,
+                                    "deep/path/file2.ext2",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/another-path/file3.ext3"].id,
+                                    "deep/another-path/file3.ext3",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/another-path/file4.ext4"].id,
+                                    "deep/another-path/file4.ext4",
+                                    1048576,
                                 ),
                             },
                         )
@@ -962,49 +999,49 @@ scenarios = [
                     action.Wait(
                         event.Start(
                             0,
-                            "deep/path/file1.ext1",
+                            FILES["deep/path/file1.ext1"].id,
                         )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "deep/path/file1.ext1",
+                            FILES["deep/path/file1.ext1"].id,
                         ),
                     ),
                     action.Wait(
                         event.Start(
                             0,
-                            "deep/path/file2.ext2",
+                            FILES["deep/path/file2.ext2"].id,
                         )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "deep/path/file2.ext2",
+                            FILES["deep/path/file2.ext2"].id,
                         ),
                     ),
                     action.Wait(
                         event.Start(
                             0,
-                            "deep/another-path/file3.ext3",
+                            FILES["deep/another-path/file3.ext3"].id,
                         )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "deep/another-path/file3.ext3",
+                            FILES["deep/another-path/file3.ext3"].id,
                         ),
                     ),
                     action.Wait(
                         event.Start(
                             0,
-                            "deep/another-path/file4.ext4",
+                            FILES["deep/another-path/file4.ext4"].id,
                         )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "deep/another-path/file4.ext4",
+                            FILES["deep/another-path/file4.ext4"].id,
                         ),
                     ),
                     action.ExpectCancel([0], True),
@@ -1020,26 +1057,24 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "deep",
-                                    0,
-                                    {
-                                        event.File(
-                                            "another-path",
-                                            0,
-                                            {
-                                                event.File("file3.ext3", 1048576),
-                                                event.File("file4.ext4", 1048576),
-                                            },
-                                        ),
-                                        event.File(
-                                            "path",
-                                            0,
-                                            {
-                                                event.File("file1.ext1", 1048576),
-                                                event.File("file2.ext2", 1048576),
-                                            },
-                                        ),
-                                    },
+                                    "deep/path/file1.ext1",
+                                    "deep/path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/path/file2.ext2",
+                                    "deep/path/file2.ext2",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/another-path/file3.ext3",
+                                    "deep/another-path/file3.ext3",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/another-path/file4.ext4",
+                                    "deep/another-path/file4.ext4",
+                                    1048576,
                                 ),
                             },
                         )
@@ -1118,12 +1153,12 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/deep/path/file1.ext1", 1048576),
-                            event.File("/tmp/received/deep/path/file2.ext2", 1048576),
-                            event.File(
+                            action.File("/tmp/received/deep/path/file1.ext1", 1048576),
+                            action.File("/tmp/received/deep/path/file2.ext2", 1048576),
+                            action.File(
                                 "/tmp/received/deep/another-path/file3.ext3", 1048576
                             ),
-                            event.File(
+                            action.File(
                                 "/tmp/received/deep/another-path/file4.ext4", 1048576
                             ),
                         ],
@@ -1151,15 +1186,19 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
                     action.Wait(
-                        event.Start(0, "testfile-small"),
+                        event.Start(0, FILES["testfile-small"].id),
                     ),
                     action.Wait(
-                        event.FinishFileUploaded(0, "testfile-small"),
+                        event.FinishFileUploaded(0, FILES["testfile-small"].id),
                     ),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
@@ -1173,7 +1212,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         ),
                     ),
@@ -1194,7 +1233,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -1217,12 +1256,18 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
-                    action.Wait(event.FinishFileUploaded(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(0, FILES["testfile-small"].id)
+                    ),
                     action.NewTransfer(
                         "172.20.0.15", ["/tmp/duplicate/testfile-small"]
                     ),
@@ -1230,12 +1275,20 @@ scenarios = [
                         event.Queued(
                             1,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["duplicate/testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(1, "testfile-small")),
-                    action.Wait(event.FinishFileUploaded(1, "testfile-small")),
+                    action.Wait(event.Start(1, FILES["duplicate/testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            1, FILES["duplicate/testfile-small"].id
+                        )
+                    ),
                     action.ExpectCancel([0, 1], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -1248,7 +1301,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         )
                     ),
@@ -1270,7 +1323,7 @@ scenarios = [
                             1,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         )
                     ),
@@ -1289,8 +1342,8 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1048576),
-                            event.File("/tmp/received/testfile-small(1)", 1048576),
+                            action.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-small(1)", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -1318,7 +1371,11 @@ scenarios = [
                             0,
                             {
                                 event.File(
-                                    "testfile.small.with.complicated.extension", 1048576
+                                    FILES[
+                                        "testfile.small.with.complicated.extension"
+                                    ].id,
+                                    "testfile.small.with.complicated.extension",
+                                    1048576,
                                 ),
                             },
                         )
@@ -1326,13 +1383,13 @@ scenarios = [
                     action.Wait(
                         event.Start(
                             0,
-                            "testfile.small.with.complicated.extension",
+                            FILES["testfile.small.with.complicated.extension"].id,
                         )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile.small.with.complicated.extension",
+                            FILES["testfile.small.with.complicated.extension"].id,
                         )
                     ),
                     action.NewTransfer(
@@ -1344,17 +1401,29 @@ scenarios = [
                             1,
                             {
                                 event.File(
-                                    "testfile.small.with.complicated.extension", 1048576
+                                    FILES[
+                                        "duplicate/testfile.small.with.complicated.extension"
+                                    ].id,
+                                    "testfile.small.with.complicated.extension",
+                                    1048576,
                                 ),
                             },
                         )
                     ),
                     action.Wait(
-                        event.Start(1, "testfile.small.with.complicated.extension")
+                        event.Start(
+                            1,
+                            FILES[
+                                "duplicate/testfile.small.with.complicated.extension"
+                            ].id,
+                        )
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
-                            1, "testfile.small.with.complicated.extension"
+                            1,
+                            FILES[
+                                "duplicate/testfile.small.with.complicated.extension"
+                            ].id,
                         )
                     ),
                     action.ExpectCancel([0, 1], True),
@@ -1370,7 +1439,9 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "testfile.small.with.complicated.extension", 1048576
+                                    "testfile.small.with.complicated.extension",
+                                    "testfile.small.with.complicated.extension",
+                                    1048576,
                                 ),
                             },
                         )
@@ -1396,7 +1467,9 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "testfile.small.with.complicated.extension", 1048576
+                                    "testfile.small.with.complicated.extension",
+                                    "testfile.small.with.complicated.extension",
+                                    1048576,
                                 ),
                             },
                         )
@@ -1418,11 +1491,11 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/testfile.small.with.complicated.extension",
                                 1048576,
                             ),
-                            event.File(
+                            action.File(
                                 "/tmp/received/testfile.small.with.complicated(1).extension",
                                 1048576,
                             ),
@@ -1449,22 +1522,34 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("file1.ext1", 1048576),
+                                event.File(
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "file1.ext1",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "file1.ext1")),
-                    action.Wait(event.FinishFileUploaded(0, "file1.ext1")),
+                    action.Wait(event.Start(0, FILES["deep/path/file1.ext1"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(0, FILES["deep/path/file1.ext1"].id)
+                    ),
                     action.NewTransfer("172.20.0.15", ["/tmp/deep/path/file1.ext1"]),
                     action.Wait(
                         event.Queued(
                             1,
                             {
-                                event.File("file1.ext1", 1048576),
+                                event.File(
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "file1.ext1",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.FinishFileUploaded(1, "file1.ext1")),
+                    action.Wait(
+                        event.FinishFileUploaded(1, FILES["deep/path/file1.ext1"].id)
+                    ),
                     action.ExpectCancel([0, 1], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -1477,7 +1562,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("file1.ext1", 1048576),
+                                event.File("file1.ext1", "file1.ext1", 1048576),
                             },
                         )
                     ),
@@ -1499,7 +1584,7 @@ scenarios = [
                             1,
                             "172.20.0.5",
                             {
-                                event.File("file1.ext1", 1048576),
+                                event.File("file1.ext1", "file1.ext1", 1048576),
                             },
                         )
                     ),
@@ -1517,7 +1602,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/file1.ext1", 1048576),
+                            action.File("/tmp/received/file1.ext1", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -1542,11 +1627,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Stop(),
                     action.Wait(
                         event.FinishFailedTransfer(
@@ -1565,7 +1652,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -1600,11 +1687,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFailedTransfer(
                             0,
@@ -1623,7 +1712,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -1674,61 +1763,61 @@ scenarios = [
                     action.WaitForAnotherPeer(),
                     # fmt: off
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(0, { event.File("testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(0, { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-02"]),
-                    action.Wait(event.Queued(1, { event.File("testfile-bulk-02", 10485760), })),
+                    action.Wait(event.Queued(1, { event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-03"]),
-                    action.Wait(event.Queued(2, { event.File("testfile-bulk-03", 10485760), })),
+                    action.Wait(event.Queued(2, { event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-04"]),
-                    action.Wait(event.Queued(3, { event.File("testfile-bulk-04", 10485760), })),
+                    action.Wait(event.Queued(3, { event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-05"]),
-                    action.Wait(event.Queued(4, { event.File("testfile-bulk-05", 10485760), })),
+                    action.Wait(event.Queued(4, { event.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-06"]),
-                    action.Wait(event.Queued(5, { event.File("testfile-bulk-06", 10485760), })),
+                    action.Wait(event.Queued(5, { event.File(FILES["testfile-bulk-06"].id, "testfile-bulk-06", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-07"]),
-                    action.Wait(event.Queued(6, { event.File("testfile-bulk-07", 10485760), })),
+                    action.Wait(event.Queued(6, { event.File(FILES["testfile-bulk-07"].id, "testfile-bulk-07", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-08"]),
-                    action.Wait(event.Queued(7, { event.File("testfile-bulk-08", 10485760), })),
+                    action.Wait(event.Queued(7, { event.File(FILES["testfile-bulk-08"].id, "testfile-bulk-08", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-09"]),
-                    action.Wait(event.Queued(8, { event.File("testfile-bulk-09", 10485760), })),
+                    action.Wait(event.Queued(8, { event.File(FILES["testfile-bulk-09"].id, "testfile-bulk-09", 10485760), })),
 
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-bulk-10"]),
-                    action.Wait(event.Queued(9, { event.File("testfile-bulk-10", 10485760), })),
+                    action.Wait(event.Queued(9, { event.File(FILES["testfile-bulk-10"].id, "testfile-bulk-10", 10485760), })),
 
                     # fmt: on
 
                     # fmt: off
                     action.WaitRacy(
                         [
-                            event.Start(0, "testfile-bulk-01"),
-                            event.Start(1, "testfile-bulk-02"),
-                            event.Start(2, "testfile-bulk-03"),
-                            event.Start(3, "testfile-bulk-04"),
-                            event.Start(4, "testfile-bulk-05"),
-                            event.Start(5, "testfile-bulk-06"),
-                            event.Start(6, "testfile-bulk-07"),
-                            event.Start(7, "testfile-bulk-08"),
-                            event.Start(8, "testfile-bulk-09"),
-                            event.Start(9, "testfile-bulk-10"),
+                            event.Start(0, FILES["testfile-bulk-01"].id),
+                            event.Start(1, FILES["testfile-bulk-02"].id),
+                            event.Start(2, FILES["testfile-bulk-03"].id),
+                            event.Start(3, FILES["testfile-bulk-04"].id),
+                            event.Start(4, FILES["testfile-bulk-05"].id),
+                            event.Start(5, FILES["testfile-bulk-06"].id),
+                            event.Start(6, FILES["testfile-bulk-07"].id),
+                            event.Start(7, FILES["testfile-bulk-08"].id),
+                            event.Start(8, FILES["testfile-bulk-09"].id),
+                            event.Start(9, FILES["testfile-bulk-10"].id),
 
-                            event.FinishFileUploaded(0, "testfile-bulk-01"),
-                            event.FinishFileUploaded(1, "testfile-bulk-02"),
-                            event.FinishFileUploaded(2, "testfile-bulk-03"),
-                            event.FinishFileUploaded(3, "testfile-bulk-04"),
-                            event.FinishFileUploaded(4, "testfile-bulk-05"),
-                            event.FinishFileUploaded(5, "testfile-bulk-06"),
-                            event.FinishFileUploaded(6, "testfile-bulk-07"),
-                            event.FinishFileUploaded(7, "testfile-bulk-08"),
-                            event.FinishFileUploaded(8, "testfile-bulk-09"),
-                            event.FinishFileUploaded(9, "testfile-bulk-10"),
+                            event.FinishFileUploaded(0, FILES["testfile-bulk-01"].id),
+                            event.FinishFileUploaded(1, FILES["testfile-bulk-02"].id),
+                            event.FinishFileUploaded(2, FILES["testfile-bulk-03"].id),
+                            event.FinishFileUploaded(3, FILES["testfile-bulk-04"].id),
+                            event.FinishFileUploaded(4, FILES["testfile-bulk-05"].id),
+                            event.FinishFileUploaded(5, FILES["testfile-bulk-06"].id),
+                            event.FinishFileUploaded(6, FILES["testfile-bulk-07"].id),
+                            event.FinishFileUploaded(7, FILES["testfile-bulk-08"].id),
+                            event.FinishFileUploaded(8, FILES["testfile-bulk-09"].id),
+                            event.FinishFileUploaded(9, FILES["testfile-bulk-10"].id),
                         ]
                     ),
                     # fmt: on
@@ -1742,16 +1831,16 @@ scenarios = [
                     # fmt: off
                     action.WaitRacy(
                         [
-                            event.Receive(0, "172.20.0.5", { event.File("testfile-bulk-01", 10485760), }),
-                            event.Receive(1, "172.20.0.5", { event.File("testfile-bulk-02", 10485760), }),
-                            event.Receive(2, "172.20.0.5", { event.File("testfile-bulk-03", 10485760), }),
-                            event.Receive(3, "172.20.0.5", { event.File("testfile-bulk-04", 10485760), }),
-                            event.Receive(4, "172.20.0.5", { event.File("testfile-bulk-05", 10485760), }),
-                            event.Receive(5, "172.20.0.5", { event.File("testfile-bulk-06", 10485760), }),
-                            event.Receive(6, "172.20.0.5", { event.File("testfile-bulk-07", 10485760), }),
-                            event.Receive(7, "172.20.0.5", { event.File("testfile-bulk-08", 10485760), }),
-                            event.Receive(8, "172.20.0.5", { event.File("testfile-bulk-09", 10485760), }),
-                            event.Receive(9, "172.20.0.5", { event.File("testfile-bulk-10", 10485760), }),
+                            event.Receive(0, "172.20.0.5", { event.File("testfile-bulk-01", "testfile-bulk-01", 10485760), }),
+                            event.Receive(1, "172.20.0.5", { event.File("testfile-bulk-02", "testfile-bulk-02", 10485760), }),
+                            event.Receive(2, "172.20.0.5", { event.File("testfile-bulk-03", "testfile-bulk-03", 10485760), }),
+                            event.Receive(3, "172.20.0.5", { event.File("testfile-bulk-04", "testfile-bulk-04", 10485760), }),
+                            event.Receive(4, "172.20.0.5", { event.File("testfile-bulk-05", "testfile-bulk-05", 10485760), }),
+                            event.Receive(5, "172.20.0.5", { event.File("testfile-bulk-06", "testfile-bulk-06", 10485760), }),
+                            event.Receive(6, "172.20.0.5", { event.File("testfile-bulk-07", "testfile-bulk-07", 10485760), }),
+                            event.Receive(7, "172.20.0.5", { event.File("testfile-bulk-08", "testfile-bulk-08", 10485760), }),
+                            event.Receive(8, "172.20.0.5", { event.File("testfile-bulk-09", "testfile-bulk-09", 10485760), }),
+                            event.Receive(9, "172.20.0.5", { event.File("testfile-bulk-10", "testfile-bulk-10", 10485760), }),
                         ]
                     ),
                     # fmt: on
@@ -1833,24 +1922,32 @@ scenarios = [
                             event.Queued(
                                 0,
                                 {
-                                    event.File("testfile-big", 10485760),
+                                    event.File(
+                                        FILES["testfile-big"].id,
+                                        "testfile-big",
+                                        10485760,
+                                    ),
                                 },
                             ),
                             event.Queued(
                                 1,
                                 {
-                                    event.File("testfile-big", 10485760),
+                                    event.File(
+                                        FILES["testfile-big"].id,
+                                        "testfile-big",
+                                        10485760,
+                                    ),
                                 },
                             ),
-                            event.Start(1, "testfile-big"),
-                            event.Start(0, "testfile-big"),
+                            event.Start(1, FILES["testfile-big"].id),
+                            event.Start(0, FILES["testfile-big"].id),
                             event.FinishFileUploaded(
                                 1,
-                                "testfile-big",
+                                FILES["testfile-big"].id,
                             ),
                             event.FinishFileUploaded(
                                 0,
-                                "testfile-big",
+                                FILES["testfile-big"].id,
                             ),
                             event.FinishTransferCanceled(0, True),
                             event.FinishTransferCanceled(1, True),
@@ -1867,7 +1964,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -1886,7 +1983,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/stimpy/testfile-big", 10485760),
+                            action.File("/tmp/received/stimpy/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -1902,7 +1999,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -1921,7 +2018,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/george/testfile-big", 10485760),
+                            action.File("/tmp/received/george/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -1951,28 +2048,36 @@ scenarios = [
                             event.Queued(
                                 0,
                                 {
-                                    event.File("testfile-small", 1024 * 1024),
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1024 * 1024,
+                                    ),
                                 },
                             ),
                             event.Queued(
                                 1,
                                 {
-                                    event.File("testfile-small", 1024 * 1024),
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1024 * 1024,
+                                    ),
                                 },
                             ),
                         ]
                     ),
                     action.WaitRacy(
                         [
-                            event.Start(0, "testfile-small"),
-                            event.Start(1, "testfile-small"),
+                            event.Start(0, FILES["testfile-small"].id),
+                            event.Start(1, FILES["testfile-small"].id),
                             event.FinishFileUploaded(
                                 0,
-                                "testfile-small",
+                                FILES["testfile-small"].id,
                             ),
                             event.FinishFileUploaded(
                                 1,
-                                "testfile-small",
+                                FILES["testfile-small"].id,
                             ),
                             event.FinishTransferCanceled(0, True),
                             event.FinishTransferCanceled(1, True),
@@ -1989,7 +2094,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2008,7 +2115,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/stimpy/testfile-small", 1024 * 1024
                             ),
                         ],
@@ -2026,7 +2133,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2045,7 +2154,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/george/testfile-small", 1024 * 1024
                             ),
                         ],
@@ -2070,17 +2179,21 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1 * 1024 * 1024,
+                                ),
                             },
                         ),
                     ),
                     action.Wait(
-                        event.Start(0, "testfile-small"),
+                        event.Start(0, FILES["testfile-small"].id),
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         ),
                     ),
                     action.ExpectCancel([0], True),
@@ -2095,7 +2208,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1 * 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2114,7 +2229,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/symtest-files/testfile-small(1)",
                                 1 * 1024 * 1024,
                             ),
@@ -2140,7 +2255,11 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1 * 1024 * 1024,
+                                ),
                             },
                         ),
                     ),
@@ -2156,7 +2275,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1 * 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2197,17 +2318,21 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1 * 1024 * 1024,
+                                ),
                             },
                         ),
                     ),
                     action.Wait(
-                        event.Start(0, "testfile-small"),
+                        event.Start(0, FILES["testfile-small"].id),
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         ),
                     ),
                     action.ExpectCancel([0], True),
@@ -2222,7 +2347,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1 * 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2253,7 +2380,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/testfile-small",
                                 1 * 1024 * 1024,
                             ),
@@ -2281,17 +2408,21 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1 * 1024 * 1024,
+                                ),
                             },
                         ),
                     ),
                     action.Wait(
-                        event.Start(0, "testfile-small"),
+                        event.Start(0, FILES["testfile-small"].id),
                     ),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         ),
                     ),
                     action.ExpectCancel([0], True),
@@ -2306,7 +2437,9 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1 * 1024 * 1024),
+                                event.File(
+                                    "testfile-small", "testfile-small", 1 * 1024 * 1024
+                                ),
                             },
                         )
                     ),
@@ -2325,7 +2458,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File(
+                            action.File(
                                 "/tmp/received/testfile-small",
                                 1 * 1024 * 1024,
                             ),
@@ -2351,15 +2484,19 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -2374,7 +2511,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         )
                     ),
@@ -2405,7 +2542,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -2429,12 +2566,14 @@ scenarios = [
                             0,
                             {
                                 event.File(
-                                    "path",
-                                    0,
-                                    {
-                                        event.File("file1.ext1", 1048576),
-                                        event.File("file2.ext2", 1048576),
-                                    },
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/path/file2.ext2"].id,
+                                    "path/file2.ext2",
+                                    1048576,
                                 ),
                             },
                         )
@@ -2443,19 +2582,19 @@ scenarios = [
                         [
                             event.Start(
                                 0,
-                                "path/file1.ext1",
+                                FILES["deep/path/file1.ext1"].id,
                             ),
                             event.Start(
                                 0,
-                                "path/file2.ext2",
+                                FILES["deep/path/file2.ext2"].id,
                             ),
                             event.FinishFileUploaded(
                                 0,
-                                "path/file1.ext1",
+                                FILES["deep/path/file1.ext1"].id,
                             ),
                             event.FinishFileUploaded(
                                 0,
-                                "path/file2.ext2",
+                                FILES["deep/path/file2.ext2"].id,
                             ),
                         ]
                     ),
@@ -2465,12 +2604,14 @@ scenarios = [
                             1,
                             {
                                 event.File(
-                                    "path",
-                                    0,
-                                    {
-                                        event.File("file1.ext1", 1048576),
-                                        event.File("file2.ext2", 1048576),
-                                    },
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/path/file2.ext2"].id,
+                                    "path/file2.ext2",
+                                    1048576,
                                 ),
                             },
                         )
@@ -2479,19 +2620,19 @@ scenarios = [
                         [
                             event.Start(
                                 1,
-                                "path/file1.ext1",
+                                FILES["deep/path/file1.ext1"].id,
                             ),
                             event.Start(
                                 1,
-                                "path/file2.ext2",
+                                FILES["deep/path/file2.ext2"].id,
                             ),
                             event.FinishFileUploaded(
                                 1,
-                                "path/file1.ext1",
+                                FILES["deep/path/file1.ext1"].id,
                             ),
                             event.FinishFileUploaded(
                                 1,
-                                "path/file2.ext2",
+                                FILES["deep/path/file2.ext2"].id,
                             ),
                         ]
                     ),
@@ -2508,12 +2649,10 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "path",
-                                    0,
-                                    {
-                                        event.File("file1.ext1", 1048576),
-                                        event.File("file2.ext2", 1048576),
-                                    },
+                                    "path/file1.ext1", "path/file1.ext1", 1048576
+                                ),
+                                event.File(
+                                    "path/file2.ext2", "path/file2.ext2", 1048576
                                 ),
                             },
                         )
@@ -2556,12 +2695,10 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
-                                    "path",
-                                    0,
-                                    {
-                                        event.File("file1.ext1", 1048576),
-                                        event.File("file2.ext2", 1048576),
-                                    },
+                                    "path/file1.ext1", "path/file1.ext1", 1048576
+                                ),
+                                event.File(
+                                    "path/file2.ext2", "path/file2.ext2", 1048576
                                 ),
                             },
                         )
@@ -2600,10 +2737,10 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/path/file1.ext1", 1048576),
-                            event.File("/tmp/received/path/file2.ext2", 1048576),
-                            event.File("/tmp/received/path(1)/file1.ext1", 1048576),
-                            event.File("/tmp/received/path(1)/file2.ext2", 1048576),
+                            action.File("/tmp/received/path/file1.ext1", 1048576),
+                            action.File("/tmp/received/path/file2.ext2", 1048576),
+                            action.File("/tmp/received/path(1)/file1.ext1", 1048576),
+                            action.File("/tmp/received/path(1)/file2.ext2", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -2648,16 +2785,18 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.ModifyFile("/tmp/testfile-big"),
                     action.Wait(
                         event.FinishFileFailed(
                             0,
-                            "testfile-big",
+                            FILES["testfile-big"].id,
                             Error.FILE_MODIFIED,
                         )
                     ),
@@ -2674,7 +2813,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -2711,15 +2850,19 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-small")),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "testfile-small",
+                            FILES["testfile-small"].id,
                         )
                     ),
                     action.NoEvent(),
@@ -2733,7 +2876,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
+                                event.File("testfile-small", "testfile-small", 1048576),
                             },
                         )
                     ),
@@ -2752,7 +2895,7 @@ scenarios = [
                     ),
                     action.CompareTrees(
                         Path(gettempdir()) / "received" / "18",
-                        [event.File("testfile-small", 1048576)],
+                        [action.File("testfile-small", 1048576)],
                     ),
                     action.NoEvent(),
                     action.Stop(),
@@ -2799,6 +2942,9 @@ scenarios = [
                                 0,
                                 {
                                     event.File(
+                                        FILES[
+                                            "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                        ].id,
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2808,6 +2954,9 @@ scenarios = [
                                 1,
                                 {
                                     event.File(
+                                        FILES[
+                                            "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                        ].id,
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2817,6 +2966,9 @@ scenarios = [
                                 2,
                                 {
                                     event.File(
+                                        FILES[
+                                            "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                        ].id,
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2826,6 +2978,9 @@ scenarios = [
                                 3,
                                 {
                                     event.File(
+                                        FILES[
+                                            "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                        ].id,
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2851,6 +3006,7 @@ scenarios = [
                                 {
                                     event.File(
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
+                                        "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
                                 },
@@ -2860,6 +3016,7 @@ scenarios = [
                                 "172.20.0.5",
                                 {
                                     event.File(
+                                        "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2908,6 +3065,7 @@ scenarios = [
                                 {
                                     event.File(
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
+                                        "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
                                 },
@@ -2917,6 +3075,7 @@ scenarios = [
                                 "172.20.0.5",
                                 {
                                     event.File(
+                                        "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt",
                                         1048576,
                                     ),
@@ -2972,17 +3131,18 @@ scenarios = [
                             0,
                             {
                                 event.File(
+                                    FILES["with-illegal-char-\x0A-"].id,
                                     "with-illegal-char-\x0A-",
                                     1048576,
                                 ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "with-illegal-char-\x0A-")),
+                    action.Wait(event.Start(0, FILES["with-illegal-char-\x0A-"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "with-illegal-char-\x0A-",
+                            FILES["with-illegal-char-\x0A-"].id,
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -2998,6 +3158,7 @@ scenarios = [
                             "172.20.0.5",
                             {
                                 event.File(
+                                    "with-illegal-char-\x0A-",
                                     "with-illegal-char-\x0A-",
                                     1048576,
                                 ),
@@ -3019,7 +3180,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/with-illegal-char-_-", 1048576),
+                            action.File("/tmp/received/with-illegal-char-_-", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -3049,47 +3210,59 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-small", 1048576),
-                                event.File("testfile-big", 10485760),
                                 event.File(
-                                    "deep",
-                                    0,
-                                    {
-                                        event.File(
-                                            "path",
-                                            0,
-                                            {
-                                                event.File("file1.ext1", 1048576),
-                                                event.File("file2.ext2", 1048576),
-                                            },
-                                        ),
-                                        event.File(
-                                            "another-path",
-                                            0,
-                                            {
-                                                event.File("file3.ext3", 1048576),
-                                                event.File("file4.ext4", 1048576),
-                                            },
-                                        ),
-                                    },
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                                event.File(
+                                    FILES["deep/path/file1.ext1"].id,
+                                    "deep/path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/path/file2.ext2"].id,
+                                    "deep/path/file2.ext2",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/another-path/file3.ext3"].id,
+                                    "deep/another-path/file3.ext3",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["deep/another-path/file4.ext4"].id,
+                                    "deep/another-path/file4.ext4",
+                                    1048576,
                                 ),
                             },
                         )
                     ),
                     action.WaitRacy(
                         [
-                            event.Start(0, "testfile-small"),
-                            event.Start(0, "testfile-big"),
-                            event.Start(0, "deep/path/file1.ext1"),
-                            event.Start(0, "deep/path/file2.ext2"),
-                            event.Start(0, "deep/another-path/file3.ext3"),
-                            event.Start(0, "deep/another-path/file4.ext4"),
-                            event.FinishFileUploaded(0, "testfile-small"),
-                            event.FinishFileUploaded(0, "testfile-big"),
-                            event.FinishFileUploaded(0, "deep/path/file1.ext1"),
-                            event.FinishFileUploaded(0, "deep/path/file2.ext2"),
-                            event.FinishFileUploaded(0, "deep/another-path/file3.ext3"),
-                            event.FinishFileUploaded(0, "deep/another-path/file4.ext4"),
+                            event.Start(0, FILES["testfile-small"].id),
+                            event.Start(0, FILES["testfile-big"].id),
+                            event.Start(0, FILES["deep/path/file1.ext1"].id),
+                            event.Start(0, FILES["deep/path/file2.ext2"].id),
+                            event.Start(0, FILES["deep/another-path/file3.ext3"].id),
+                            event.Start(0, FILES["deep/another-path/file4.ext4"].id),
+                            event.FinishFileUploaded(0, FILES["testfile-small"].id),
+                            event.FinishFileUploaded(0, FILES["testfile-big"].id),
+                            event.FinishFileUploaded(
+                                0, FILES["deep/path/file1.ext1"].id
+                            ),
+                            event.FinishFileUploaded(
+                                0, FILES["deep/path/file2.ext2"].id
+                            ),
+                            event.FinishFileUploaded(
+                                0, FILES["deep/another-path/file3.ext3"].id
+                            ),
+                            event.FinishFileUploaded(
+                                0, FILES["deep/another-path/file4.ext4"].id
+                            ),
                         ]
                     ),
                     action.ExpectCancel([0], True),
@@ -3104,29 +3277,27 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-small", 1048576),
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-small", "testfile-small", 1048576),
+                                event.File("testfile-big", "testfile-big", 10485760),
                                 event.File(
-                                    "deep",
-                                    0,
-                                    {
-                                        event.File(
-                                            "path",
-                                            0,
-                                            {
-                                                event.File("file1.ext1", 1048576),
-                                                event.File("file2.ext2", 1048576),
-                                            },
-                                        ),
-                                        event.File(
-                                            "another-path",
-                                            0,
-                                            {
-                                                event.File("file3.ext3", 1048576),
-                                                event.File("file4.ext4", 1048576),
-                                            },
-                                        ),
-                                    },
+                                    "deep/path/file1.ext1",
+                                    "deep/path/file1.ext1",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/path/file2.ext2",
+                                    "deep/path/file2.ext2",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/another-path/file3.ext3",
+                                    "deep/another-path/file3.ext3",
+                                    1048576,
+                                ),
+                                event.File(
+                                    "deep/another-path/file4.ext4",
+                                    "deep/another-path/file4.ext4",
+                                    1048576,
                                 ),
                             },
                         )
@@ -3179,18 +3350,18 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/20/testfile-small", 1048576),
-                            event.File("/tmp/received/20/testfile-big", 10485760),
-                            event.File(
+                            action.File("/tmp/received/20/testfile-small", 1048576),
+                            action.File("/tmp/received/20/testfile-big", 10485760),
+                            action.File(
                                 "/tmp/received/20/deep/path/file1.ext1", 1048576
                             ),
-                            event.File(
+                            action.File(
                                 "/tmp/received/20/deep/path/file2.ext2", 1048576
                             ),
-                            event.File(
+                            action.File(
                                 "/tmp/received/20/deep/another-path/file3.ext3", 1048576
                             ),
-                            event.File(
+                            action.File(
                                 "/tmp/received/20/deep/another-path/file4.ext4", 1048576
                             ),
                         ],
@@ -3216,11 +3387,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.FinishTransferCanceled(0, True)),
                     action.WaitForAnotherPeer(),
                     # new transfer
@@ -3229,15 +3402,17 @@ scenarios = [
                         event.Queued(
                             1,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(1, "testfile-big")),
+                    action.Wait(event.Start(1, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             1,
-                            "testfile-big",
+                            FILES["testfile-big"].id,
                         )
                     ),
                     action.ExpectCancel([1], True),
@@ -3252,7 +3427,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -3274,7 +3449,7 @@ scenarios = [
                             1,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -3295,7 +3470,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/21-1/testfile-big", 10485760),
+                            action.File("/tmp/received/21-1/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(1),
@@ -3319,11 +3494,13 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "testfile-big")),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.FinishTransferCanceled(0, True)),
                     action.WaitForAnotherPeer(),
                     # new transfer
@@ -3332,15 +3509,17 @@ scenarios = [
                         event.Queued(
                             1,
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(1, "testfile-big")),
+                    action.Wait(event.Start(1, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             1,
-                            "testfile-big",
+                            FILES["testfile-big"].id,
                         )
                     ),
                     action.ExpectCancel([1], True),
@@ -3355,7 +3534,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -3378,7 +3557,7 @@ scenarios = [
                             1,
                             "172.20.0.5",
                             {
-                                event.File("testfile-big", 10485760),
+                                event.File("testfile-big", "testfile-big", 10485760),
                             },
                         )
                     ),
@@ -3398,7 +3577,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/21-2/testfile-big", 10485760),
+                            action.File("/tmp/received/21-2/testfile-big", 10485760),
                         ],
                     ),
                     action.CancelTransferRequest(1),
@@ -3421,15 +3600,17 @@ scenarios = [
                         event.Queued(
                             0,
                             {
-                                event.File("zero-sized-file", 0),
+                                event.File(
+                                    FILES["zero-sized-file"].id, "zero-sized-file", 0
+                                ),
                             },
                         )
                     ),
-                    action.Wait(event.Start(0, "zero-sized-file")),
+                    action.Wait(event.Start(0, FILES["zero-sized-file"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
                             0,
-                            "zero-sized-file",
+                            FILES["zero-sized-file"].id,
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -3444,7 +3625,7 @@ scenarios = [
                             0,
                             "172.20.0.5",
                             {
-                                event.File("zero-sized-file", 0),
+                                event.File("zero-sized-file", "zero-sized-file", 0),
                             },
                         )
                     ),
@@ -3463,7 +3644,7 @@ scenarios = [
                     ),
                     action.CheckDownloadedFiles(
                         [
-                            event.File("/tmp/received/22/zero-sized-file", 0),
+                            action.File("/tmp/received/22/zero-sized-file", 0),
                         ],
                     ),
                     action.CancelTransferRequest(0),


### PR DESCRIPTION
I've implemented the file identification by hashing the filesystem paths. It is used in events and the API layer.
For compatibility and file placement reasons the old Id still is in use, but has been renamed to `FileSubPath`.

Test cases are also adjusted but since the receiving peer does not have access to the full path of the file, it is forced to use the subpath as an ID. The implementation allows for that because `FileId` is just a `String` under the hood.

Also the `RequestQueued/Received` now contains the flat file list, with Id and subpath as separate fields