### PR TITLE
Update docs

### DIFF
--- a/norddrop/ffi/bindings/linux/go/norddropgo.go
+++ b/norddrop/ffi/bindings/linux/go/norddropgo.go
@@ -52,59 +52,59 @@ typedef long long swig_type_20;
 typedef _gostring_ swig_type_21;
 typedef long long swig_type_22;
 typedef _gostring_ swig_type_23;
-extern void _wrap_Swig_free_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_norddropgo_04a1a3b61a2a8ea3(swig_intgo arg1);
-extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_04a1a3b61a2a8ea3(void);
-extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_04a1a3b61a2a8ea3(void);
-extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern void _wrap_NorddropEventCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_1 arg2);
-extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(void);
-extern void _wrap_delete_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_3 arg2);
-extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3(void);
-extern void _wrap_delete_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_5 arg2);
-extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3(void);
-extern void _wrap_delete_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
+extern void _wrap_Swig_free_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_norddropgo_8962ac4695316737(swig_intgo arg1);
+extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737(void);
+extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737(void);
+extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern void _wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_1 arg2);
+extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_8962ac4695316737(void);
+extern void _wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_3 arg2);
+extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737(void);
+extern void _wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_5 arg2);
+extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737(void);
+extern void _wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(uintptr_t arg1);
 
 #include <string.h>
 
-extern uintptr_t _wrap_new_Norddrop_norddropgo_04a1a3b61a2a8ea3(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_7 arg5);
-extern void _wrap_delete_Norddrop_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_Start_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3);
-extern swig_intgo _wrap_Norddrop_Stop_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_10 arg2);
-extern swig_intgo _wrap_Norddrop_CancelFile_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_11 arg2, swig_type_12 arg3);
-extern swig_intgo _wrap_Norddrop_Download_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3, swig_type_15 arg4);
-extern swig_type_16 _wrap_Norddrop_NewTransfer_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_17 arg2, swig_type_18 arg3);
-extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_19 arg2);
-extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_20 arg2);
-extern swig_type_21 _wrap_Norddrop_GetTransfersSince_norddropgo_04a1a3b61a2a8ea3(uintptr_t arg1, swig_type_22 arg2);
-extern swig_type_23 _wrap_Norddrop_Version_norddropgo_04a1a3b61a2a8ea3(void);
+extern uintptr_t _wrap_new_Norddrop_norddropgo_8962ac4695316737(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_7 arg5);
+extern void _wrap_delete_Norddrop_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_Start_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3);
+extern swig_intgo _wrap_Norddrop_Stop_norddropgo_8962ac4695316737(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_10 arg2);
+extern swig_intgo _wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_11 arg2, swig_type_12 arg3);
+extern swig_intgo _wrap_Norddrop_Download_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3, swig_type_15 arg4);
+extern swig_type_16 _wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_17 arg2, swig_type_18 arg3);
+extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_19 arg2);
+extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_20 arg2);
+extern swig_type_21 _wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_22 arg2);
+extern swig_type_23 _wrap_Norddrop_Version_norddropgo_8962ac4695316737(void);
 #undef intgo
 */
 import "C"
