### PR TITLE
.github: workflows: lint: Check out HEAD of PR target

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -49,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
Currently, the checkout action checks out a merge commit, linting code that theoretically does not exist. This commit changes the ref to be the target of the PR.