### PR TITLE
Implement global upload throttle

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ### **Broken Records**
 ---
 * Persist transfers across libdrop shutdowns. Automatically restart the transfer as soon as the connection can be established.
+* Add `max_uploads_in_flight` config option to limit the number of files being concurrently uploaded
 
 ---
 <br>

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -13,6 +13,7 @@ pub struct DropConfig {
     pub connection_max_retry_interval: Duration,
     pub transfer_idle_lifetime: Duration,
     pub storage_path: String,
+    pub max_uploads_in_flight: usize,
 }
 
 impl Default for DropConfig {
@@ -23,6 +24,7 @@ impl Default for DropConfig {
             connection_max_retry_interval: Duration::from_secs(10),
             transfer_idle_lifetime: Duration::from_secs(60),
             storage_path: "libdrop.sqlite".to_string(),
+            max_uploads_in_flight: 4,
         }
     }
 }

--- a/norddrop/src/ffi/version.rs
+++ b/norddrop/src/ffi/version.rs
@@ -5,7 +5,7 @@ static VERSION: &[u8] = concat!(env!("DROP_VERSION"), "\0").as_bytes();
 /// Get the version of the library
 ///
 /// # Returns
-/// 
+///
 /// Version string
 #[no_mangle]
 pub extern "C" fn norddrop_version() -> *const c_char {


### PR DESCRIPTION
This PR implements limiting the number of files currently being uploaded.
I have two questions:
* Should we also limit the downloads? It seems pretty unreasonable IMHO
* the limit should be imposed on a global, per-transfer, or per-peer basis?