### PR TITLE
Fetch preexisting transfer directories on resume

### DIFF
--- a/drop-storage/.sqlx/query-b769b301331cb8c977f22acd9656206ece79c0bd4e7ad711ebb587ded9a9bca2.json
+++ b/drop-storage/.sqlx/query-b769b301331cb8c977f22acd9656206ece79c0bd4e7ad711ebb587ded9a9bca2.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT relative_path as subpath, final_path\n            FROM incoming_paths ip\n            INNER JOIN incoming_path_completed_states ipcs ON ip.id = ipcs.path_id\n            WHERE transfer_id = ?1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "subpath",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "final_path",
+        "ordinal": 1,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "b769b301331cb8c977f22acd9656206ece79c0bd4e7ad711ebb587ded9a9bca2"
+}

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -142,6 +142,11 @@ pub struct FileToRetry {
     pub size: u64,
 }
 
+pub struct FinishedIncomingFile {
+    pub subpath: String,
+    pub final_path: String,
+}
+
 pub struct TransferToRetry {
     pub uuid: uuid::Uuid,
     pub peer: String,


### PR DESCRIPTION
So we have this cache of our own created directories in the `TransferManager` but it's stored in RAM and is wiped out on transfer failures.
This PR implements restoring the cache from DB in case the transfer is resumed. It's an alternative to marker files