### PR TITLE
Fix go bindings for pubkey callback

### DIFF
--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NorddropResult.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NorddropResult.java
@@ -20,6 +20,7 @@ public final class NorddropResult {
   public final static NorddropResult NORDDROP_RES_INSTANCE_START = new NorddropResult("NORDDROP_RES_INSTANCE_START", libnorddropJNI.NORDDROP_RES_INSTANCE_START_get());
   public final static NorddropResult NORDDROP_RES_INSTANCE_STOP = new NorddropResult("NORDDROP_RES_INSTANCE_STOP", libnorddropJNI.NORDDROP_RES_INSTANCE_STOP_get());
   public final static NorddropResult NORDDROP_RES_INVALID_PRIVKEY = new NorddropResult("NORDDROP_RES_INVALID_PRIVKEY", libnorddropJNI.NORDDROP_RES_INVALID_PRIVKEY_get());
+  public final static NorddropResult NORDDROP_RES_DB_ERROR = new NorddropResult("NORDDROP_RES_DB_ERROR", libnorddropJNI.NORDDROP_RES_DB_ERROR_get());
 
   public final int swigValue() {
     return swigValue;
@@ -55,7 +56,7 @@ public final class NorddropResult {
     swigNext = this.swigValue+1;
   }
 
-  private static NorddropResult[] swigValues = { NORDDROP_RES_OK, NORDDROP_RES_ERROR, NORDDROP_RES_INVALID_STRING, NORDDROP_RES_BAD_INPUT, NORDDROP_RES_JSON_PARSE, NORDDROP_RES_TRANSFER_CREATE, NORDDROP_RES_NOT_STARTED, NORDDROP_RES_ADDR_IN_USE, NORDDROP_RES_INSTANCE_START, NORDDROP_RES_INSTANCE_STOP, NORDDROP_RES_INVALID_PRIVKEY };
+  private static NorddropResult[] swigValues = { NORDDROP_RES_OK, NORDDROP_RES_ERROR, NORDDROP_RES_INVALID_STRING, NORDDROP_RES_BAD_INPUT, NORDDROP_RES_JSON_PARSE, NORDDROP_RES_TRANSFER_CREATE, NORDDROP_RES_NOT_STARTED, NORDDROP_RES_ADDR_IN_USE, NORDDROP_RES_INSTANCE_START, NORDDROP_RES_INSTANCE_STOP, NORDDROP_RES_INVALID_PRIVKEY, NORDDROP_RES_DB_ERROR };
   private static int swigNext = 0;
   private final int swigValue;
   private final String swigName;

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
@@ -26,6 +26,7 @@ public class libnorddropJNI {
   public final static native int NORDDROP_RES_INSTANCE_START_get();
   public final static native int NORDDROP_RES_INSTANCE_STOP_get();
   public final static native int NORDDROP_RES_INVALID_PRIVKEY_get();
+  public final static native int NORDDROP_RES_DB_ERROR_get();
   public final static native long new_NordDrop(INordDropEventCb jarg1, int jarg2, INordDropLoggerCb jarg3, INordDropPubkeyCb jarg4, byte[] jarg5);
   public final static native void delete_NordDrop(long jarg1);
   public final static native int NordDrop_start(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);

--- a/norddrop/ffi/bindings/android/wrap/java_wrap.c
+++ b/norddrop/ffi/bindings/android/wrap/java_wrap.c
@@ -620,6 +620,18 @@ SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NORDDROP_1RES_1
 }
 
 
+SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NORDDROP_1RES_1DB_1ERROR_1get(JNIEnv *jenv, jclass jcls) {
+  jint jresult = 0 ;
+  enum norddrop_result result;
+  
+  (void)jenv;
+  (void)jcls;
+  result = (enum norddrop_result)NORDDROP_RES_DB_ERROR;
+  jresult = (jint)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT jlong JNICALL Java_com_nordsec_norddrop_libnorddropJNI_new_1NordDrop(JNIEnv *jenv, jclass jcls, jobject jarg1, jint jarg2, jobject jarg3, jobject jarg4, jbyteArray jarg5) {
   jlong jresult = 0 ;
   norddrop_event_cb arg1 ;

--- a/norddrop/ffi/bindings/linux/go/norddropgo.go
+++ b/norddrop/ffi/bindings/linux/go/norddropgo.go
@@ -67,6 +67,7 @@ extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_7f406083ff4c9731(void);
 extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_7f406083ff4c9731(void);
 extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_7f406083ff4c9731(void);
 extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_7f406083ff4c9731(void);
+extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_7f406083ff4c9731(void);
 extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_7f406083ff4c9731(uintptr_t arg1, uintptr_t arg2);
 extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_7f406083ff4c9731(uintptr_t arg1);
 extern void _wrap_NorddropEventCb_Cb_set_norddropgo_7f406083ff4c9731(uintptr_t arg1, swig_type_1 arg2);
@@ -85,7 +86,7 @@ extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_7f406083ff4c9731(uintptr_t 
 extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_7f406083ff4c9731(uintptr_t arg1);
 extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_7f406083ff4c9731(void);
 extern void _wrap_delete_NorddropPubkeyCb_norddropgo_7f406083ff4c9731(uintptr_t arg1);
-extern uintptr_t _wrap_new_Norddrop_norddropgo_7f406083ff4c9731(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, uintptr_t arg4, swig_type_7 arg5);
+extern uintptr_t _wrap_new_Norddrop_norddropgo_7f406083ff4c9731(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_7 arg5);
 extern void _wrap_delete_Norddrop_norddropgo_7f406083ff4c9731(uintptr_t arg1);
 extern swig_intgo _wrap_Norddrop_Start_norddropgo_7f406083ff4c9731(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3);
 extern swig_intgo _wrap_Norddrop_Stop_norddropgo_7f406083ff4c9731(uintptr_t arg1);
@@ -259,6 +260,13 @@ func _swig_getNORDDROPRESINVALIDPRIVKEY() (_swig_ret Enum_SS_norddrop_result) {
 }
 
 var NORDDROPRESINVALIDPRIVKEY Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDPRIVKEY()
+func _swig_getNORDDROPRESDBERROR() (_swig_ret Enum_SS_norddrop_result) {
+	var swig_r Enum_SS_norddrop_result
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_7f406083ff4c9731())
+	return swig_r
+}
+
+var NORDDROPRESDBERROR Enum_SS_norddrop_result = _swig_getNORDDROPRESDBERROR()
 type SwigcptrNorddropEventCb uintptr
 
 func (p SwigcptrNorddropEventCb) Swigcptr() uintptr {
@@ -482,22 +490,6 @@ func call_norddrop_logger_cb(ctx uintptr, level C.int, str *C.char) {
 }
 
 
-%typemap(gotype) norddrop_pubkey_cb "func(string, *byte) int";
-%typemap(imtype) norddrop_pubkey_cb "C.norddrop_pubkey_cb";
-%typemap(goin) norddrop_pubkey_cb {
-        index := maxPubkeyCbIndex() + 1
-        cb := C.norddrop_pubkey_cb{
-                ctx: unsafe.Pointer(index),
-                cb: (C.norddrop_pubkey_fn)(C.call_norddrop_pubkey_cb),
-        }
-        pubkeyCallbacks[index] = $input
-        $result = cb
-}
-%typemap(in) norddrop_pubkey_cb {
-        $1 = $input;
-}
-
-%insert(go_wrapper) %{
 //export call_norddrop_pubkey_cb
 func call_norddrop_pubkey_cb(ctx uintptr, ip *C.char, pubkey *C.char) C.int {
         if callback, ok := pubkeyCallbacks[ctx]; ok {
@@ -524,7 +516,7 @@ func (p SwigcptrNorddrop) Swigcptr() uintptr {
 func (p SwigcptrNorddrop) SwigIsNorddrop() {
 }
 
-func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(int, string), arg4 NorddropPubkeyCb, arg5 string) (_swig_ret Norddrop) {
+func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(int, string), arg4 func(string, *byte) int, arg5 string) (_swig_ret Norddrop) {
 	var swig_r Norddrop
 	var _swig_i_0 C.norddrop_event_cb
 {
@@ -547,9 +539,18 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
         loggerCallbacks[index] = arg3
         _swig_i_2 = cb
 }
-	_swig_i_3 := arg4.Swigcptr()
+	var _swig_i_3 C.norddrop_pubkey_cb
+{
+        index := maxPubkeyCbIndex() + 1
+        cb := C.norddrop_pubkey_cb{
+                ctx: unsafe.Pointer(index),
+                cb: (C.norddrop_pubkey_fn)(C.call_norddrop_pubkey_cb),
+        }
+        pubkeyCallbacks[index] = arg4
+        _swig_i_3 = cb
+}
 	_swig_i_4 := arg5
-	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_7f406083ff4c9731(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.uintptr_t(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
+	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_7f406083ff4c9731(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg5
 	}

--- a/norddrop/ffi/bindings/linux/wrap/go_wrap.c
+++ b/norddrop/ffi/bindings/linux/wrap/go_wrap.c
@@ -469,6 +469,18 @@ intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_7f406083ff4c9731() {
 }
 
 
+intgo _wrap_NORDDROPRESDBERROR_norddropgo_7f406083ff4c9731() {
+  enum norddrop_result result;
+  intgo _swig_go_result;
+  
+  
+  result = NORDDROP_RES_DB_ERROR;
+  
+  _swig_go_result = (intgo)result; 
+  return _swig_go_result;
+}
+
+
 void _wrap_NorddropEventCb_Ctx_set_norddropgo_7f406083ff4c9731(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
@@ -682,13 +694,12 @@ void _wrap_delete_NorddropPubkeyCb_norddropgo_7f406083ff4c9731(struct norddrop_p
 }
 
 
-struct norddrop *_wrap_new_Norddrop_norddropgo_7f406083ff4c9731(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, struct norddrop_pubkey_cb *_swig_go_3, _gostring_ _swig_go_4) {
+struct norddrop *_wrap_new_Norddrop_norddropgo_7f406083ff4c9731(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
   norddrop_event_cb arg1 ;
   enum norddrop_log_level arg2 ;
   norddrop_logger_cb arg3 ;
   norddrop_pubkey_cb arg4 ;
   char *arg5 = (char *) 0 ;
-  norddrop_pubkey_cb *argp4 ;
   struct norddrop *result = 0 ;
   struct norddrop *_swig_go_result;
   
@@ -699,13 +710,9 @@ struct norddrop *_wrap_new_Norddrop_norddropgo_7f406083ff4c9731(norddrop_event_c
   {
     arg3 = _swig_go_2;
   }
-  
-  argp4 = (norddrop_pubkey_cb *)_swig_go_3;
-  if (argp4 == NULL) {
-    _swig_gopanic("Attempt to dereference null norddrop_pubkey_cb");
+  {
+    arg4 = _swig_go_3;
   }
-  arg4 = (norddrop_pubkey_cb)*argp4;
-  
   
   arg5 = (char *)malloc(_swig_go_4.n + 1);
   memcpy(arg5, _swig_go_4.p, _swig_go_4.n);

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -68,6 +68,7 @@ typedef enum norddrop_result {
    * Invalid private key provided
    */
   NORDDROP_RES_INVALID_PRIVKEY = 10,
+  NORDDROP_RES_DB_ERROR = 11,
 } norddrop_result;
 
 typedef struct norddrop norddrop;

--- a/norddrop/ffi/bindings/norddrop_types.h
+++ b/norddrop/ffi/bindings/norddrop_types.h
@@ -68,6 +68,7 @@ typedef enum norddrop_result {
    * Invalid private key provided
    */
   NORDDROP_RES_INVALID_PRIVKEY = 10,
+  NORDDROP_RES_DB_ERROR = 11,
 } norddrop_result;
 
 typedef void (*norddrop_event_fn)(void*, const char*);

--- a/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
+++ b/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
@@ -33,7 +33,8 @@ public enum NorddropResult {
   ResAddrInUse = 7,
   ResInstanceStart = 8,
   ResInstanceStop = 9,
-  ResInvalidPrivkey = 10
+  ResInvalidPrivkey = 10,
+  ResDbError = 11
 }
 
 }

--- a/norddrop/ffi/norddropgo.i
+++ b/norddrop/ffi/norddropgo.i
@@ -98,6 +98,7 @@ func call_norddrop_logger_cb(ctx uintptr, level C.int, str *C.char) {
                 callback(int(level), C.GoString(str))
         }
 }
+%}
 
 
 %typemap(gotype) norddrop_pubkey_cb "func(string, *byte) int";
@@ -133,4 +134,5 @@ func call_norddrop_pubkey_cb(ctx uintptr, ip *C.char, pubkey *C.char) C.int {
         return 1
 }
 %}
+
 #endif


### PR DESCRIPTION
There was a typo in the `norddropgo.i` swig file