### PR TITLE
Lukasp/storage layer logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros"] }
-slog = { version = "2.7.0", features = ["release_max_level_info"] }
+slog = { version = "2.7.0", features = ["release_max_level_info", "max_level_trace"] }
 serde = { version = "1.0.160", features = ["derive"] }
 async-trait = "0.1.68"
 base64 = "0.21.0"

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -256,7 +256,7 @@ class Drop:
         norddrop_lib.norddrop_new(
             ctypes.pointer(norddrop_instance),
             eventer_instance,
-            LogLevel.Debug,
+            LogLevel.Trace,
             logger_instance,
             pubkey_instance,
             ctypes.create_string_buffer(keys.secret()),


### PR DESCRIPTION
This PR introduces storage layer logging as well as query logging from `sqlx`. For this to work `tracing` is marshalled through a global logger and then marshalled to `slog` so we would be able to drain those logs via callback