### PR TITLE
Parse file subpath from the relative path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ---
 * Remove reporting already downloaded file as finished. Instead, redownload it with (1) suffix 
 * Fix the go bindings being unusable
+* Fix directory flattening on Windows
 
 ---
 <br>

--- a/drop-transfer/src/file/id.rs
+++ b/drop-transfer/src/file/id.rs
@@ -92,6 +92,15 @@ impl FileSubPath {
     pub fn name(&self) -> &str {
         self.0.last().expect("Missing last path component")
     }
+
+    pub fn from_path(path: impl AsRef<Path>) -> crate::Result<Self> {
+        let vec = path
+            .as_ref()
+            .iter()
+            .map(|cmp| cmp.to_str().map(String::from).ok_or(crate::Error::BadPath))
+            .collect::<Result<_, _>>()?;
+        Ok(Self(vec))
+    }
 }
 
 impl<T> From<T> for FileSubPath

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -77,11 +77,11 @@ impl File {
             let subpath = entry
                 .path()
                 .strip_prefix(parent)
-                .map_err(|_| crate::Error::BadPath)?
-                .to_str()
-                .ok_or(crate::Error::BadPath)?;
+                .map_err(|_| crate::Error::BadPath)?;
 
-            let file = File::new(subpath.into(), entry.into_path(), meta)?;
+            let subpath = FileSubPath::from_path(subpath)?;
+
+            let file = File::new(subpath, entry.into_path(), meta)?;
             files.push(file);
         }
 

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -406,8 +406,8 @@ fn prepare_transfer_files(
 ) -> Result<Vec<File>> {
     let mut files = Vec::new();
 
+    #[allow(unused_variables)]
     for (i, desc) in descriptors.iter().enumerate() {
-        #[allow(unused_variables)]
         if let Some(fd) = desc.fd {
             #[cfg(target_os = "windows")]
             {


### PR DESCRIPTION
This is a fix for Windows issues when sending the directories. The `FileSubPath` was parsed incorrectly from the filesystem path