### PR TITLE
Sending multiple files with the same filename sends only one

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ---
 * Accept `storage_path` through `norddrop_start` config for SQLite persistence
 * File IDs are no longer valid paths. Changed the structure of `RequestQueued/Received` events to contain a flat file list
+* Fix duplicate filenames error
 
 ---
 <br>

--- a/drop-transfer/src/utils.rs
+++ b/drop-transfer/src/utils.rs
@@ -65,9 +65,7 @@ pub fn filepath_variants(location: &'_ Path) -> crate::Result<impl Iterator<Item
             filename.extend([".", &extension.to_string_lossy()]);
         };
 
-        let mut dst_loc = location.to_path_buf();
-        dst_loc.set_file_name(filename);
-        dst_loc
+        location.with_file_name(filename)
     }));
 
     Ok(iter)

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     auth,
     error::ResultExt,
     event::DownloadSuccess,
-    file::{self},
+    file,
     manager::{TransferConnection, TransferGuard},
     protocol,
     quarantine::PathExt,
@@ -48,6 +48,8 @@ use crate::{
 };
 
 const MAX_FILENAME_LENGTH: usize = 255;
+const MAX_FILE_SUFFIX_LEN: usize = 5; // Assume that the suffix will fit into 5 characters e.g.
+                                      // `<filename>(999).<ext>`
 const REPORT_PROGRESS_THRESHOLD: u64 = 1024 * 64;
 
 pub enum ServerReq {
@@ -58,7 +60,6 @@ pub enum ServerReq {
 pub struct FileXferTask {
     pub file: crate::File,
     pub location: Hidden<PathBuf>,
-    pub filename: String,
     pub size: u64,
     pub xfer: crate::Transfer,
 }
@@ -411,19 +412,12 @@ async fn handle_client(
 
 impl FileXferTask {
     pub fn new(file: crate::File, xfer: crate::Transfer, location: PathBuf) -> crate::Result<Self> {
-        let filename = location
-            .file_stem()
-            .ok_or(crate::Error::BadFile)?
-            .to_string_lossy()
-            .to_string();
-
         let size = file.size();
 
         Ok(Self {
             file,
             xfer,
             location: Hidden(location),
-            filename,
             size,
         })
     }
@@ -433,7 +427,27 @@ impl FileXferTask {
         tmp_location: &Hidden<PathBuf>,
         logger: &Logger,
     ) -> crate::Result<PathBuf> {
-        let dst_location = crate::utils::map_path_if_exists(&self.location.0)?;
+        let mut opts = fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+
+        let mut iter = crate::utils::filepath_variants(&self.location.0)?;
+        let dst_location = loop {
+            let path = iter.next().expect("File paths iterator should never end");
+
+            match opts.open(&path) {
+                Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+                    continue;
+                }
+                Err(err) => {
+                    error!(logger, "Failed to crate destination file: {err}");
+                    return Err(err.into());
+                }
+                Ok(file) => {
+                    drop(file); // Close the file
+                    break path;
+                }
+            }
+        };
 
         fs::rename(&tmp_location.0, &dst_location)?;
 

--- a/drop-transfer/src/ws/server/v3.rs
+++ b/drop-transfer/src/ws/server/v3.rs
@@ -441,10 +441,11 @@ impl Downloader {
                 continue;
             }
 
-            if meta.len() != task.size {
+            if meta.len() != task.file.size() {
                 info!(
                     self.logger,
-                    "Fould file {variant:?} but size does not match {}", task.size
+                    "Fould file {variant:?} but size does not match {}",
+                    task.file.size()
                 );
                 continue;
             }
@@ -453,8 +454,8 @@ impl Downloader {
             let target_csum = if let Some(csum) = &csum {
                 csum
             } else {
-                let report = self.request_csum(task.size).await?;
-                if report.limit != task.size {
+                let report = self.request_csum(task.file.size()).await?;
+                if report.limit != task.file.size() {
                     error!(
                         self.logger,
                         "Checksum report missmatch. Most likely protocol error"
@@ -508,7 +509,7 @@ impl handler::Downloader for Downloader {
 
                 let msg = v3::ServerMsg::Done(v3::Done {
                     file: self.file_id.clone(),
-                    bytes_transfered: task.size,
+                    bytes_transfered: task.file.size(),
                 });
                 self.send(Message::from(&msg)).await?;
 

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -508,7 +508,7 @@ impl handler::Downloader for Downloader {
 
                 let msg = v4::ServerMsg::Done(v4::Done {
                     file: self.file_id.clone(),
-                    bytes_transfered: task.size,
+                    bytes_transfered: task.file.size(),
                 });
                 self.send(Message::from(&msg)).await?;
 

--- a/test/drop_test/config.py
+++ b/test/drop_test/config.py
@@ -106,4 +106,7 @@ FILES = {
     "zero-sized-file": TestFile(
         size=0, id="d5d4ohM4nRb8b6-Ob19WnSAr_uTtGoUXjT-L575CCMY"
     ),
+    "duplicate/testfile-big": TestFile(
+        size=20 * 1024, id="Jr2sHMHPjPP5Y19bGJMf17GeT3B4Jrs1ozB1UnFcRzo"
+    ),
 }

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3608,7 +3608,7 @@ scenarios = [
                     action.WaitForResume(
                         1,
                         FILES["testfile-big"].id,
-                        "/tmp/received/21-1/testfile-big.dropdl-part",
+                        f"/tmp/received/21-1/{FILES['testfile-big'].id}.dropdl-part",
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
@@ -3702,7 +3702,9 @@ scenarios = [
                     action.CancelTransferRequest(0),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     # new transfer
-                    action.ModifyFile("/tmp/received/21-2/testfile-big.dropdl-part"),
+                    action.ModifyFile(
+                        f"/tmp/received/21-2/{FILES['testfile-big'].id}.dropdl-part"
+                    ),
                     action.Wait(
                         event.Receive(
                             1,


### PR DESCRIPTION
This PR has the following changes:

* change the temp file naming scheme, to avoid conflicts on duplicate names
* test cases for duplicate file names
* making temp -> target rename more atomic

These changes guarantee proper handling of duplicated file names as well as Windows names collision due to the case insensitivity 