### PR TITLE
Remove check for already downloaded files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+### UNRELEASE
+### **Calm**
+---
+* Remove reporting already downloaded file as finished. Instead, redownload it with (1) suffix 
+* Fix the go bindings being unusable
+
+---
+<br>
+
 ### v3.0.0
 ### **ANGERY**
 ---

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -44,9 +44,6 @@ pub enum DownloadInit {
         offset: u64,
         tmp_location: Hidden<PathBuf>,
     },
-    AlreadyDone {
-        destination: Hidden<PathBuf>,
-    },
 }
 
 #[async_trait::async_trait]

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -644,17 +644,6 @@ impl FileXferTask {
                     events.stop(event).await;
                 }
             }
-            handler::DownloadInit::AlreadyDone { destination } => {
-                events
-                    .emit_force(crate::Event::FileDownloadSuccess(
-                        self.xfer.clone(),
-                        DownloadSuccess {
-                            id: self.file.id().clone(),
-                            final_path: Hidden(destination.0.into_boxed_path()),
-                        },
-                    ))
-                    .await;
-            }
         }
     }
 }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashMap,
-    fs, io,
+    fs,
     net::IpAddr,
     ops::ControlFlow,
     path::PathBuf,
@@ -20,8 +20,7 @@ use warp::ws::{Message, WebSocket};
 
 use super::{handler, ServerReq};
 use crate::{
-    file, file::FileKind, protocol::v4, service::State, utils::Hidden, ws::events::FileEventTx,
-    FileId,
+    file::FileKind, protocol::v4, service::State, utils::Hidden, ws::events::FileEventTx, FileId,
 };
 
 pub struct HandlerInit<'a> {
@@ -411,78 +410,6 @@ impl Downloader {
 
         Ok(report)
     }
-
-    async fn check_candidate_file(
-        &mut self,
-        task: &super::FileXferTask,
-    ) -> crate::Result<Option<Hidden<PathBuf>>> {
-        let mut csum = None;
-        for variant in crate::utils::filepath_variants(&task.location.0)?.map(Hidden) {
-            let meta = if let Ok(meta) = variant.symlink_metadata() {
-                meta
-            } else {
-                // If the file does not exists we expect that furter iteration will not yield
-                // more file with (i) suffix
-                break;
-            };
-
-            if !meta.is_file() {
-                continue;
-            }
-
-            if meta.len() != task.file.size() {
-                info!(
-                    self.logger,
-                    "Fould file {variant:?} but size does not match {}",
-                    task.file.size(),
-                );
-                continue;
-            }
-
-            // The file exists let's compare checksum
-            let target_csum = if let Some(csum) = &csum {
-                csum
-            } else {
-                let report = self.request_csum(task.file.size()).await?;
-                if report.limit != task.file.size() {
-                    error!(
-                        self.logger,
-                        "Checksum report missmatch. Most likely protocol error"
-                    );
-                    return Err(crate::Error::BadTransferState);
-                }
-
-                &*csum.insert(report.checksum)
-            };
-
-            let candidate_csum = match tokio::task::block_in_place(|| {
-                let file = fs::File::open(&*variant)?;
-                file::checksum(&mut io::BufReader::new(file))
-            }) {
-                Ok(csum) => csum,
-                Err(err) => {
-                    warn!(
-                        self.logger,
-                        "Failed to compute checksum for candidate file {variant:?}: {err}",
-                    );
-                    continue;
-                }
-            };
-
-            if candidate_csum != *target_csum {
-                info!(
-                    self.logger,
-                    "Fould file {variant:?} but checksum does not match"
-                );
-                continue;
-            }
-
-            // We found the file
-            return Ok(Some(variant));
-        }
-
-        Ok(None)
-    }
 }
 
 #[async_trait::async_trait]
@@ -497,25 +424,6 @@ impl handler::Downloader for Downloader {
         if filename_len + super::MAX_FILE_SUFFIX_LEN > super::MAX_FILENAME_LENGTH {
             return Err(crate::Error::FilenameTooLong);
         }
-
-        // Check if the file is already there
-        match self.check_candidate_file(task).await? {
-            Some(destination) => {
-                info!(
-                    self.logger,
-                    "Found the file here {destination:?}, it's already downloaded"
-                );
-
-                let msg = v4::ServerMsg::Done(v4::Done {
-                    file: self.file_id.clone(),
-                    bytes_transfered: task.file.size(),
-                });
-                self.send(Message::from(&msg)).await?;
-
-                return Ok(handler::DownloadInit::AlreadyDone { destination });
-            }
-            None => debug!(self.logger, "Did not find any candidate files"),
-        };
 
         let tmp_location: Hidden<PathBuf> = Hidden(
             task.location

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -1573,7 +1573,7 @@ scenarios = [
     ),
     Scenario(
         "scenario9",
-        "Send the same file twice, expect reporting that the file is already downloaded",
+        "Send the same file twice, expect downloading the file again and appending (1) suffix",
         {
             "ren": ActionList(
                 [
@@ -1608,6 +1608,7 @@ scenarios = [
                             },
                         )
                     ),
+                    action.Wait(event.Start(1, FILES["deep/path/file1.ext1"].id)),
                     action.Wait(
                         event.FinishFileUploaded(1, FILES["deep/path/file1.ext1"].id)
                     ),
@@ -1662,16 +1663,18 @@ scenarios = [
                         FILES["deep/path/file1.ext1"].id,
                         "/tmp/received",
                     ),
+                    action.Wait(event.Start(1, FILES["deep/path/file1.ext1"].id)),
                     action.Wait(
                         event.FinishFileDownloaded(
                             1,
                             FILES["deep/path/file1.ext1"].id,
-                            "/tmp/received/file1.ext1",
+                            "/tmp/received/file1(1).ext1",
                         )
                     ),
                     action.CheckDownloadedFiles(
                         [
                             action.File("/tmp/received/file1.ext1", 1048576),
+                            action.File("/tmp/received/file1(1).ext1", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),
@@ -2605,6 +2608,13 @@ scenarios = [
                             FILES["testfile-small"].id,
                         )
                     ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            0,
+                            FILES["testfile-small"].id,
+                        )
+                    ),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -2643,16 +2653,18 @@ scenarios = [
                         FILES["testfile-small"].id,
                         "/tmp/received",
                     ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileDownloaded(
                             0,
                             FILES["testfile-small"].id,
-                            "/tmp/received/testfile-small",
+                            "/tmp/received/testfile-small(1)",
                         )
                     ),
                     action.CheckDownloadedFiles(
                         [
                             action.File("/tmp/received/testfile-small", 1048576),
+                            action.File("/tmp/received/testfile-small(1)", 1048576),
                         ],
                     ),
                     action.CancelTransferRequest(0),


### PR DESCRIPTION
This PR removes the check for already downloaded files. This feature was introduced along the resumes but turned out to be a bug 