### PR TITLE
Clarify timestamp input values

### DIFF
--- a/norddrop/ffi/norddrop.i
+++ b/norddrop/ffi/norddrop.i
@@ -83,12 +83,14 @@ struct norddrop {};
     enum norddrop_result purge_transfers(const char *txids);
 
     // Purge all transfers that are older than the given timestamp from the
-    // database. Accepts a UNIX timestamp in seconds
+    // database. Accepts a UNIX timestamp in seconds with values between
+    // -210866760000 and 253402300799 inclusive
     enum norddrop_result purge_transfers_until(long long until_timestamp);
 
     %newobject get_transfers_since;
     // Get all transfers since the given timestamp from the database.
-    // Accepts a UNIX timestamp in seconds
+    // Accepts a UNIX timestamp in seconds with values between
+    // -210866760000 and 253402300799 inclusive
     char *get_transfers_since(long long since_timestamp);
 
     // Returns current version of the library


### PR DESCRIPTION
The Android team ran into an issue where passing `Long.MAX_VALUE` to `purge_transfers_until` would not delete any of the entries, and according to the SQLite documentation

`These functions only work for dates between 0000-01-01 00:00:00 and 9999-12-31 23:59:59 (julian day numbers 1721059.5 through 5373484.5). For dates outside that range, the results of these functions are undefined.`

To help avoid issues like this in the future, I have added the min and max bounds for the timestamps in the comment of the function