### PR TITLE
Merge database JSON events into one list

### DIFF
--- a/drop-storage/src/lib.rs
+++ b/drop-storage/src/lib.rs
@@ -575,9 +575,10 @@ impl Storage {
 
             transfer.states.extend(
                 sqlx::query!(
-                "SELECT status_code, created_at FROM transfer_failed_states WHERE transfer_id = ?1",
-                tid
-            )
+                    "SELECT status_code, created_at FROM transfer_failed_states WHERE transfer_id \
+                     = ?1",
+                    tid
+                )
                 .fetch_all(&mut *conn)
                 .await
                 .map_err(error::Error::DBError)?

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -36,6 +36,7 @@ pub enum PathStateEventData {
 
 #[derive(Debug, Serialize)]
 pub struct PathStateEvent {
+    #[serde(skip_serializing)]
     pub path_id: i64,
     pub created_at: i64,
     #[serde(flatten)]
@@ -55,6 +56,7 @@ pub enum TransferStateEventData {
 
 #[derive(Debug, Serialize)]
 pub struct TransferStateEvent {
+    #[serde(skip_serializing)]
     pub transfer_id: TransferId,
     pub created_at: i64,
     #[serde(flatten)]

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -41,38 +41,35 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.15",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
-                                "by_peer": true,
-                                "created_at": "*"
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": true
                             }
                         ],
-                        "failed_states": [],
                         "type": "outgoing",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
-                                "pending_states": [
+                                "states": [
                                     {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                        "created_at": "*",
+                                        "state": "pending"
+                                    },
                                     {
-                                        "bytes_sent": 0,
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": 0
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
@@ -122,38 +119,35 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.5",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
-                                "by_peer": false,
-                                "created_at": "*"
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": false
                             }
                         ],
-                        "failed_states": [],
                         "type": "incoming",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "bytes": 10485760,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
                                         "bytes_received": 0,
                                         "base_dir": "/tmp/received"
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
@@ -219,76 +213,70 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.15",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
-                                "by_peer": true,
-                                "created_at": "*"
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": true
                             }
                         ],
-                        "failed_states": [],
                         "type": "outgoing",
                         "paths": [
                             {
                                 "relative_path": "testfile-small",
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
-                                        "bytes_sent": 0
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                        "state": "pending"
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": 0
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
                         ]
                     }""",
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.15",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
                                 "created_at": "*",
+                                "state": "cancel",
                                 "by_peer": true
                             }
                         ],
-                        "failed_states": [],
                         "type": "outgoing",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
-                                        "bytes_sent": 0
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                        "state": "pending"
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": 0
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
@@ -365,75 +353,70 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.5",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
                                 "created_at": "*",
+                                "state": "cancel",
                                 "by_peer": false
                             }
                         ],
-                        "failed_states": [],
                         "type": "incoming",
                         "paths": [
                             {
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
-                                "pending_states": [
-                                    {   
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
                                         "bytes_received": 0,
                                         "base_dir": "/tmp/received"
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
                         ]
                     }""",
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.5",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
                                 "created_at": "*",
+                                "state": "cancel",
                                 "by_peer": false
                             }
                         ],
-                        "failed_states": [],
                         "type": "incoming",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "bytes": 10485760,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
-                                        "bytes_received": 0
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [],
-                                "completed_states": [
+                                        "state": "pending"
+                                    },
                                     {
-                                        "created_at": "*"
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_received": 0,
+                                        "base_dir": "/tmp/received"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
                                     }
                                 ]
                             }
@@ -3187,41 +3170,38 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.15",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
                                 "created_at": "*",
+                                "state": "cancel",
                                 "by_peer": true
                             }
                         ],
-                        "failed_states": [],
                         "type": "outgoing",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
                                         "bytes_sent": 0
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [
+                                    },
                                     {
                                         "created_at": "*",
+                                        "state": "failed",
                                         "status_code": 28
                                     }
-                                ],
-                                "completed_states": []
+                                ]
                             }
                         ]
                     }"""
@@ -3263,41 +3243,38 @@ scenarios = [
                     action.AssertTransfers(
                         [
                             """{
+                        "id": "*",
                         "peer_id": "172.20.0.5",
                         "created_at": "*",
-                        "active_states": [],
-                        "cancel_states": [
+                        "states": [
                             {
                                 "created_at": "*",
+                                "state": "cancel",
                                 "by_peer": false
                             }
                         ],
-                        "failed_states": [],
                         "type": "incoming",
                         "paths": [
                             {
                                 "relative_path": "testfile-big",
                                 "bytes": 10485760,
-                                "pending_states": [
-                                    {
-                                        "created_at": "*"
-                                    }
-                                ],
-                                "started_states": [
+                                "states": [
                                     {
                                         "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
                                         "bytes_received": 0,
                                         "base_dir": "/tmp/received"
-                                    }
-                                ],
-                                "cancel_states": [],
-                                "failed_states": [
+                                    },
                                     {
                                         "created_at": "*",
+                                        "state": "failed",
                                         "status_code": 8
                                     }
-                                ],
-                                "completed_states": []
+                                ]
                             }
                         ]
                     }"""


### PR DESCRIPTION
Even more spring cleaning for the JSON output

- Reordered some of the fields to make the output a bit more efficient to visually parse
- Merge both the path and transfer events into one list and sort them by timestamp

And as a side effect-the `types.rs` for storage is a little less bloated