### PR TITLE
Introduce rejections

### DIFF
--- a/drop-core/src/status.rs
+++ b/drop-core/src/status.rs
@@ -24,6 +24,7 @@ pub enum Status {
     StorageError = 31,
     DbLost = 32,
     FileChecksumMismatch = 33,
+    FileRejected = 34,
 }
 
 impl serde::Serialize for Status {

--- a/drop-storage/.sqlx/query-5f6e2267e59463782fc63d1d41a65dcf3cb2a689135fd999d9759efb4c19d237.json
+++ b/drop-storage/.sqlx/query-5f6e2267e59463782fc63d1d41a65dcf3cb2a689135fd999d9759efb4c19d237.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO incoming_path_reject_states (path_id, by_peer)\n            SELECT id, ?3 FROM incoming_paths WHERE transfer_id = ?1 AND path_hash = ?2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "5f6e2267e59463782fc63d1d41a65dcf3cb2a689135fd999d9759efb4c19d237"
+}

--- a/drop-storage/.sqlx/query-62accb483316855478d1a970ab88fb192130e9f77db410a3439b57cbf7f322d1.json
+++ b/drop-storage/.sqlx/query-62accb483316855478d1a970ab88fb192130e9f77db410a3439b57cbf7f322d1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            INSERT INTO outgoing_path_reject_states (path_id, by_peer)\n            SELECT id, ?3 FROM outgoing_paths WHERE transfer_id = ?1 AND path_hash = ?2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "62accb483316855478d1a970ab88fb192130e9f77db410a3439b57cbf7f322d1"
+}