@@ -139,55 +139,55 @@ func swigCopyString(s string) string {
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_04a1a3b61a2a8ea3(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_8962ac4695316737(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_norddrop_log_level int
 func _swig_getNORDDROPLOGCRITICAL() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPLOGCRITICAL Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGCRITICAL()
 func _swig_getNORDDROPLOGERROR() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPLOGERROR Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGERROR()
 func _swig_getNORDDROPLOGWARNING() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPLOGWARNING Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGWARNING()
 func _swig_getNORDDROPLOGINFO() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPLOGINFO Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGINFO()
 func _swig_getNORDDROPLOGDEBUG() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPLOGDEBUG Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGDEBUG()
 func _swig_getNORDDROPLOGTRACE() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
@@ -195,84 +195,84 @@ var NORDDROPLOGTRACE Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGTRACE()
 type Enum_SS_norddrop_result int
 func _swig_getNORDDROPRESOK() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESOK Enum_SS_norddrop_result = _swig_getNORDDROPRESOK()
 func _swig_getNORDDROPRESERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESERROR Enum_SS_norddrop_result = _swig_getNORDDROPRESERROR()
 func _swig_getNORDDROPRESINVALIDSTRING() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDSTRING Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDSTRING()
 func _swig_getNORDDROPRESBADINPUT() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESBADINPUT Enum_SS_norddrop_result = _swig_getNORDDROPRESBADINPUT()
 func _swig_getNORDDROPRESJSONPARSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESJSONPARSE Enum_SS_norddrop_result = _swig_getNORDDROPRESJSONPARSE()
 func _swig_getNORDDROPRESTRANSFERCREATE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESTRANSFERCREATE Enum_SS_norddrop_result = _swig_getNORDDROPRESTRANSFERCREATE()
 func _swig_getNORDDROPRESNOTSTARTED() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESNOTSTARTED Enum_SS_norddrop_result = _swig_getNORDDROPRESNOTSTARTED()
 func _swig_getNORDDROPRESADDRINUSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESADDRINUSE Enum_SS_norddrop_result = _swig_getNORDDROPRESADDRINUSE()
 func _swig_getNORDDROPRESINSTANCESTART() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTART Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTART()
 func _swig_getNORDDROPRESINSTANCESTOP() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTOP Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTOP()
 func _swig_getNORDDROPRESINVALIDPRIVKEY() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDPRIVKEY Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDPRIVKEY()
 func _swig_getNORDDROPRESDBERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_04a1a3b61a2a8ea3())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737())
 	return swig_r
 }
 
@@ -289,38 +289,38 @@ func (p SwigcptrNorddropEventCb) SwigIsNorddropEventCb() {
 func (arg1 SwigcptrNorddropEventCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropEventCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
+	C._wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropEventCb() (_swig_ret NorddropEventCb) {
 	var swig_r NorddropEventCb
-	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3()))
+	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_8962ac4695316737()))
 	return swig_r
 }
 
 func DeleteNorddropEventCb(arg1 NorddropEventCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropEventCb interface {
@@ -344,38 +344,38 @@ func (p SwigcptrNorddropLoggerCb) SwigIsNorddropLoggerCb() {
 func (arg1 SwigcptrNorddropLoggerCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropLoggerCb() (_swig_ret NorddropLoggerCb) {
 	var swig_r NorddropLoggerCb
-	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3()))
+	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737()))
 	return swig_r
 }
 
 func DeleteNorddropLoggerCb(arg1 NorddropLoggerCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropLoggerCb interface {
@@ -399,38 +399,38 @@ func (p SwigcptrNorddropPubkeyCb) SwigIsNorddropPubkeyCb() {
 func (arg1 SwigcptrNorddropPubkeyCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropPubkeyCb() (_swig_ret NorddropPubkeyCb) {
 	var swig_r NorddropPubkeyCb
-	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3()))
+	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737()))
 	return swig_r
 }
 
 func DeleteNorddropPubkeyCb(arg1 NorddropPubkeyCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropPubkeyCb interface {
@@ -560,7 +560,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
         _swig_i_3 = cb
 }
 	_swig_i_4 := arg5
-	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_04a1a3b61a2a8ea3(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
+	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_8962ac4695316737(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg5
 	}
@@ -577,7 +577,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
 
 func DeleteNorddrop(arg1 Norddrop) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_Norddrop_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_Norddrop_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
 }
 
 func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result) {
@@ -585,7 +585,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -598,7 +598,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 func (arg1 SwigcptrNorddrop) Stop() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -606,7 +606,7 @@ func (arg1 SwigcptrNorddrop) CancelTransfer(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -618,7 +618,7 @@ func (arg1 SwigcptrNorddrop) CancelFile(arg2 string, arg3 string) (_swig_ret Enu
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelFile_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -634,7 +634,7 @@ func (arg1 SwigcptrNorddrop) Download(arg2 string, arg3 string, arg4 string) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -652,7 +652,7 @@ func (arg1 SwigcptrNorddrop) NewTransfer(arg2 string, arg3 string) (_swig_ret st
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_2)))
+	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_2)))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
@@ -669,7 +669,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfers(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -680,7 +680,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.swig_type_20(_swig_i_1)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_20(_swig_i_1)))
 	return swig_r
 }
 
