### PR TITLE
Remove outdated comment about NULL param to pubkey cb

### DIFF
--- a/norddrop/ffi/bindings/norddrop_types.h
+++ b/norddrop/ffi/bindings/norddrop_types.h
@@ -108,8 +108,6 @@ typedef struct norddrop_logger_cb {
 /**
  * Writes the peer's public key into the buffer of length 32.
  * The peer is identifed by IP address passed as string,
- * If IP is null that means we're requesting the public key
- * of the caller itself.
  * Returns 0 on success and 1 on failure or missing key
  */
 typedef int (*norddrop_pubkey_fn)(void*, const char*, char*);

--- a/norddrop/src/ffi/types.rs
+++ b/norddrop/src/ffi/types.rs
@@ -111,8 +111,6 @@ pub struct norddrop_logger_cb {
 #[allow(non_camel_case_types)]
 /// Writes the peer's public key into the buffer of length 32.
 /// The peer is identifed by IP address passed as string,
-/// If IP is null that means we're requesting the public key
-/// of the caller itself.
 /// Returns 0 on success and 1 on failure or missing key
 pub type norddrop_pubkey_fn =
     unsafe extern "C" fn(*mut c_void, *const c_char, *mut c_char) -> c_int;


### PR DESCRIPTION
Public key callback initially passed in NULL
so that the host should return it's own pubkey, however that was changed and is no longer relevant.