--- a/drop-storage/migrations/20230620101954_rejections.sql
+++ b/drop-storage/migrations/20230620101954_rejections.sql
@@ -1,0 +1,17 @@
+-- Add migration script here
+
+CREATE TABLE IF NOT EXISTS incoming_path_reject_states (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, 
+  path_id INTEGER NOT NULL,
+  by_peer INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  FOREIGN KEY(path_id) REFERENCES incoming_paths(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS outgoing_path_reject_states (
+  id INTEGER PRIMARY KEY AUTOINCREMENT, 
+  path_id INTEGER NOT NULL,
+  by_peer INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  FOREIGN KEY(path_id) REFERENCES outgoing_paths(id) ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/drop-storage/src/lib.rs
+++ b/drop-storage/src/lib.rs
@@ -445,6 +445,56 @@ impl Storage {
         Ok(())
     }
 
+    pub async fn insert_outgoing_path_reject_state(
+        &self,
+        transfer_id: Uuid,
+        path_id: &str,
+        by_peer: bool,
+    ) -> Result<()> {
+        let tid = transfer_id.hyphenated();
+
+        let mut conn = self.conn.acquire().await?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO outgoing_path_reject_states (path_id, by_peer)
+            SELECT id, ?3 FROM outgoing_paths WHERE transfer_id = ?1 AND path_hash = ?2
+            "#,
+            tid,
+            path_id,
+            by_peer,
+        )
+        .execute(&mut *conn)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn insert_incoming_path_reject_state(
+        &self,
+        transfer_id: Uuid,
+        path_id: &str,
+        by_peer: bool,
+    ) -> Result<()> {
+        let tid = transfer_id.hyphenated();
+
+        let mut conn = self.conn.acquire().await?;
+
+        sqlx::query!(
+            r#"
+            INSERT INTO incoming_path_reject_states (path_id, by_peer)
+            SELECT id, ?3 FROM incoming_paths WHERE transfer_id = ?1 AND path_hash = ?2
+            "#,
+            tid,
+            path_id,
+            by_peer,
+        )
+        .execute(&mut *conn)
+        .await?;
+
+        Ok(())
+    }
+
     pub async fn purge_transfers_until(&self, until_timestamp: i64) -> Result<()> {
         let mut conn = self.conn.acquire().await?;
 

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -174,12 +174,12 @@ pub enum Event {
         file_id: FileId,
         final_path: String,
     },
-    Progress {
+    FileProgress {
         transfer_id: TransferId,
         file_id: FileId,
         progress: i64,
     },
-    Reject {
+    FileReject {
         transfer_type: TransferType,
         transfer_id: TransferId,
         file_id: FileId,

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -180,6 +180,7 @@ pub enum Event {
         progress: i64,
     },
     Reject {
+        transfer_type: TransferType,
         transfer_id: TransferId,
         file_id: FileId,
         by_peer: bool,

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -179,6 +179,11 @@ pub enum Event {
         file_id: FileId,
         progress: i64,
     },
+    Reject {
+        transfer_id: TransferId,
+        file_id: FileId,
+        by_peer: bool,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -227,6 +227,12 @@ async fn listen(
                     xfers.remove(&xfer.id());
                 });
             }
+            Event::FileRejected(xfer, file, by_peer) => {
+                info!(
+                    "[EVENT] FileRejected {}: {file}, by_peer?: {by_peer}",
+                    xfer.id(),
+                );
+            }
         }
     }
 

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -227,11 +227,20 @@ async fn listen(
                     xfers.remove(&xfer.id());
                 });
             }
-            Event::FileRejected(xfer, file, by_peer) => {
-                info!(
-                    "[EVENT] FileRejected {}: {file}, by_peer?: {by_peer}",
-                    xfer.id(),
-                );
+            Event::FileDownloadRejected {
+                transfer_id,
+                file_id,
+                by_peer,
+            } => {
+                info!("[EVENT] FileDownloadRejected {transfer_id}: {file_id}, by_peer?: {by_peer}")
+            }
+
+            Event::FileUploadRejected {
+                transfer_id,
+                file_id,
+                by_peer,
+            } => {
+                info!("[EVENT] FileUploadRejected {transfer_id}: {file_id}, by_peer?: {by_peer}")
             }
         }
     }

--- a/drop-transfer/src/error.rs
+++ b/drop-transfer/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     StorageError,
     #[error("Checksum validation failed")]
     ChecksumMismatch,
+    #[error("File is rejected")]
+    Rejected,
 }
 
 impl Error {
@@ -99,6 +101,7 @@ impl From<&Error> for u32 {
             Error::AuthenticationFailed => Status::AuthenticationFailed as _,
             Error::StorageError => Status::StorageError as _,
             Error::ChecksumMismatch => Status::FileChecksumMismatch as _,
+            Error::Rejected => Status::FileRejected as _,
         }
     }
 }

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -28,6 +28,8 @@ pub enum Event {
     FileUploadFailed(Transfer, FileId, Error),
     FileDownloadFailed(Transfer, FileId, Error),
 
+    FileRejected(Transfer, FileId, bool),
+
     TransferCanceled(Transfer, bool, bool),
 
     TransferFailed(Transfer, Error, bool),

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use uuid::Uuid;
+
 use crate::{file::FileId, utils::Hidden, Error, Transfer};
 
 #[derive(Debug)]
@@ -28,7 +30,16 @@ pub enum Event {
     FileUploadFailed(Transfer, FileId, Error),
     FileDownloadFailed(Transfer, FileId, Error),
 
-    FileRejected(Transfer, FileId, bool),
+    FileUploadRejected {
+        transfer_id: Uuid,
+        file_id: FileId,
+        by_peer: bool,
+    },
+    FileDownloadRejected {
+        transfer_id: Uuid,
+        file_id: FileId,
+        by_peer: bool,
+    },
 
     TransferCanceled(Transfer, bool, bool),
 

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -71,11 +71,6 @@ impl TransferManager {
         }
     }
 
-    pub(crate) fn is_file_rejected(&self, id: Uuid, file: &FileId) -> crate::Result<bool> {
-        let xstate = self.transfers.get(&id).ok_or(crate::Error::BadTransfer)?;
-        Ok(xstate.rejected.contains(file))
-    }
-
     /// Returns `true` if file was sucesfully marked as rejected and `false` if
     /// it was already marked as such
     pub(crate) fn reject_file(&mut self, id: Uuid, file: FileId) -> crate::Result<bool> {

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -85,6 +85,27 @@ impl TransferManager {
         Ok(xstate.rejected.insert(file))
     }
 
+    pub(crate) fn ensure_file_not_rejected(
+        &self,
+        transfer_id: Uuid,
+        file: &FileId,
+    ) -> crate::Result<()> {
+        let xstate = self
+            .transfers
+            .get(&transfer_id)
+            .ok_or(crate::Error::BadTransfer)?;
+
+        if !xstate.xfer.files().contains_key(file) {
+            return Err(crate::Error::BadFileId);
+        }
+
+        if xstate.rejected.contains(file) {
+            Err(Error::Rejected)
+        } else {
+            Ok(())
+        }
+    }
+
     pub(crate) fn transfer(&self, id: &Uuid) -> Option<&Transfer> {
         self.transfers.get(id).map(|state| &state.xfer)
     }

--- a/drop-transfer/src/protocol/mod.rs
+++ b/drop-transfer/src/protocol/mod.rs
@@ -3,6 +3,7 @@ pub mod v2 {
     pub use super::v1::*;
 }
 pub mod v4;
+pub mod v5;
 
 #[derive(Copy, Clone, strum::Display, strum::EnumString)]
 pub enum Version {

--- a/drop-transfer/src/protocol/mod.rs
+++ b/drop-transfer/src/protocol/mod.rs
@@ -15,4 +15,6 @@ pub enum Version {
     // security flaw. It should never be added back.
     #[strum(serialize = "v4")]
     V4,
+    #[strum(serialize = "v5")]
+    V5,
 }

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -315,6 +315,33 @@ impl Service {
         Ok(())
     }
 
+    /// Reject a single file in a transfer. After rejection the file can no
+    /// logner be transfered
+    pub async fn reject(&self, transfer_id: Uuid, file: FileId) -> crate::Result<()> {
+        let mut lock = self.state.transfer_manager.lock().await;
+
+        if !lock.reject_file(transfer_id, file.clone())? {
+            return Err(crate::Error::Rejected);
+        }
+
+        let conn = lock
+            .connection(transfer_id)
+            .expect("The transfer is present since reject was sucessful");
+
+        match conn {
+            TransferConnection::Client(conn) => {
+                conn.send(ClientReq::Reject { file })
+                    .map_err(|err| Error::BadTransferState(err.to_string()))?;
+            }
+            TransferConnection::Server(conn) => {
+                conn.send(ServerReq::Reject { file })
+                    .map_err(|err| Error::BadTransferState(err.to_string()))?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Cancel all of the files in a transfer
     pub async fn cancel_all(&mut self, transfer_id: Uuid) -> crate::Result<()> {
         let mut lock = self.state.transfer_manager.lock().await;

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -208,6 +208,7 @@ impl Service {
 
         let fetch_xfer = async {
             let mut lock = self.state.transfer_manager.lock().await;
+            lock.ensure_file_not_rejected(uuid, file_id)?;
 
             let chann = lock.connection(uuid).ok_or(Error::BadTransfer)?;
             let chann = match chann {
@@ -298,6 +299,7 @@ impl Service {
     /// Cancel a single file in a transfer
     pub async fn cancel(&mut self, xfer_uuid: Uuid, file: FileId) -> crate::Result<()> {
         let lock = self.state.transfer_manager.lock().await;
+        lock.ensure_file_not_rejected(xfer_uuid, &file)?;
 
         let conn = lock.connection(xfer_uuid).ok_or(Error::BadTransfer)?;
 

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -149,7 +149,7 @@ impl<'a> StorageDispatch<'a> {
                 }
             }
 
-            Event::Progress {
+            Event::FileProgress {
                 transfer_id,
                 file_id,
                 progress,
@@ -160,7 +160,7 @@ impl<'a> StorageDispatch<'a> {
                     .or_default() = progress;
             }
 
-            Event::Reject {
+            Event::FileReject {
                 transfer_type,
                 transfer_id,
                 file_id,
@@ -266,12 +266,12 @@ impl From<&crate::Event> for Event {
                     error_code: error.into(),
                 }
             }
-            crate::Event::FileDownloadProgress(transfer, file, progress) => Event::Progress {
+            crate::Event::FileDownloadProgress(transfer, file, progress) => Event::FileProgress {
                 transfer_id: transfer.id(),
                 file_id: file.to_string(),
                 progress: *progress as i64,
             },
-            crate::Event::FileUploadProgress(transfer, file, progress) => Event::Progress {
+            crate::Event::FileUploadProgress(transfer, file, progress) => Event::FileProgress {
                 transfer_id: transfer.id(),
                 file_id: file.to_string(),
                 progress: *progress as i64,
@@ -280,7 +280,7 @@ impl From<&crate::Event> for Event {
                 transfer_id,
                 file_id,
                 by_peer,
-            } => Event::Reject {
+            } => Event::FileReject {
                 transfer_type: TransferType::Incoming,
                 transfer_id: *transfer_id,
                 file_id: file_id.to_string(),
@@ -290,7 +290,7 @@ impl From<&crate::Event> for Event {
                 transfer_id,
                 file_id,
                 by_peer,
-            } => Event::Reject {
+            } => Event::FileReject {
                 transfer_type: TransferType::Outgoing,
                 transfer_id: *transfer_id,
                 file_id: file_id.to_string(),

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -159,6 +159,14 @@ impl<'a> StorageDispatch<'a> {
                     .entry((transfer_id, file_id))
                     .or_default() = progress;
             }
+
+            Event::Reject {
+                transfer_id,
+                file_id,
+                by_peer,
+            } => {
+                todo!("msz: insert rejection into DB");
+            }
         }
 
         Ok(())
@@ -257,6 +265,11 @@ impl From<&crate::Event> for Event {
                 transfer_id: transfer.id(),
                 file_id: file.to_string(),
                 progress: *progress as i64,
+            },
+            crate::Event::FileRejected(transfer, file, by_peer) => Event::Reject {
+                transfer_id: transfer.id(),
+                file_id: file.to_string(),
+                by_peer: *by_peer,
             },
         }
     }

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -1,6 +1,7 @@
 mod handler;
 mod v2;
 mod v4;
+mod v5;
 
 use std::{
     io,
@@ -40,6 +41,7 @@ pub type WebSocket = WebSocketStream<TcpStream>;
 
 pub enum ClientReq {
     Cancel { file: FileId },
+    Reject { file: FileId },
 }
 
 struct RunContext<'a> {
@@ -81,6 +83,7 @@ pub(crate) async fn run(state: Arc<State>, xfer: crate::Transfer, logger: Logger
         }
         protocol::Version::V2 => ctx.run(v2::HandlerInit::<true>::new(&state, &logger)).await,
         protocol::Version::V4 => ctx.run(v4::HandlerInit::new(state, &logger)).await,
+        protocol::Version::V5 => ctx.run(v5::HandlerInit::new(state, &logger)).await,
     }
 }
 
@@ -97,6 +100,7 @@ async fn establish_ws_conn(
     .map_err(|err| io::Error::new(io::ErrorKind::TimedOut, err))?;
 
     let mut versions_to_try = [
+        protocol::Version::V5,
         protocol::Version::V4,
         protocol::Version::V2,
         protocol::Version::V1,

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -214,6 +214,14 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
 
     async fn on_download(&mut self, file_id: FileSubPath) {
         let start = async {
+            if let Some(file) = self.xfer.file_by_subpath(&file_id) {
+                self.state
+                    .transfer_manager
+                    .lock()
+                    .await
+                    .ensure_file_not_rejected(self.xfer.id(), file.id())?;
+            }
+
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
                     let task = o.into_mut();

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -241,6 +241,9 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
     async fn on_req(&mut self, socket: &mut WebSocket, req: ClientReq) -> anyhow::Result<()> {
         match req {
             ClientReq::Cancel { file } => self.issue_cancel(socket, file).await,
+            ClientReq::Reject { .. } => {
+                todo!("(msz): need to handle it in a backwards complatible manner")
+            }
         }
     }
 

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -7,12 +7,12 @@ use std::{
 
 use anyhow::Context;
 use futures::SinkExt;
-use slog::{debug, error, warn};
+use slog::{debug, error, info, warn};
 use tokio::{sync::mpsc::Sender, task::JoinHandle};
 use tokio_tungstenite::tungstenite::{self, Message};
 
 use super::{handler, ClientReq, WebSocket};
-use crate::{protocol::v4, service::State, ws, FileId};
+use crate::{protocol::v5 as prot, service::State, ws, FileId};
 
 pub struct HandlerInit<'a> {
     state: Arc<State>,
@@ -52,7 +52,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     type Loop = HandlerLoop<'a>;
 
     async fn start(&mut self, socket: &mut WebSocket, xfer: &crate::Transfer) -> crate::Result<()> {
-        let req = v4::TransferRequest::from(xfer);
+        let req = prot::TransferRequest::from(xfer);
         socket.send(Message::from(&req)).await?;
         Ok(())
     }
@@ -82,12 +82,27 @@ impl HandlerLoop<'_> {
         socket: &mut WebSocket,
         file_id: FileId,
     ) -> anyhow::Result<()> {
-        let msg = v4::ClientMsg::Cancel(v4::Cancel {
+        let msg = prot::ClientMsg::Cancel(prot::Cancel {
             file: file_id.clone(),
         });
         socket.send(Message::from(&msg)).await?;
 
         self.on_cancel(file_id, false).await;
+
+        Ok(())
+    }
+
+    async fn issue_reject(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let msg = prot::ClientMsg::Reject(prot::Reject {
+            file: file_id.clone(),
+        });
+        socket.send(Message::from(&msg)).await?;
+
+        self.on_reject(file_id, false).await;
 
         Ok(())
     }
@@ -120,6 +135,67 @@ impl HandlerLoop<'_> {
                     .await;
             }
         }
+    }
+
+    async fn on_reject(&mut self, file_id: FileId, by_peer: bool) {
+        if by_peer {
+            match self
+                .state
+                .transfer_manager
+                .lock()
+                .await
+                .reject_file(self.xfer.id(), file_id.clone())
+            {
+                Ok(true) => (),
+                res => {
+                    debug!(
+                        self.logger,
+                        "Failed to run rejection procedure on peers request: {res:?}"
+                    );
+                    return;
+                }
+            }
+        }
+
+        info!(self.logger, "Rejecting file {file_id}, by_peer?: {by_peer}");
+
+        if let Some(task) = self.tasks.remove(&file_id) {
+            if !task.job.is_finished() {
+                task.job.abort();
+
+                task.events
+                    .stop(crate::Event::FileUploadCancelled(
+                        self.xfer.clone(),
+                        file_id.clone(),
+                        by_peer,
+                    ))
+                    .await;
+            }
+        }
+
+        let file = self
+            .xfer
+            .files()
+            .get(&file_id)
+            .expect("The file is correct since manager was able to reject the file");
+
+        self.state.moose.service_quality_transfer_file(
+            Err(drop_core::Status::FileRejected as i32),
+            drop_analytics::Phase::End,
+            self.xfer.id().to_string(),
+            0,
+            file.info(),
+        );
+
+        self.state
+            .event_tx
+            .send(crate::Event::FileUploadRejected {
+                transfer_id: self.xfer.id(),
+                file_id,
+                by_peer,
+            })
+            .await
+            .expect("Event channel should be open");
     }
 
     async fn on_progress(&self, file_id: FileId, transfered: u64) {
@@ -160,7 +236,7 @@ impl HandlerLoop<'_> {
             let xfile = self.xfer.files().get(&file_id).context("File not found")?;
             let checksum = tokio::task::block_in_place(|| xfile.checksum(limit))?;
 
-            anyhow::Ok(v4::ReportChsum {
+            anyhow::Ok(prot::ReportChsum {
                 file: file_id.clone(),
                 limit,
                 checksum,
@@ -170,19 +246,19 @@ impl HandlerLoop<'_> {
         match f() {
             Ok(report) => {
                 socket
-                    .send(Message::from(&v4::ClientMsg::ReportChsum(report)))
+                    .send(Message::from(&prot::ClientMsg::ReportChsum(report)))
                     .await
                     .context("Failed to send checksum report")?;
             }
             Err(err) => {
                 error!(self.logger, "Failed to report checksum: {:?}", err);
 
-                let msg = v4::Error {
+                let msg = prot::Error {
                     file: Some(file_id),
                     msg: err.to_string(),
                 };
                 socket
-                    .send(Message::from(&v4::ClientMsg::Error(msg)))
+                    .send(Message::from(&prot::ClientMsg::Error(msg)))
                     .await
                     .context("Failed to report error")?;
             }
@@ -238,12 +314,12 @@ impl HandlerLoop<'_> {
         if let Err(err) = start.await {
             error!(self.logger, "Failed to start upload: {:?}", err);
 
-            let msg = v4::Error {
+            let msg = prot::Error {
                 file: Some(file_id),
                 msg: err.to_string(),
             };
             socket
-                .send(Message::from(&v4::ClientMsg::Error(msg)))
+                .send(Message::from(&prot::ClientMsg::Error(msg)))
                 .await
                 .context("Failed to report error")?;
         }
@@ -290,9 +366,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_req(&mut self, socket: &mut WebSocket, req: ClientReq) -> anyhow::Result<()> {
         match req {
             ClientReq::Cancel { file } => self.issue_cancel(socket, file).await,
-            ClientReq::Reject { .. } => {
-                todo!("(msz): need to handle it in a backwards complatible manner")
-            }
+            ClientReq::Reject { file } => self.issue_reject(socket, file).await,
         }
     }
 
@@ -341,26 +415,33 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             Message::Text(json) => {
                 debug!(self.logger, "Received:\n\t{json}");
 
-                let msg: v4::ServerMsg =
+                let msg: prot::ServerMsg =
                     serde_json::from_str(&json).context("Failed to deserialize server message")?;
 
                 match msg {
-                    v4::ServerMsg::Progress(v4::Progress {
+                    prot::ServerMsg::Progress(prot::Progress {
                         file,
                         bytes_transfered,
                     }) => self.on_progress(file, bytes_transfered).await,
-                    v4::ServerMsg::Done(v4::Done {
+                    prot::ServerMsg::Done(prot::Done {
                         file,
                         bytes_transfered: _,
                     }) => self.on_done(file).await,
-                    v4::ServerMsg::Error(v4::Error { file, msg }) => self.on_error(file, msg).await,
-                    v4::ServerMsg::ReqChsum(v4::ReqChsum { file, limit }) => {
+                    prot::ServerMsg::Error(prot::Error { file, msg }) => {
+                        self.on_error(file, msg).await
+                    }
+                    prot::ServerMsg::ReqChsum(prot::ReqChsum { file, limit }) => {
                         self.on_checksum(socket, file, limit).await?
                     }
-                    v4::ServerMsg::Start(v4::Start { file, offset }) => {
+                    prot::ServerMsg::Start(prot::Start { file, offset }) => {
                         self.on_start(socket, file, offset).await?
                     }
-                    v4::ServerMsg::Cancel(v4::Cancel { file }) => self.on_cancel(file, true).await,
+                    prot::ServerMsg::Cancel(prot::Cancel { file }) => {
+                        self.on_cancel(file, true).await
+                    }
+                    prot::ServerMsg::Reject(prot::Reject { file }) => {
+                        self.on_reject(file, true).await
+                    }
                 }
             }
             Message::Close(_) => {
@@ -431,7 +512,7 @@ impl Drop for HandlerLoop<'_> {
 #[async_trait::async_trait]
 impl handler::Uploader for Uploader {
     async fn chunk(&mut self, chunk: &[u8]) -> Result<(), crate::Error> {
-        let msg = v4::Chunk {
+        let msg = prot::Chunk {
             file: self.file_id.clone(),
             data: chunk.to_vec(),
         };
@@ -445,7 +526,7 @@ impl handler::Uploader for Uploader {
     }
 
     async fn error(&mut self, msg: String) {
-        let msg = v4::ClientMsg::Error(v4::Error {
+        let msg = prot::ClientMsg::Error(prot::Error {
             file: Some(self.file_id.clone()),
             msg,
         });

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -232,7 +232,15 @@ impl HandlerLoop<'_> {
         file_id: FileId,
         limit: u64,
     ) -> anyhow::Result<()> {
-        let f = || {
+        let f = async {
+            {
+                self.state
+                    .transfer_manager
+                    .lock()
+                    .await
+                    .ensure_file_not_rejected(self.xfer.id(), &file_id)?;
+            }
+
             let xfile = self.xfer.files().get(&file_id).context("File not found")?;
             let checksum = tokio::task::block_in_place(|| xfile.checksum(limit))?;
 
@@ -243,7 +251,7 @@ impl HandlerLoop<'_> {
             })
         };
 
-        match f() {
+        match f.await {
             Ok(report) => {
                 socket
                     .send(Message::from(&prot::ClientMsg::ReportChsum(report)))
@@ -274,6 +282,14 @@ impl HandlerLoop<'_> {
         offset: u64,
     ) -> anyhow::Result<()> {
         let start = async {
+            {
+                self.state
+                    .transfer_manager
+                    .lock()
+                    .await
+                    .ensure_file_not_rejected(self.xfer.id(), &file_id)?;
+            }
+
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
                     let task = o.into_mut();

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -274,6 +274,9 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         match req {
             ServerReq::Download { task } => self.issue_download(ws, *task)?,
             ServerReq::Cancel { file } => self.issue_cancel(ws, file).await?,
+            ServerReq::Reject { .. } => {
+                todo!("(msz): need to handle it in a backwards complatible manner")
+            }
         }
 
         Ok(())

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -94,7 +94,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     async fn on_error(&mut self, ws: &mut WebSocket, err: anyhow::Error) -> anyhow::Result<()> {
-        let msg = v4::ServerMsg::<FileId>::Error(v4::Error {
+        let msg = v4::ServerMsg::Error(v4::Error {
             file: None,
             msg: err.to_string(),
         });

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -242,6 +242,61 @@ impl HandlerLoop<'_> {
         Ok(())
     }
 
+    async fn issue_reject(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        debug!(self.logger, "ServerHandler::issue_cancel");
+
+        let msg = v4::ServerMsg::Cancel(v4::Cancel {
+            file: file_id.clone(),
+        });
+        socket.send(Message::from(&msg)).await?;
+
+        if let Some(FileTask {
+            job: task,
+            events,
+            chunks_tx: _,
+            csum_tx: _,
+        }) = self.jobs.remove(&file_id)
+        {
+            if !task.is_finished() {
+                task.abort();
+
+                events
+                    .stop(crate::Event::FileDownloadCancelled(
+                        self.xfer.clone(),
+                        file_id.clone(),
+                        false,
+                    ))
+                    .await;
+            }
+        }
+
+        if let Some(file) = self.xfer.files().get(&file_id) {
+            self.state.moose.service_quality_transfer_file(
+                Err(drop_core::Status::FileRejected as i32),
+                drop_analytics::Phase::End,
+                self.xfer.id().to_string(),
+                0,
+                file.info(),
+            );
+
+            self.state
+                .event_tx
+                .send(crate::Event::FileDownloadRejected {
+                    transfer_id: self.xfer.id(),
+                    file_id,
+                    by_peer: false,
+                })
+                .await
+                .expect("Event channel should be open");
+        }
+
+        Ok(())
+    }
+
     async fn on_chunk(
         &mut self,
         socket: &mut WebSocket,
@@ -375,9 +430,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         match req {
             ServerReq::Download { task } => self.issue_download(ws, *task)?,
             ServerReq::Cancel { file } => self.issue_cancel(ws, file).await?,
-            ServerReq::Reject { .. } => {
-                todo!("(msz): need to handle it in a backwards complatible manner")
-            }
+            ServerReq::Reject { file } => self.issue_reject(ws, file).await?,
         }
 
         Ok(())

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -21,7 +21,14 @@ use tokio::{
 use warp::ws::{Message, WebSocket};
 
 use super::{handler, ServerReq};
-use crate::{file, protocol::v4, service::State, utils::Hidden, ws::events::FileEventTx, FileId};
+use crate::{
+    file::{self, FileKind},
+    protocol::v5 as prot,
+    service::State,
+    utils::Hidden,
+    ws::events::FileEventTx,
+    FileId,
+};
 
 pub struct HandlerInit<'a> {
     peer: IpAddr,
@@ -43,7 +50,7 @@ struct Downloader {
     logger: slog::Logger,
     file_id: FileId,
     msg_tx: Sender<Message>,
-    csum_rx: mpsc::Receiver<v4::ReportChsum>,
+    csum_rx: mpsc::Receiver<prot::ReportChsum>,
     full_csum: Arc<AsyncCell<[u8; 32]>>,
     offset: u64,
 }
@@ -52,7 +59,7 @@ struct FileTask {
     job: JoinHandle<()>,
     chunks_tx: UnboundedSender<Vec<u8>>,
     events: Arc<FileEventTx>,
-    csum_tx: mpsc::Sender<v4::ReportChsum>,
+    csum_tx: mpsc::Sender<prot::ReportChsum>,
 }
 
 impl<'a> HandlerInit<'a> {
@@ -67,7 +74,7 @@ impl<'a> HandlerInit<'a> {
 
 #[async_trait::async_trait]
 impl<'a> handler::HandlerInit for HandlerInit<'a> {
-    type Request = (v4::TransferRequest, IpAddr, Arc<DropConfig>);
+    type Request = (prot::TransferRequest, IpAddr, Arc<DropConfig>);
     type Loop = HandlerLoop<'a>;
     type Pinger = tokio::time::Interval;
 
@@ -87,7 +94,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     async fn on_error(&mut self, ws: &mut WebSocket, err: anyhow::Error) -> anyhow::Result<()> {
-        let msg = v4::ServerMsg::Error(v4::Error {
+        let msg = prot::ServerMsg::Error(prot::Error {
             file: None,
             msg: err.to_string(),
         });
@@ -161,11 +168,11 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
 
             async move {
                 for xfile in to_fetch.into_iter().filter_map(|id| xfer.files().get(&id)) {
-                    let msg = v4::ReqChsum {
+                    let msg = prot::ReqChsum {
                         file: xfile.file_id.clone(),
                         limit: xfile.size(),
                     };
-                    let msg = v4::ServerMsg::ReqChsum(msg);
+                    let msg = prot::ServerMsg::ReqChsum(msg);
                     if let Err(err) = msg_tx.send((&msg).into()).await {
                         warn!(logger, "Failed to request checksum: {err}");
                     }
@@ -232,12 +239,27 @@ impl HandlerLoop<'_> {
     ) -> anyhow::Result<()> {
         debug!(self.logger, "ServerHandler::issue_cancel");
 
-        let msg = v4::ServerMsg::Cancel(v4::Cancel {
+        let msg = prot::ServerMsg::Cancel(prot::Cancel {
             file: file_id.clone(),
         });
         socket.send(Message::from(&msg)).await?;
 
         self.on_cancel(file_id, false).await;
+
+        Ok(())
+    }
+
+    async fn issue_reject(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let msg = prot::ServerMsg::Reject(prot::Reject {
+            file: file_id.clone(),
+        });
+        socket.send(Message::from(&msg)).await?;
+
+        self.on_reject(file_id, false).await;
 
         Ok(())
     }
@@ -250,13 +272,13 @@ impl HandlerLoop<'_> {
     ) -> anyhow::Result<()> {
         if let Some(task) = self.jobs.get(&file_id) {
             if let Err(err) = task.chunks_tx.send(chunk) {
-                let msg = v4::Error {
+                let msg = prot::Error {
                     msg: format!("Failed to consume chunk for file: {file_id:?}, msg: {err}",),
                     file: Some(file_id),
                 };
 
                 socket
-                    .send(Message::from(&v4::ServerMsg::Error(msg)))
+                    .send(Message::from(&prot::ServerMsg::Error(msg)))
                     .await?;
             }
         }
@@ -300,6 +322,73 @@ impl HandlerLoop<'_> {
         }
     }
 
+    async fn on_reject(&mut self, file_id: FileId, by_peer: bool) {
+        if by_peer {
+            match self
+                .state
+                .transfer_manager
+                .lock()
+                .await
+                .reject_file(self.xfer.id(), file_id.clone())
+            {
+                Ok(true) => (),
+                res => {
+                    debug!(
+                        self.logger,
+                        "Failed to run rejection procedure on peers request: {res:?}"
+                    );
+                    return;
+                }
+            }
+        }
+
+        info!(self.logger, "Rejecting file {file_id}, by_peer?: {by_peer}");
+
+        if let Some(FileTask {
+            job: task,
+            events,
+            chunks_tx: _,
+            csum_tx: _,
+        }) = self.jobs.remove(&file_id)
+        {
+            if !task.is_finished() {
+                task.abort();
+
+                events
+                    .stop(crate::Event::FileDownloadCancelled(
+                        self.xfer.clone(),
+                        file_id.clone(),
+                        by_peer,
+                    ))
+                    .await;
+            }
+        }
+
+        let file = self
+            .xfer
+            .files()
+            .get(&file_id)
+            .expect("File should exists since we have a transfer task running");
+
+        self.state.moose.service_quality_transfer_file(
+            Err(drop_core::Status::FileRejected as i32),
+            drop_analytics::Phase::End,
+            self.xfer.id().to_string(),
+            0,
+            file.info(),
+        );
+
+        self.state
+            .event_tx
+            .send(crate::Event::FileDownloadRejected {
+                transfer_id: self.xfer.id(),
+                file_id,
+                by_peer,
+            })
+            .await
+            .expect("Event channel should be open");
+    }
+
     async fn on_error(&mut self, file_id: Option<FileId>, msg: String) {
         error!(
             self.logger,
@@ -331,7 +420,7 @@ impl HandlerLoop<'_> {
         }
     }
 
-    async fn on_checksum(&mut self, report: v4::ReportChsum) {
+    async fn on_checksum(&mut self, report: prot::ReportChsum) {
         let xfile = match self.xfer.files().get(&report.file) {
             Some(file) => file,
             None => return,
@@ -375,9 +464,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         match req {
             ServerReq::Download { task } => self.issue_download(ws, *task)?,
             ServerReq::Cancel { file } => self.issue_cancel(ws, file).await?,
-            ServerReq::Reject { .. } => {
-                todo!("(msz): need to handle it in a backwards complatible manner")
-            }
+            ServerReq::Reject { file } => self.issue_reject(ws, file).await?,
         }
 
         Ok(())
@@ -427,17 +514,18 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         if let Ok(json) = msg.to_str() {
             debug!(self.logger, "Received:\n\t{json}");
 
-            let msg: v4::ClientMsg =
+            let msg: prot::ClientMsg =
                 serde_json::from_str(json).context("Failed to deserialize json")?;
 
             match msg {
-                v4::ClientMsg::Error(v4::Error { file, msg }) => self.on_error(file, msg).await,
-                v4::ClientMsg::Cancel(v4::Cancel { file }) => self.on_cancel(file, true).await,
-                v4::ClientMsg::ReportChsum(report) => self.on_checksum(report).await,
+                prot::ClientMsg::Error(prot::Error { file, msg }) => self.on_error(file, msg).await,
+                prot::ClientMsg::Cancel(prot::Cancel { file }) => self.on_cancel(file, true).await,
+                prot::ClientMsg::ReportChsum(report) => self.on_checksum(report).await,
+                prot::ClientMsg::Reject(prot::Reject { file }) => self.on_reject(file, true).await,
             }
         } else if msg.is_binary() {
-            let v4::Chunk { file, data } =
-                v4::Chunk::decode(msg.into_bytes()).context("Failed to decode file chunk")?;
+            let prot::Chunk { file, data } =
+                prot::Chunk::decode(msg.into_bytes()).context("Failed to decode file chunk")?;
 
             self.on_chunk(ws, file, data).await?;
         } else if msg.is_close() {
@@ -513,8 +601,8 @@ impl Downloader {
             .map_err(|_| crate::Error::Canceled)
     }
 
-    async fn request_csum(&mut self, limit: u64) -> crate::Result<v4::ReportChsum> {
-        let msg = v4::ServerMsg::ReqChsum(v4::ReqChsum {
+    async fn request_csum(&mut self, limit: u64) -> crate::Result<prot::ReportChsum> {
+        let msg = prot::ServerMsg::ReqChsum(prot::ReqChsum {
             file: self.file_id.clone(),
             limit,
         });
@@ -607,7 +695,7 @@ impl handler::Downloader for Downloader {
             }
         };
 
-        let msg = v4::ServerMsg::Start(v4::Start {
+        let msg = prot::ServerMsg::Start(prot::Start {
             file: self.file_id.clone(),
             offset: self.offset,
         });
@@ -630,7 +718,7 @@ impl handler::Downloader for Downloader {
     }
 
     async fn progress(&mut self, bytes: u64) -> crate::Result<()> {
-        self.send(&v4::ServerMsg::Progress(v4::Progress {
+        self.send(&prot::ServerMsg::Progress(prot::Progress {
             file: self.file_id.clone(),
             bytes_transfered: bytes,
         }))
@@ -638,7 +726,7 @@ impl handler::Downloader for Downloader {
     }
 
     async fn done(&mut self, bytes: u64) -> crate::Result<()> {
-        self.send(&v4::ServerMsg::Done(v4::Done {
+        self.send(&prot::ServerMsg::Done(prot::Done {
             file: self.file_id.clone(),
             bytes_transfered: bytes,
         }))
@@ -646,7 +734,7 @@ impl handler::Downloader for Downloader {
     }
 
     async fn error(&mut self, msg: String) -> crate::Result<()> {
-        self.send(&v4::ServerMsg::Error(v4::Error {
+        self.send(&prot::ServerMsg::Error(prot::Error {
             file: Some(self.file_id.clone()),
             msg,
         }))
@@ -696,5 +784,22 @@ impl FileTask {
             events,
             csum_tx,
         }
+    }
+}
+
+impl handler::Request for (prot::TransferRequest, IpAddr, Arc<DropConfig>) {
+    fn parse(self) -> anyhow::Result<crate::Transfer> {
+        let (prot::TransferRequest { files, id }, peer, config) = self;
+
+        let files = files
+            .into_iter()
+            .map(|f| crate::File {
+                file_id: f.id,
+                subpath: f.path,
+                kind: FileKind::FileToRecv { size: f.size },
+            })
+            .collect();
+
+        crate::Transfer::new_with_uuid(peer, files, id, &config).context("Failed to crate transfer")
     }
 }

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
@@ -56,6 +56,10 @@ public class NordDrop {
     return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_cancelFile(swigCPtr, this, txid, fid));
   }
 
+  public NorddropResult rejectFile(String txid, String fid) {
+    return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_rejectFile(swigCPtr, this, txid, fid));
+  }
+
   public NorddropResult download(String txid, String fid, String dstPath) {
     return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_download(swigCPtr, this, txid, fid, dstPath));
   }

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
@@ -33,6 +33,7 @@ public class libnorddropJNI {
   public final static native int NordDrop_stop(long jarg1, NordDrop jarg1_);
   public final static native int NordDrop_cancelTransfer(long jarg1, NordDrop jarg1_, String jarg2);
   public final static native int NordDrop_cancelFile(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);
+  public final static native int NordDrop_rejectFile(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);
   public final static native int NordDrop_download(long jarg1, NordDrop jarg1_, String jarg2, String jarg3, String jarg4);
   public final static native String NordDrop_newTransfer(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);
   public final static native int NordDrop_purgeTransfers(long jarg1, NordDrop jarg1_, String jarg2);

--- a/norddrop/ffi/bindings/android/wrap/java_wrap.c
+++ b/norddrop/ffi/bindings/android/wrap/java_wrap.c
@@ -794,6 +794,35 @@ SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1cance
 }
 
 
+SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1rejectFile(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jstring jarg3) {
+  jint jresult = 0 ;
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) 0 ;
+  enum norddrop_result result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(struct norddrop **)&jarg1; 
+  arg2 = 0;
+  if (jarg2) {
+    arg2 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg2, 0);
+    if (!arg2) return 0;
+  }
+  arg3 = 0;
+  if (jarg3) {
+    arg3 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg3, 0);
+    if (!arg3) return 0;
+  }
+  result = (enum norddrop_result)norddrop_reject_file(arg1,(char const *)arg2,(char const *)arg3);
+  jresult = (jint)result; 
+  if (arg2) (*jenv)->ReleaseStringUTFChars(jenv, jarg2, (const char *)arg2);
+  if (arg3) (*jenv)->ReleaseStringUTFChars(jenv, jarg3, (const char *)arg3);
+  return jresult;
+}
+
+
 SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1download(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jstring jarg3, jstring jarg4) {
   jint jresult = 0 ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;

--- a/norddrop/ffi/bindings/linux/go/norddropgo.go
+++ b/norddrop/ffi/bindings/linux/go/norddropgo.go
@@ -48,63 +48,66 @@ typedef _gostring_ swig_type_16;
 typedef _gostring_ swig_type_17;
 typedef _gostring_ swig_type_18;
 typedef _gostring_ swig_type_19;
-typedef long long swig_type_20;
+typedef _gostring_ swig_type_20;
 typedef _gostring_ swig_type_21;
 typedef long long swig_type_22;
 typedef _gostring_ swig_type_23;
-extern void _wrap_Swig_free_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_norddropgo_8962ac4695316737(swig_intgo arg1);
-extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737(void);
-extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737(void);
-extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern void _wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_1 arg2);
-extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_8962ac4695316737(void);
-extern void _wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_3 arg2);
-extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737(void);
-extern void _wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_5 arg2);
-extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737(void);
-extern void _wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(uintptr_t arg1);
+typedef long long swig_type_24;
+typedef _gostring_ swig_type_25;
+extern void _wrap_Swig_free_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_norddropgo_0827d1f6f06eb1ea(swig_intgo arg1);
+extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_0827d1f6f06eb1ea(void);
+extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_0827d1f6f06eb1ea(void);
+extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern void _wrap_NorddropEventCb_Cb_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_1 arg2);
+extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_0827d1f6f06eb1ea(void);
+extern void _wrap_delete_NorddropEventCb_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_3 arg2);
+extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea(void);
+extern void _wrap_delete_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_5 arg2);
+extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea(void);
+extern void _wrap_delete_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
 
 #include <string.h>
 
-extern uintptr_t _wrap_new_Norddrop_norddropgo_8962ac4695316737(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_7 arg5);
-extern void _wrap_delete_Norddrop_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_Start_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3);
-extern swig_intgo _wrap_Norddrop_Stop_norddropgo_8962ac4695316737(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_10 arg2);
-extern swig_intgo _wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_11 arg2, swig_type_12 arg3);
-extern swig_intgo _wrap_Norddrop_Download_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3, swig_type_15 arg4);
-extern swig_type_16 _wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_17 arg2, swig_type_18 arg3);
-extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_19 arg2);
-extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_20 arg2);
-extern swig_type_21 _wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(uintptr_t arg1, swig_type_22 arg2);
-extern swig_type_23 _wrap_Norddrop_Version_norddropgo_8962ac4695316737(void);
+extern uintptr_t _wrap_new_Norddrop_norddropgo_0827d1f6f06eb1ea(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_7 arg5);
+extern void _wrap_delete_Norddrop_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_Start_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_8 arg2, swig_type_9 arg3);
+extern swig_intgo _wrap_Norddrop_Stop_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_10 arg2);
+extern swig_intgo _wrap_Norddrop_CancelFile_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_11 arg2, swig_type_12 arg3);
+extern swig_intgo _wrap_Norddrop_RejectFile_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3);
+extern swig_intgo _wrap_Norddrop_Download_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
+extern swig_type_18 _wrap_Norddrop_NewTransfer_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_19 arg2, swig_type_20 arg3);
+extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_21 arg2);
+extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_22 arg2);
+extern swig_type_23 _wrap_Norddrop_GetTransfersSince_norddropgo_0827d1f6f06eb1ea(uintptr_t arg1, swig_type_24 arg2);
+extern swig_type_25 _wrap_Norddrop_Version_norddropgo_0827d1f6f06eb1ea(void);
 #undef intgo
 */
 import "C"
@@ -139,55 +142,55 @@ func swigCopyString(s string) string {
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_8962ac4695316737(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_0827d1f6f06eb1ea(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_norddrop_log_level int
 func _swig_getNORDDROPLOGCRITICAL() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPLOGCRITICAL Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGCRITICAL()
 func _swig_getNORDDROPLOGERROR() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPLOGERROR Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGERROR()
 func _swig_getNORDDROPLOGWARNING() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPLOGWARNING Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGWARNING()
 func _swig_getNORDDROPLOGINFO() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPLOGINFO Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGINFO()
 func _swig_getNORDDROPLOGDEBUG() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPLOGDEBUG Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGDEBUG()
 func _swig_getNORDDROPLOGTRACE() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
@@ -195,84 +198,84 @@ var NORDDROPLOGTRACE Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGTRACE()
 type Enum_SS_norddrop_result int
 func _swig_getNORDDROPRESOK() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESOK Enum_SS_norddrop_result = _swig_getNORDDROPRESOK()
 func _swig_getNORDDROPRESERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESERROR Enum_SS_norddrop_result = _swig_getNORDDROPRESERROR()
 func _swig_getNORDDROPRESINVALIDSTRING() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDSTRING Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDSTRING()
 func _swig_getNORDDROPRESBADINPUT() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESBADINPUT Enum_SS_norddrop_result = _swig_getNORDDROPRESBADINPUT()
 func _swig_getNORDDROPRESJSONPARSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESJSONPARSE Enum_SS_norddrop_result = _swig_getNORDDROPRESJSONPARSE()
 func _swig_getNORDDROPRESTRANSFERCREATE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESTRANSFERCREATE Enum_SS_norddrop_result = _swig_getNORDDROPRESTRANSFERCREATE()
 func _swig_getNORDDROPRESNOTSTARTED() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESNOTSTARTED Enum_SS_norddrop_result = _swig_getNORDDROPRESNOTSTARTED()
 func _swig_getNORDDROPRESADDRINUSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESADDRINUSE Enum_SS_norddrop_result = _swig_getNORDDROPRESADDRINUSE()
 func _swig_getNORDDROPRESINSTANCESTART() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTART Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTART()
 func _swig_getNORDDROPRESINSTANCESTOP() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTOP Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTOP()
 func _swig_getNORDDROPRESINVALIDPRIVKEY() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDPRIVKEY Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDPRIVKEY()
 func _swig_getNORDDROPRESDBERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_0827d1f6f06eb1ea())
 	return swig_r
 }
 
@@ -289,38 +292,38 @@ func (p SwigcptrNorddropEventCb) SwigIsNorddropEventCb() {
 func (arg1 SwigcptrNorddropEventCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropEventCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropEventCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
+	C._wrap_NorddropEventCb_Cb_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropEventCb() (_swig_ret NorddropEventCb) {
 	var swig_r NorddropEventCb
-	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_8962ac4695316737()))
+	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_0827d1f6f06eb1ea()))
 	return swig_r
 }
 
 func DeleteNorddropEventCb(arg1 NorddropEventCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropEventCb_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropEventCb interface {
@@ -344,38 +347,38 @@ func (p SwigcptrNorddropLoggerCb) SwigIsNorddropLoggerCb() {
 func (arg1 SwigcptrNorddropLoggerCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropLoggerCb() (_swig_ret NorddropLoggerCb) {
 	var swig_r NorddropLoggerCb
-	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737()))
+	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea()))
 	return swig_r
 }
 
 func DeleteNorddropLoggerCb(arg1 NorddropLoggerCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropLoggerCb interface {
@@ -399,38 +402,38 @@ func (p SwigcptrNorddropPubkeyCb) SwigIsNorddropPubkeyCb() {
 func (arg1 SwigcptrNorddropPubkeyCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropPubkeyCb() (_swig_ret NorddropPubkeyCb) {
 	var swig_r NorddropPubkeyCb
-	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737()))
+	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea()))
 	return swig_r
 }
 
 func DeleteNorddropPubkeyCb(arg1 NorddropPubkeyCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropPubkeyCb interface {
@@ -560,7 +563,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
         _swig_i_3 = cb
 }
 	_swig_i_4 := arg5
-	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_8962ac4695316737(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
+	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_0827d1f6f06eb1ea(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_7)(unsafe.Pointer(&_swig_i_4)))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg5
 	}
@@ -577,7 +580,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
 
 func DeleteNorddrop(arg1 Norddrop) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_Norddrop_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_Norddrop_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0))
 }
 
 func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result) {
@@ -585,7 +588,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_8)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -598,7 +601,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 func (arg1 SwigcptrNorddrop) Stop() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -606,7 +609,7 @@ func (arg1 SwigcptrNorddrop) CancelTransfer(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -618,7 +621,22 @@ func (arg1 SwigcptrNorddrop) CancelFile(arg2 string, arg3 string) (_swig_ret Enu
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelFile_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_2))))
+	if Swig_escape_always_false {
+		Swig_escape_val = arg2
+	}
+	if Swig_escape_always_false {
+		Swig_escape_val = arg3
+	}
+	return swig_r
+}
+
+func (arg1 SwigcptrNorddrop) RejectFile(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result) {
+	var swig_r Enum_SS_norddrop_result
+	_swig_i_0 := arg1
+	_swig_i_1 := arg2
+	_swig_i_2 := arg3
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RejectFile_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -634,7 +652,7 @@ func (arg1 SwigcptrNorddrop) Download(arg2 string, arg3 string, arg4 string) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -652,7 +670,7 @@ func (arg1 SwigcptrNorddrop) NewTransfer(arg2 string, arg3 string) (_swig_ret st
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_18)(unsafe.Pointer(&_swig_i_2)))
+	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_2)))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
@@ -669,7 +687,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfers(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -680,7 +698,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_20(_swig_i_1)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1)))
 	return swig_r
 }
 
@@ -688,7 +706,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1))
+	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_0827d1f6f06eb1ea(C.uintptr_t(_swig_i_0), C.swig_type_24(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -697,7 +715,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 
 func NorddropVersion() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Norddrop_Version_norddropgo_8962ac4695316737()
+	swig_r_p := C._wrap_Norddrop_Version_norddropgo_0827d1f6f06eb1ea()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -711,6 +729,7 @@ type Norddrop interface {
 	Stop() (_swig_ret Enum_SS_norddrop_result)
 	CancelTransfer(arg2 string) (_swig_ret Enum_SS_norddrop_result)
 	CancelFile(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result)
+	RejectFile(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result)
 	Download(arg2 string, arg3 string, arg4 string) (_swig_ret Enum_SS_norddrop_result)
 	NewTransfer(arg2 string, arg3 string) (_swig_ret string)
 	PurgeTransfers(arg2 string) (_swig_ret Enum_SS_norddrop_result)

--- a/norddrop/ffi/bindings/linux/wrap/go_wrap.c
+++ b/norddrop/ffi/bindings/linux/wrap/go_wrap.c
@@ -242,7 +242,7 @@ SWIGINTERN void delete_norddrop(struct norddrop *self){
 extern "C" {
 #endif
 
-void _wrap_Swig_free_norddropgo_8962ac4695316737(void *_swig_go_0) {
+void _wrap_Swig_free_norddropgo_0827d1f6f06eb1ea(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -252,7 +252,7 @@ void _wrap_Swig_free_norddropgo_8962ac4695316737(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_norddropgo_8962ac4695316737(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_norddropgo_0827d1f6f06eb1ea(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -265,7 +265,7 @@ void *_wrap_Swig_malloc_norddropgo_8962ac4695316737(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -277,7 +277,7 @@ intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGERROR_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -289,7 +289,7 @@ intgo _wrap_NORDDROPLOGERROR_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGWARNING_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -301,7 +301,7 @@ intgo _wrap_NORDDROPLOGWARNING_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGINFO_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -313,7 +313,7 @@ intgo _wrap_NORDDROPLOGINFO_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGDEBUG_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -325,7 +325,7 @@ intgo _wrap_NORDDROPLOGDEBUG_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPLOGTRACE_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -337,7 +337,7 @@ intgo _wrap_NORDDROPLOGTRACE_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESOK_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESOK_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -349,7 +349,7 @@ intgo _wrap_NORDDROPRESOK_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESERROR_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -361,7 +361,7 @@ intgo _wrap_NORDDROPRESERROR_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -373,7 +373,7 @@ intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESBADINPUT_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -385,7 +385,7 @@ intgo _wrap_NORDDROPRESBADINPUT_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -397,7 +397,7 @@ intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -409,7 +409,7 @@ intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -421,7 +421,7 @@ intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -433,7 +433,7 @@ intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -445,7 +445,7 @@ intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -457,7 +457,7 @@ intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -469,7 +469,7 @@ intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_8962ac4695316737() {
 }
 
 
-intgo _wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737() {
+intgo _wrap_NORDDROPRESDBERROR_norddropgo_0827d1f6f06eb1ea() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -481,7 +481,7 @@ intgo _wrap_NORDDROPRESDBERROR_norddropgo_8962ac4695316737() {
 }
 
 
-void _wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropEventCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -493,7 +493,7 @@ void _wrap_NorddropEventCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_e
 }
 
 
-void *_wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
+void *_wrap_NorddropEventCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -506,7 +506,7 @@ void *_wrap_NorddropEventCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_
 }
 
 
-void _wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropEventCb_Cb_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn arg2 = (norddrop_event_fn) 0 ;
   
@@ -518,7 +518,7 @@ void _wrap_NorddropEventCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_ev
 }
 
 
-void* _wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
+void* _wrap_NorddropEventCb_Cb_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn result;
   void* _swig_go_result;
@@ -531,7 +531,7 @@ void* _wrap_NorddropEventCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_e
 }
 
 
-struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_8962ac4695316737() {
+struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_0827d1f6f06eb1ea() {
   struct norddrop_event_cb *result = 0 ;
   struct norddrop_event_cb *_swig_go_result;
   
@@ -542,7 +542,7 @@ struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_8962ac4695316737(
 }
 
 
-void _wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(struct norddrop_event_cb *_swig_go_0) {
+void _wrap_delete_NorddropEventCb_norddropgo_0827d1f6f06eb1ea(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   
   arg1 = *(struct norddrop_event_cb **)&_swig_go_0; 
@@ -552,7 +552,7 @@ void _wrap_delete_NorddropEventCb_norddropgo_8962ac4695316737(struct norddrop_ev
 }
 
 
-void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -564,7 +564,7 @@ void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_
 }
 
 
-void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
+void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -577,7 +577,7 @@ void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop
 }
 
 
-void _wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropLoggerCb_Cb_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn arg2 = (norddrop_logger_fn) 0 ;
   
@@ -589,7 +589,7 @@ void _wrap_NorddropLoggerCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_l
 }
 
 
-void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
+void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn result;
   void* _swig_go_result;
@@ -602,7 +602,7 @@ void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_
 }
 
 
-struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_8962ac4695316737() {
+struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea() {
   struct norddrop_logger_cb *result = 0 ;
   struct norddrop_logger_cb *_swig_go_result;
   
@@ -613,7 +613,7 @@ struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_8962ac469531673
 }
 
 
-void _wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(struct norddrop_logger_cb *_swig_go_0) {
+void _wrap_delete_NorddropLoggerCb_norddropgo_0827d1f6f06eb1ea(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   
   arg1 = *(struct norddrop_logger_cb **)&_swig_go_0; 
@@ -623,7 +623,7 @@ void _wrap_delete_NorddropLoggerCb_norddropgo_8962ac4695316737(struct norddrop_l
 }
 
 
-void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -635,7 +635,7 @@ void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_8962ac4695316737(struct norddrop_
 }
 
 
-void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
+void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -648,7 +648,7 @@ void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_8962ac4695316737(struct norddrop
 }
 
 
-void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_0827d1f6f06eb1ea(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn arg2 = (norddrop_pubkey_fn) 0 ;
   
@@ -660,7 +660,7 @@ void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_8962ac4695316737(struct norddrop_p
 }
 
 
-void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
+void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_0827d1f6f06eb1ea(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn result;
   void* _swig_go_result;
@@ -673,7 +673,7 @@ void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_8962ac4695316737(struct norddrop_
 }
 
 
-struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_8962ac4695316737() {
+struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea() {
   struct norddrop_pubkey_cb *result = 0 ;
   struct norddrop_pubkey_cb *_swig_go_result;
   
@@ -684,7 +684,7 @@ struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_8962ac469531673
 }
 
 
-void _wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(struct norddrop_pubkey_cb *_swig_go_0) {
+void _wrap_delete_NorddropPubkeyCb_norddropgo_0827d1f6f06eb1ea(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   
   arg1 = *(struct norddrop_pubkey_cb **)&_swig_go_0; 
@@ -694,7 +694,7 @@ void _wrap_delete_NorddropPubkeyCb_norddropgo_8962ac4695316737(struct norddrop_p
 }
 
 
-struct norddrop *_wrap_new_Norddrop_norddropgo_8962ac4695316737(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
+struct norddrop *_wrap_new_Norddrop_norddropgo_0827d1f6f06eb1ea(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
   norddrop_event_cb arg1 ;
   enum norddrop_log_level arg2 ;
   norddrop_logger_cb arg3 ;
@@ -726,7 +726,7 @@ struct norddrop *_wrap_new_Norddrop_norddropgo_8962ac4695316737(norddrop_event_c
 }
 
 
-void _wrap_delete_Norddrop_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0) {
+void _wrap_delete_Norddrop_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   
   arg1 = *(struct norddrop **)&_swig_go_0; 
@@ -736,7 +736,7 @@ void _wrap_delete_Norddrop_norddropgo_8962ac4695316737(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Start_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_Start_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -763,7 +763,7 @@ intgo _wrap_Norddrop_Start_norddropgo_8962ac4695316737(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Stop_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0) {
+intgo _wrap_Norddrop_Stop_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   enum norddrop_result result;
   intgo _swig_go_result;
@@ -776,7 +776,7 @@ intgo _wrap_Norddrop_Stop_norddropgo_8962ac4695316737(struct norddrop *_swig_go_
 }
 
 
-intgo _wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_CancelTransfer_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -796,7 +796,7 @@ intgo _wrap_Norddrop_CancelTransfer_norddropgo_8962ac4695316737(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_CancelFile_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -823,7 +823,34 @@ intgo _wrap_Norddrop_CancelFile_norddropgo_8962ac4695316737(struct norddrop *_sw
 }
 
 
-intgo _wrap_Norddrop_Download_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Norddrop_RejectFile_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) 0 ;
+  enum norddrop_result result;
+  intgo _swig_go_result;
+  
+  arg1 = *(struct norddrop **)&_swig_go_0; 
+  
+  arg2 = (char *)malloc(_swig_go_1.n + 1);
+  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
+  arg2[_swig_go_1.n] = '\0';
+  
+  
+  arg3 = (char *)malloc(_swig_go_2.n + 1);
+  memcpy(arg3, _swig_go_2.p, _swig_go_2.n);
+  arg3[_swig_go_2.n] = '\0';
+  
+  
+  result = (enum norddrop_result)norddrop_reject_file(arg1,(char const *)arg2,(char const *)arg3);
+  _swig_go_result = (intgo)result; 
+  free(arg2); 
+  free(arg3); 
+  return _swig_go_result;
+}
+
+
+intgo _wrap_Norddrop_Download_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -857,7 +884,7 @@ intgo _wrap_Norddrop_Download_norddropgo_8962ac4695316737(struct norddrop *_swig
 }
 
 
-_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -885,7 +912,7 @@ _gostring_ _wrap_Norddrop_NewTransfer_norddropgo_8962ac4695316737(struct norddro
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfers_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -905,7 +932,7 @@ intgo _wrap_Norddrop_PurgeTransfers_norddropgo_8962ac4695316737(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, long long _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   enum norddrop_result result;
@@ -920,7 +947,7 @@ intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_8962ac4695316737(struct nord
 }
 
 
-_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(struct norddrop *_swig_go_0, long long _swig_go_1) {
+_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_0827d1f6f06eb1ea(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   char *result = 0 ;
@@ -936,7 +963,7 @@ _gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_8962ac4695316737(struct n
 }
 
 
-_gostring_ _wrap_Norddrop_Version_norddropgo_8962ac4695316737() {
+_gostring_ _wrap_Norddrop_Version_norddropgo_0827d1f6f06eb1ea() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -210,6 +210,18 @@ enum norddrop_result norddrop_cancel_file(const struct norddrop *dev,
                                           const char *fid);
 
 /**
+ * @brief  Reject a file from either side
+ *
+ * @param dev   Pointer to the instance
+ * @param xfid  Transfer ID
+ * @param fid   File ID
+ * @return enum norddrop_result   Result of the operation
+ */
+enum norddrop_result norddrop_reject_file(const struct norddrop *dev,
+                                          const char *xfid,
+                                          const char *fid);
+
+/**
  * @brief   Start libdrop
  *
  * @param dev   Pointer to the instance

--- a/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
+++ b/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
@@ -102,6 +102,11 @@ public class Norddrop : global::System.IDisposable {
     return ret;
   }
 
+  public NorddropResult RejectFile(string txid, string fid) {
+    NorddropResult ret = (NorddropResult)libnorddropPINVOKE.Norddrop_RejectFile(swigCPtr, txid, fid);
+    return ret;
+  }
+
   public NorddropResult Download(string txid, string fid, string dstPath) {
     NorddropResult ret = (NorddropResult)libnorddropPINVOKE.Norddrop_Download(swigCPtr, txid, fid, dstPath);
     return ret;
@@ -337,6 +342,9 @@ class libnorddropPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_CancelFile___")]
   public static extern int Norddrop_CancelFile(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+
+  [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_RejectFile___")]
+  public static extern int Norddrop_RejectFile(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
 
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_Download___")]
   public static extern int Norddrop_Download(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3, string jarg4);

--- a/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
+++ b/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
@@ -419,6 +419,22 @@ SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_CancelFile___(void *
 }
 
 
+SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_RejectFile___(void * jarg1, char * jarg2, char * jarg3) {
+  int jresult ;
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  char *arg3 = (char *) 0 ;
+  enum norddrop_result result;
+  
+  arg1 = (struct norddrop *)jarg1; 
+  arg2 = (char *)jarg2; 
+  arg3 = (char *)jarg3; 
+  result = (enum norddrop_result)norddrop_reject_file(arg1,(char const *)arg2,(char const *)arg3);
+  jresult = (int)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_Download___(void * jarg1, char * jarg2, char * jarg3, char * jarg4) {
   int jresult ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;

--- a/norddrop/ffi/norddrop.i
+++ b/norddrop/ffi/norddrop.i
@@ -67,6 +67,8 @@ struct norddrop {};
 
     enum norddrop_result cancel_file(const char* txid, const char* fid);
 
+    enum norddrop_result reject_file(const char* txid, const char* fid);
+
     enum norddrop_result download(const char* txid, const char* fid, const char* dst_path);
 
     %newobject new_transfer;

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -444,7 +444,7 @@ impl NordDropFFI {
         Ok(())
     }
 
-    pub(super) fn cancel_file(&mut self, xfid: uuid::Uuid, file: String) -> Result<()> {
+    pub(super) fn cancel_file(&mut self, xfid: uuid::Uuid, file: String) {
         let instance = self.instance.clone();
         let logger = self.logger.clone();
         let ed = self.event_dispatcher.clone();
@@ -476,6 +476,41 @@ impl NordDropFFI {
                         status: From::from(&e),
                     },
                 })
+            }
+        });
+    }
+
+    pub(super) fn reject_file(&self, xfid: uuid::Uuid, file: String) -> Result<()> {
+        trace!(
+            self.logger,
+            "norddrop_reject_file() for transfer {xfid}, file {file}",
+        );
+
+        let logger = self.logger.clone();
+        let evdisp = self.event_dispatcher.clone();
+
+        let inst = self.instance.clone().blocking_lock_owned();
+
+        if inst.is_none() {
+            return Err(ffi::types::NORDDROP_RES_NOT_STARTED);
+        }
+
+        self.rt.spawn(async move {
+            let inst = inst.as_ref().expect("Instance not initialized");
+
+            if let Err(err) = inst.reject(xfid, file.clone().into()).await {
+                error!(
+                    logger,
+                    "Failed to reject a file with xfid: {xfid}, file: {file}, error: {err:?}"
+                );
+
+                evdisp.dispatch(types::Event::TransferFinished {
+                    transfer: xfid.to_string(),
+                    data: FinishEvent::FileFailed {
+                        file,
+                        status: From::from(&err),
+                    },
+                });
             }
         });
 

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -221,10 +221,25 @@ impl From<drop_transfer::Event> for Event {
                     status: From::from(&status),
                 },
             },
-            drop_transfer::Event::FileRejected(tx, fid, by_peer) => Event::TransferFinished {
-                transfer: tx.id().to_string(),
+            drop_transfer::Event::FileDownloadRejected {
+                transfer_id,
+                file_id,
+                by_peer,
+            } => Event::TransferFinished {
+                transfer: transfer_id.to_string(),
                 data: FinishEvent::FileRejected {
-                    file: fid.to_string(),
+                    file: file_id.to_string(),
+                    by_peer,
+                },
+            },
+            drop_transfer::Event::FileUploadRejected {
+                transfer_id,
+                file_id,
+                by_peer,
+            } => Event::TransferFinished {
+                transfer: transfer_id.to_string(),
+                data: FinishEvent::FileRejected {
+                    file: file_id.to_string(),
                     by_peer,
                 },
             },

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -86,6 +86,10 @@ pub enum FinishEvent {
         #[serde(flatten)]
         status: Status,
     },
+    FileRejected {
+        file: String,
+        by_peer: bool,
+    },
 }
 
 #[derive(serde::Serialize)]
@@ -215,6 +219,13 @@ impl From<drop_transfer::Event> for Event {
                 transfer: tx.id().to_string(),
                 data: FinishEvent::TransferFailed {
                     status: From::from(&status),
+                },
+            },
+            drop_transfer::Event::FileRejected(tx, fid, by_peer) => Event::TransferFinished {
+                transfer: tx.id().to_string(),
+                data: FinishEvent::FileRejected {
+                    file: fid.to_string(),
+                    by_peer,
                 },
             },
         }

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -196,6 +196,20 @@ class CancelTransferFile(Action):
         return f"CancelTransferFile({print_uuid(self._uuid_slot)}, {self._fid})"
 
 
+class RejectTransferFile(Action):
+    def __init__(self, uuid_slot: int, fid):
+        self._uuid_slot = uuid_slot
+        self._fid = fid
+
+    async def run(self, drop: ffi.Drop):
+        UUIDS_LOCK.acquire()
+        drop.reject_transfer_file(UUIDS[self._uuid_slot], self._fid)
+        UUIDS_LOCK.release()
+
+    def __str__(self):
+        return f"RejectTransferFile({print_uuid(self._uuid_slot)}, {self._fid})"
+
+
 class CheckDownloadedFiles(Action):
     def __init__(self, files: typing.List[File]):
         self._files: typing.List[File] = files

--- a/test/drop_test/error.py
+++ b/test/drop_test/error.py
@@ -34,3 +34,5 @@ class Error(IntEnum):
     AUTHENTICATION_FAILED = (30,)
     STORAGE_ERROR = (31,)
     DB_LOST = (32,)
+    FILE_CHECKSUM_MISMATCH = (33,)
+    FILE_REJECTED = (34,)

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -230,6 +230,28 @@ class FinishFileCanceled(Event):
         return f"FinishFileCanceled(transfer={print_uuid(self._uuid_slot)}, file={self._file}, by_peer={self._by_peer})"
 
 
+class FinishFileRejected(Event):
+    def __init__(self, uuid_slot: int, file: str, by_peer: bool):
+        self._uuid_slot = uuid_slot
+        self._file = file
+        self._by_peer = by_peer
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, FinishFileRejected):
+            return False
+        if self._uuid_slot != rhs._uuid_slot:
+            return False
+        if self._file != rhs._file:
+            return False
+        if self._by_peer != rhs._by_peer:
+            return False
+
+        return True
+
+    def __str__(self):
+        return f"FinishFileRejected(transfer={print_uuid(self._uuid_slot)}, file={self._file}, by_peer={self._by_peer})"
+
+
 class FinishFileFailed(Event):
     def __init__(
         self,

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -335,6 +335,17 @@ class Drop:
             err_type = LibResult(err).name
             raise Exception(f"cancel_file has failed with code: {err}({err_type})")
 
+    def reject_transfer_file(self, uuid: str, fid: str):
+        err = self._lib.norddrop_reject_file(
+            self._instance,
+            ctypes.create_string_buffer(bytes(uuid, "utf-8")),
+            ctypes.create_string_buffer(bytes(fid, "utf-8")),
+        )
+
+        if err != 0:
+            err_type = LibResult(err).name
+            raise Exception(f"cancel_file has failed with code: {err}({err_type})")
+
     def get_transfers_since(self, since_timestamp: int) -> str:
         transfers = self._lib.norddrop_get_transfers_since(
             self._instance,
@@ -502,6 +513,10 @@ def new_event(event_str: str) -> event.Event:
         elif reason == "FileFailed":
             return event.FinishFileFailed(
                 transfer_slot, data["file"], data["status"], data.get("os_error_code")
+            )
+        elif reason == "FileRejected":
+            return event.FinishFileRejected(
+                transfer_slot, data["file"], data["by_peer"]
             )
         else:
             raise ValueError(f"Unexpected reason of {reason} for TransferFinished")

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4746,7 +4746,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-3"),
+                    action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-4"),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.RejectTransferFile(0, FILES["testfile-big"].id),
                     action.Wait(
@@ -4754,6 +4754,132 @@ scenarios = [
                     ),
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario27-5",
+        "Reject file on sender side, then try to download it. Expect event on both peers plus error event on the receiver side",
+        {
+            "ren": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.RejectTransferFile(0, FILES["testfile-small"].id),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, False)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, True)
+                    ),
+                    action.Download(
+                        0, FILES["testfile-small"].id, "/tmp/received/27-5"
+                    ),
+                    action.Wait(
+                        event.FinishFileFailed(
+                            0, FILES["testfile-small"].id, Error.FILE_REJECTED
+                        )
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario27-6",
+        "Reject file on receiver side, then try to download it. Expect event on both peers plus error event on the receiver side",
+        {
+            "ren": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, True)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.RejectTransferFile(0, FILES["testfile-small"].id),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, False)
+                    ),
+                    action.Download(
+                        0, FILES["testfile-small"].id, "/tmp/received/27-6"
+                    ),
+                    action.Wait(
+                        event.FinishFileFailed(
+                            0, FILES["testfile-small"].id, Error.FILE_REJECTED
+                        )
                     ),
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4529,4 +4529,238 @@ scenarios = [
         },
         dbpath="/tmp/db/26-corrupted.sqlite",
     ),
+    Scenario(
+        "scenario27-1",
+        "Reject file on sending side. Expect event on both peers",
+        {
+            "ren": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.RejectTransferFile(0, FILES["testfile-small"].id),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, False)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, True)
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario27-2",
+        "Reject file on receiving side. Expect event on both peers",
+        {
+            "ren": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, True)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.RejectTransferFile(0, FILES["testfile-small"].id),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-small"].id, False)
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario27-3",
+        "Reject currently transmited file on sender side. Expect event on both peers plus cancel event",
+        {
+            "ren": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.RejectTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-3"),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, True)
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, True)
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario27-4",
+        "Reject currently transmited file on receiver side. Expect event on both peers plus cancel event",
+        {
+            "ren": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, True)
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, True)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-3"),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.RejectTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]


### PR DESCRIPTION
Introducing V5 wire protocol with rejection support. On older protocols, there is a fallback to cancelation.
Currently what I did for older protocols is that cancel is issued and if peer requests download after that it will receive the error message.
It can be changed so that we can emit an error upon calling `reject()` if our peer does not support rejection, what do you think?

The old <-> new protocol is actually not tested because TBH there is not an easy way to issue rejection from udrop. It would require proper manual testing on actual integration or to somehow devise a test framework for testing wire compatibility which we don't have at this moment.

There is one thing still missing. The temporaries are not deleted after rejection and in general, after the transfer is failed or terminated before all files are downloaded. It's a wider problem and deserves a PR on its own IMHO