@@ -688,7 +688,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_04a1a3b61a2a8ea3(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1))
+	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -697,7 +697,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 
 func NorddropVersion() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Norddrop_Version_norddropgo_04a1a3b61a2a8ea3()
+	swig_r_p := C._wrap_Norddrop_Version_norddropgo_8962ac4695316737()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 

--- a/norddrop/ffi/bindings/linux/wrap/go_wrap.c
+++ b/norddrop/ffi/bindings/linux/wrap/go_wrap.c
@@ -242,7 +242,7 @@ SWIGINTERN void delete_norddrop(struct norddrop *self){
 extern "C" {
 #endif
 
-void _wrap_Swig_free_norddropgo_04a1a3b61a2a8ea3(void *_swig_go_0) {
+void _wrap_Swig_free_norddropgo_8962ac4695316737(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -252,7 +252,7 @@ void _wrap_Swig_free_norddropgo_04a1a3b61a2a8ea3(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_norddropgo_04a1a3b61a2a8ea3(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_norddropgo_8962ac4695316737(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -265,7 +265,7 @@ void *_wrap_Swig_malloc_norddropgo_04a1a3b61a2a8ea3(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -277,7 +277,7 @@ intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPLOGERROR_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -289,7 +289,7 @@ intgo _wrap_NORDDROPLOGERROR_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPLOGWARNING_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -301,7 +301,7 @@ intgo _wrap_NORDDROPLOGWARNING_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPLOGINFO_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -313,7 +313,7 @@ intgo _wrap_NORDDROPLOGINFO_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPLOGDEBUG_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -325,7 +325,7 @@ intgo _wrap_NORDDROPLOGDEBUG_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPLOGTRACE_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -337,7 +337,7 @@ intgo _wrap_NORDDROPLOGTRACE_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESOK_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESOK_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -349,7 +349,7 @@ intgo _wrap_NORDDROPRESOK_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESERROR_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -361,7 +361,7 @@ intgo _wrap_NORDDROPRESERROR_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -373,7 +373,7 @@ intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESBADINPUT_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -385,7 +385,7 @@ intgo _wrap_NORDDROPRESBADINPUT_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -397,7 +397,7 @@ intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -409,7 +409,7 @@ intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -421,7 +421,7 @@ intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -433,7 +433,7 @@ intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -445,7 +445,7 @@ intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -457,7 +457,7 @@ intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -469,7 +469,7 @@ intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-intgo _wrap_NORDDROPRESDBERROR_norddropgo_04a1a3b61a2a8ea3() {
+intgo _wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -481,7 +481,7 @@ intgo _wrap_NORDDROPRESDBERROR_norddropgo_04a1a3b61a2a8ea3() {
 }
 
 
-void _wrap_NorddropEventCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -493,7 +493,7 @@ void _wrap_NorddropEventCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_e
 }
 
 
-void *_wrap_NorddropEventCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_event_cb *_swig_go_0) {
+void *_wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -506,7 +506,7 @@ void *_wrap_NorddropEventCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_
 }
 
 
-void _wrap_NorddropEventCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn arg2 = (norddrop_event_fn) 0 ;
   
@@ -518,7 +518,7 @@ void _wrap_NorddropEventCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_ev
 }
 
 
-void* _wrap_NorddropEventCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_event_cb *_swig_go_0) {
+void* _wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn result;
   void* _swig_go_result;
@@ -531,7 +531,7 @@ void* _wrap_NorddropEventCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_e
 }
 
 
-struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3() {
+struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_8962ac4695316737() {
   struct norddrop_event_cb *result = 0 ;
   struct norddrop_event_cb *_swig_go_result;
   
@@ -542,7 +542,7 @@ struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(
 }
 
 
-void _wrap_delete_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_event_cb *_swig_go_0) {
+void _wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   
   arg1 = *(struct norddrop_event_cb **)&_swig_go_0; 
@@ -552,7 +552,7 @@ void _wrap_delete_NorddropEventCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_ev
 }
 
 
-void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -564,7 +564,7 @@ void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_
 }
 
 
-void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_logger_cb *_swig_go_0) {
+void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -577,7 +577,7 @@ void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop
 }
 
 
-void _wrap_NorddropLoggerCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn arg2 = (norddrop_logger_fn) 0 ;
   
@@ -589,7 +589,7 @@ void _wrap_NorddropLoggerCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_l
 }
 
 
-void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_logger_cb *_swig_go_0) {
+void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn result;
   void* _swig_go_result;
@@ -602,7 +602,7 @@ void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_
 }
 
 
-struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3() {
+struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737() {
   struct norddrop_logger_cb *result = 0 ;
   struct norddrop_logger_cb *_swig_go_result;
   
@@ -613,7 +613,7 @@ struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea
 }
 
 
-void _wrap_delete_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_logger_cb *_swig_go_0) {
+void _wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   
   arg1 = *(struct norddrop_logger_cb **)&_swig_go_0; 
@@ -623,7 +623,7 @@ void _wrap_delete_NorddropLoggerCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_l
 }
 
 
-void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -635,7 +635,7 @@ void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_
 }
 
 
-void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_pubkey_cb *_swig_go_0) {
+void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -648,7 +648,7 @@ void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop
 }
 
 
-void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn arg2 = (norddrop_pubkey_fn) 0 ;
   
@@ -660,7 +660,7 @@ void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_04a1a3b61a2a8ea3(struct norddrop_p
 }
 
 
-void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_pubkey_cb *_swig_go_0) {
+void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn result;
   void* _swig_go_result;
@@ -673,7 +673,7 @@ void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_04a1a3b61a2a8ea3(struct norddrop_
 }
 
 
-struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3() {
+struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737() {
   struct norddrop_pubkey_cb *result = 0 ;
   struct norddrop_pubkey_cb *_swig_go_result;
   
@@ -684,7 +684,7 @@ struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea
 }
 
 
-void _wrap_delete_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_pubkey_cb *_swig_go_0) {
+void _wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   
   arg1 = *(struct norddrop_pubkey_cb **)&_swig_go_0; 
@@ -694,7 +694,7 @@ void _wrap_delete_NorddropPubkeyCb_norddropgo_04a1a3b61a2a8ea3(struct norddrop_p
 }
 
 
-struct norddrop *_wrap_new_Norddrop_norddropgo_04a1a3b61a2a8ea3(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
+struct norddrop *_wrap_new_Norddrop_norddropgo_8962ac4695316737(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
   norddrop_event_cb arg1 ;
   enum norddrop_log_level arg2 ;
   norddrop_logger_cb arg3 ;
@@ -726,7 +726,7 @@ struct norddrop *_wrap_new_Norddrop_norddropgo_04a1a3b61a2a8ea3(norddrop_event_c
 }
 
 
-void _wrap_delete_Norddrop_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0) {
+void _wrap_delete_Norddrop_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   
   arg1 = *(struct norddrop **)&_swig_go_0; 
@@ -736,7 +736,7 @@ void _wrap_delete_Norddrop_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Start_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_Start_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -763,7 +763,7 @@ intgo _wrap_Norddrop_Start_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Stop_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0) {
+intgo _wrap_Norddrop_Stop_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   enum norddrop_result result;
   intgo _swig_go_result;
@@ -776,7 +776,7 @@ intgo _wrap_Norddrop_Stop_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_
 }
 
 
-intgo _wrap_Norddrop_CancelTransfer_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -796,7 +796,7 @@ intgo _wrap_Norddrop_CancelTransfer_norddropgo_04a1a3b61a2a8ea3(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_CancelFile_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -823,7 +823,7 @@ intgo _wrap_Norddrop_CancelFile_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_sw
 }
 
 
-intgo _wrap_Norddrop_Download_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Norddrop_Download_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -857,7 +857,7 @@ intgo _wrap_Norddrop_Download_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig
 }
 
 
-_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -885,7 +885,7 @@ _gostring_ _wrap_Norddrop_NewTransfer_norddropgo_04a1a3b61a2a8ea3(struct norddro
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfers_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -905,7 +905,7 @@ intgo _wrap_Norddrop_PurgeTransfers_norddropgo_04a1a3b61a2a8ea3(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, long long _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   enum norddrop_result result;
@@ -920,7 +920,7 @@ intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_04a1a3b61a2a8ea3(struct nord
 }
 
 
-_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_04a1a3b61a2a8ea3(struct norddrop *_swig_go_0, long long _swig_go_1) {
+_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   char *result = 0 ;
@@ -936,7 +936,7 @@ _gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_04a1a3b61a2a8ea3(struct n
 }
 
 
-_gostring_ _wrap_Norddrop_Version_norddropgo_04a1a3b61a2a8ea3() {
+_gostring_ _wrap_Norddrop_Version_norddropgo_8962ac4695316737() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -68,6 +68,9 @@ typedef enum norddrop_result {
    * Invalid private key provided
    */
   NORDDROP_RES_INVALID_PRIVKEY = 10,
+  /**
+   * Database error
+   */
   NORDDROP_RES_DB_ERROR = 11,
 } norddrop_result;
 
@@ -135,15 +138,50 @@ extern "C" {
 
 extern void fortify_source(void);
 
+/**
+ * @brief Initialize a new transfer with the peer and descriptors provided and
+ * return the transfer ID
+ *
+ * @param dev   Pointer to the instance
+ * @param peer  Peer address
+ * @param descriptors   JSON descriptors
+ * @return char*  Transfer ID
+ *
+ * descriptors format:
+ * [
+ *  {
+ *    "path": "/path/to/file",
+ *  },
+ * {
+ *   "path": "/path/to/dir",
+ * }
+ * ]
+ *
+ * On Android due to limitations we must also accept a file descriptor
+ * {
+ *  [
+ *  "path": "/path/to/file",
+ *  "fd" 1234
+ *  ]
+ * }
+ */
 char *norddrop_new_transfer(const struct norddrop *dev, const char *peer, const char *descriptors);
 
 /**
- * Destroy libdrop instance
+ * @brief Destroy the libdrop instance
+ *
+ * @param dev   Pointer to the instance
  */
 void norddrop_destroy(struct norddrop *dev);
 
 /**
- * Download a file from the peer
+ * @brief Download a file from the peer
+ *
+ * @param dev   Pointer to the instance
+ * @param xfid  Transfer ID
+ * @param fid   File ID
+ * @param dst   Destination path
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_download(const struct norddrop *dev,
                                        const char *xfid,
@@ -151,51 +189,198 @@ enum norddrop_result norddrop_download(const struct norddrop *dev,
                                        const char *dst);
 
 /**
- * Cancel a transfer from the sender side
+ * @brief  Cancel a transfer from either side
+ *
+ * @param dev   Pointer to the instance
+ * @param xfid  Transfer ID
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_cancel_transfer(const struct norddrop *dev, const char *xfid);
 
 /**
- * Cancel a transfer from the sender side
+ * @brief  Cancel a file from either side
+ *
+ * @param dev   Pointer to the instance
+ * @param xfid  Transfer ID
+ * @param fid   File ID
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_cancel_file(const struct norddrop *dev,
                                           const char *xfid,
                                           const char *fid);
 
 /**
- * Start norddrop instance.
+ * @brief   Start libdrop
+ *
+ * @param dev   Pointer to the instance
+ * @param listen_addr   Address to listen on
+ * @param config  JSON configuration
+ * @return enum norddrop_result   Result of the operation
+ *
+ * configuration parameters:
+ *
+ * dir_depth_limit - if the tree contains more levels then the error is
+ * returned.
+ *
+ * transfer_file_limit - when aggregating files from the path, if this
+ * limit is reached, an error is returned.
+ *
+ * req_connection_timeout_ms - timeout value used in connecting to the peer.
+ * The formula for retrying is: starting from 0.2 seconds we double it
+ * each time until we cap at req_connection_timeout_ms / 10. This is useful
+ * when the peer is not responding at all.
+ *
+ * transfer_idle_lifetime_ms - this timeout plays a role in an already
+ * established transfer as sometimes one peer might go offline with no notice.
+ * This timeout controls the amount of time we will wait for any action from
+ * the peer and after that, we will fail the transfer.
+ *
+ * moose_event_path - moose database path.
+ *
+ * storage_path - storage path for persistence engine.
  */
 enum norddrop_result norddrop_start(const struct norddrop *dev,
                                     const char *listen_addr,
                                     const char *config);
 
 /**
- * Stop norddrop instance and all related activities
+ * @brief Stop norddrop instance.
+ *
+ * @param dev   Pointer to the instance
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_stop(const struct norddrop *dev);
 
 /**
- * Purge transfers with the given id(s) from the database, accepts a JSON array
- * of strings
+ * @brief Purge transfers from the database
+ *
+ * @param dev   Pointer to the instance
+ * @param txids   JSON array of transfer IDs
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_purge_transfers(const struct norddrop *dev, const char *txids);
 
 /**
- * Purge all transfers that are older than the given timestamp from the
- * database. Accepts a UNIX timestamp in seconds
+ * @brief Purge transfers from the database until the given timestamp
+ *
+ * @param dev   Pointer to the instance
+ * @param until_timestamp   Unix timestamp in seconds
+ * @return enum norddrop_result   Result of the operation
  */
 enum norddrop_result norddrop_purge_transfers_until(const struct norddrop *dev,
                                                     long long until_timestamp);
 
 /**
- * Get all transfers since the given timestamp from the database. Accepts a
- * UNIX timestamp in seconds
+ * @brief Get transfers from the database
+ *
+ * @param dev  Pointer to the instance
+ * @param since_timestamp   Timestamp in seconds
+ * @return char*  JSON array of transfers
+ *
+ * JSON example from the sender side:
+ *  {
+ *      "id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",
+ *      "peer_id": "192.168.0.0",
+ *      "created_at": 1686651025988,
+ *      "states": [
+ *          {
+ *              "created_at": 1686651026008,
+ *              "state": "cancel",
+ *              "by_peer": true
+ *          }
+ *      ],
+ *      "type": "outgoing",
+ *      "paths": [
+ *          {
+ *              "transfer_id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",
+ *              "base_path": "/home/user/Pictures",
+ *              "relative_path": "doggo.jpg",
+ *              "file_id": "Unu_l4PVyu15-RsdVL9IOQvaKQdqcqUy7F9EpvP-CrY",
+ *              "bytes": 29852,
+ *              "created_at": 1686651025988,
+ *              "states": [
+ *                  {
+ *                      "created_at": 1686651025991,
+ *                      "state": "pending"
+ *                  },
+ *                  {
+ *                      "created_at": 1686651025997,
+ *                      "state": "started",
+ *                      "bytes_sent": 0
+ *                  },
+ *                  {
+ *                      "created_at": 1686651026002,
+ *                      "state": "completed"
+ *                  }
+ *              ]
+ *          }
+ *      ]
+ *  }
+ *
+ * JSON example from the receiver side:
+ * {
+ *     "id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",
+ *     "peer_id": "172.17.0.1",
+ *     "created_at": 1686651025988,
+ *     "states": [
+ *         {
+ *             "created_at": 1686651026007,
+ *             "state": "cancel",
+ *             "by_peer": false
+ *         }
+ *     ],
+ *     "type": "outgoing",
+ *     "paths": [
+ *         {
+ *             "transfer_id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",
+ *             "relative_path": "doggo.jpg",
+ *             "file_id": "Unu_l4PVyu15-RsdVL9IOQvaKQdqcqUy7F9EpvP-CrY",
+ *             "bytes": 29852,
+ *             "created_at": 1686651025988,
+ *             "states": [
+ *                 {
+ *                     "created_at": 1686651025992,
+ *                     "state": "pending"
+ *                 },
+ *                 {
+ *                     "created_at": 1686651026000,
+ *                     "state": "started",
+ *                     "base_dir": "/root",
+ *                     "bytes_received": 0
+ *                 },
+ *                 {
+ *                     "created_at": 1686651026003,
+ *                     "state": "completed",
+ *                     "final_path": "/root/doggo.jpg"
+ *                 }
+ *             ]
+ *         }
+ *     ]
+ * }
  */
 char *norddrop_get_transfers_since(const struct norddrop *dev, long long since_timestamp);
 
 /**
- * Create a new instance of norddrop. This is a required step to work with API
- * further
+ * @brief Create a new instance of norddrop. This is a required step to work
+ * with API further.
+ *
+ * @param dev  Pointer to the pointer to the instance. The pointer will be
+ *             allocated by the function and should be freed by the caller
+ *             using norddrop_destroy()
+ * @param event_cb     Event callback
+ * @param log_level    Log level
+ * @param logger_cb    Logger callback
+ * @param pubkey_cb    Fetch peer public key callback. It is used to request
+ * the app to provide the peer’s public key or the node itself. The callback
+ * provides two parameters, `const char *ip` which is a string
+ * representation of the peer’s IP address, and `char *pubkey` which is
+ * preallocated buffer of size 32 into which the app should write the public
+ * key as bytes. The app returns the status of the callback call, 0 on
+ * success and a non-zero value to indicate that the key could not be
+ * provided. Note that it’s not BASE64, it must be decoded if it is beforehand.
+ * @param privkey     32bytes private key. Note that it’s not BASE64, it must
+ * be decoded if it is beforehand. @return NORDDROP_RES_OK on success, error
+ * code otherwise
  */
 enum norddrop_result norddrop_new(struct norddrop **dev,
                                   struct norddrop_event_cb event_cb,
@@ -209,6 +394,11 @@ void __norddrop_force_export(enum norddrop_result,
                              struct norddrop_logger_cb,
                              struct norddrop_pubkey_cb);
 
+/**
+ * @brief Get the version of the library
+ *
+ * @return const char*
+ */
 const char *norddrop_version(void);
 
 #ifdef __cplusplus

--- a/norddrop/ffi/bindings/norddrop_types.h
+++ b/norddrop/ffi/bindings/norddrop_types.h
@@ -68,6 +68,9 @@ typedef enum norddrop_result {
    * Invalid private key provided
    */
   NORDDROP_RES_INVALID_PRIVKEY = 10,
+  /**
+   * Database error
+   */
   NORDDROP_RES_DB_ERROR = 11,
 } norddrop_result;
 

--- a/norddrop/ffi/norddrop.i
+++ b/norddrop/ffi/norddrop.i
@@ -59,41 +59,26 @@ struct norddrop {};
         norddrop_destroy($self);
     }
 
-    // Start drop server. Listens for incoming connections. Allows files and responses to be received
     enum norddrop_result start(const char *listen_addr, const char* config_json);
 
-    // Stop drop server. Will not be reachable for peers
     enum norddrop_result stop();
         
-    // Cancel the whole the transfer request
     enum norddrop_result cancel_transfer(const char* txid);
 
-    // Cancel a single file in a request
     enum norddrop_result cancel_file(const char* txid, const char* fid);
 
-    // Download a file to a destination path
     enum norddrop_result download(const char* txid, const char* fid, const char* dst_path);
 
     %newobject new_transfer;
-    // Create a new transfer for the given descriptor(s). Returns transfer id(xfid)
     char* new_transfer(const char* peer, const char* descriptors);
 
-    // Purge transfers with the given id(s) from the database, accepts a JSON
-    // array of strings
     enum norddrop_result purge_transfers(const char *txids);
 
-    // Purge all transfers that are older than the given timestamp from the
-    // database. Accepts a UNIX timestamp in seconds with values between
-    // -210866760000 and 253402300799 inclusive
     enum norddrop_result purge_transfers_until(long long until_timestamp);
 
     %newobject get_transfers_since;
-    // Get all transfers since the given timestamp from the database.
-    // Accepts a UNIX timestamp in seconds with values between
-    // -210866760000 and 253402300799 inclusive
     char *get_transfers_since(long long since_timestamp);
 
-    // Returns current version of the library
     static char* version();
 };
 

--- a/norddrop/src/ffi/types.rs
+++ b/norddrop/src/ffi/types.rs
@@ -48,7 +48,7 @@ pub enum norddrop_result {
     /// Invalid private key provided
     NORDDROP_RES_INVALID_PRIVKEY = 10,
 
-    // Database error
+    /// Database error
     NORDDROP_RES_DB_ERROR = 11,
 }
 

--- a/norddrop/src/ffi/version.rs
+++ b/norddrop/src/ffi/version.rs
@@ -2,6 +2,9 @@ use libc::c_char;
 
 static VERSION: &[u8] = concat!(env!("DROP_VERSION"), "\0").as_bytes();
 
+/// @brief Get the version of the library
+///
+/// @return const char*
 #[no_mangle]
 pub extern "C" fn norddrop_version() -> *const c_char {
     VERSION.as_ptr() as *const _


### PR DESCRIPTION
Our documentation is generated straight from Rust code however we have leftovers in `norddrop.i`. This is cleaned up to reduce confusion in the future.

JSON descriptions, examples and all parameters
are commented on FFI calls allowing us to
just copy-paste the generated `norddrop.h`
straight into the documentation.