### PR TITLE
Fxi tempfile collisions across different transfers

### DIFF
--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -586,16 +586,11 @@ impl handler::Downloader for Downloader {
             return Err(crate::Error::FilenameTooLong);
         }
 
-        let tmp_filename = if cfg!(target_os = "android") {
-            format!(
-                "{}-{}.dropdl-part",
-                task.xfer.id().as_simple(),
-                task.file.id()
-            )
-        } else {
-            format!("{}.dropdl-part", task.file.id())
-        };
-
+        let tmp_filename = format!(
+            "{}-{}.dropdl-part",
+            task.xfer.id().as_simple(),
+            task.file.id()
+        );
         let tmp_location: Hidden<PathBuf> = Hidden(task.base_dir.join(tmp_filename));
 
         // Check if we can resume the temporary file

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -623,16 +623,11 @@ impl handler::Downloader for Downloader {
             return Err(crate::Error::FilenameTooLong);
         }
 
-        let tmp_filename = if cfg!(target_os = "android") {
-            format!(
-                "{}-{}.dropdl-part",
-                task.xfer.id().as_simple(),
-                task.file.id()
-            )
-        } else {
-            format!("{}.dropdl-part", task.file.id())
-        };
-
+        let tmp_filename = format!(
+            "{}-{}.dropdl-part",
+            task.xfer.id().as_simple(),
+            task.file.id()
+        );
         let tmp_location: Hidden<PathBuf> = Hidden(task.base_dir.join(tmp_filename));
 
         // Check if we can resume the temporary file

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -273,6 +273,21 @@ class WaitRacy(Action):
         return f"WaitRacy({', '.join(str(e) for e in self._events)})"
 
 
+class DrainEvents(Action):
+    def __init__(self, count: int):
+        self._count = count
+
+    async def run(self, drop: ffi.Drop):
+        for i in range(0, self._count):
+            e = await drop._events.wait_for_any_event(100, ignore_progress=True)
+
+            if e is None:
+                raise Exception(f"Missing event number {i} while draining")
+
+    def __str__(self):
+        return f"DrainEvents({self._count})"
+
+
 class NoEvent(Action):
     def __init__(self, duration: int = 6):
         self._duration = duration

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -9,6 +9,7 @@ import subprocess
 import typing
 import json
 import time
+import glob
 
 from . import event, ffi
 from .logger import logger
@@ -360,11 +361,14 @@ class Stop(Action):
 
 
 class ModifyFile(Action):
-    def __init__(self, file: str):
-        self._file = file
+    def __init__(self, file_glob: str):
+        self._file = file_glob
 
     async def run(self, drop: ffi.Drop):
-        with open(self._file, "a") as f:
+        file_list = glob.glob(self._file)
+        file = file_list[0]
+
+        with open(file, "a") as f:
             f.write("42")
 
     def __str__(self):
@@ -393,13 +397,15 @@ class CompareTrees(Action):
 
 
 class WaitForResume(Action):
-    def __init__(self, uuid_slot: int, file_id: str, tmp_file_path: str):
+    def __init__(self, uuid_slot: int, file_id: str, tmp_file_path_glob: str):
         self._uuid_slot = uuid_slot
         self._file_id = file_id
-        self._tmp_file_path = tmp_file_path
+        self._tmp_file_path = tmp_file_path_glob
 
     async def run(self, drop: ffi.Drop):
-        stat = os.stat(self._tmp_file_path)
+        file_list = glob.glob(self._tmp_file_path)
+        stat = os.stat(file_list[0])  # just take the first find
+
         await drop._events.wait_for(event.Start(self._uuid_slot, self._file_id), False)
         await drop._events.wait_for(
             event.Progress(self._uuid_slot, self._file_id, stat.st_size), False
@@ -422,11 +428,13 @@ class DropPrivileges(Action):
 
 
 class DeleteFile(Action):
-    def __init__(self, file_path: str):
-        self._file_path = file_path
+    def __init__(self, file_path_glob: str):
+        self._file_path = file_path_glob
 
     async def run(self, drop: ffi.Drop):
-        os.remove(self._file_path)
+        file_list = glob.glob(self._file_path)
+        for file in file_list:
+            os.remove(file)
 
     def __str__(self):
         return f"DeleteFile({self._file_path})"

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -77,7 +77,9 @@ class EventQueue:
                 ]
 
             if len(self._events) > 0:
-                return self._events[0]
+                e = self._events[0]
+                self._events = self._events[1:]
+                return e
 
             await asyncio.sleep(1)
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3905,7 +3905,7 @@ scenarios = [
     ),
     Scenario(
         "scenario21-1",
-        "Cancel the file transfer in flight, expect second transfer to resume using the temporary file",
+        "Cancel the file transfer in flight, then download it again. Expect to resume using the temporary file",
         {
             "ren": ActionList(
                 [
@@ -3924,28 +3924,12 @@ scenarios = [
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
-                    action.Wait(event.FinishTransferCanceled(0, True)),
-                    action.WaitForAnotherPeer(),
-                    # new transfer
-                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
                     action.Wait(
-                        event.Queued(
-                            1,
-                            {
-                                event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
-                                ),
-                            },
-                        )
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, True)
                     ),
-                    action.Wait(event.Start(1, FILES["testfile-big"].id)),
-                    action.Wait(
-                        event.FinishFileUploaded(
-                            1,
-                            FILES["testfile-big"].id,
-                        )
-                    ),
-                    action.ExpectCancel([1], True),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(event.FinishFileUploaded(0, FILES["testfile-big"].id)),
+                    action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
                 ]
@@ -3974,33 +3958,23 @@ scenarios = [
                     action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
-                    action.CancelTransferRequest(0),
-                    action.Wait(event.FinishTransferCanceled(0, False)),
-                    # new transfer
+                    action.CancelTransferFile(0, FILES["testfile-big"].id),
                     action.Wait(
-                        event.Receive(
-                            1,
-                            "172.20.0.5",
-                            {
-                                event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
-                                ),
-                            },
-                        )
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, False)
                     ),
                     action.Download(
-                        1,
+                        0,
                         FILES["testfile-big"].id,
                         "/tmp/received/21-1",
                     ),
                     action.WaitForResume(
-                        1,
+                        0,
                         FILES["testfile-big"].id,
-                        f"/tmp/received/21-1/{FILES['testfile-big'].id}.dropdl-part",
+                        "/tmp/received/21-1/*.dropdl-part",
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
-                            1,
+                            0,
                             FILES["testfile-big"].id,
                             "/tmp/received/21-1/testfile-big",
                         )
@@ -4010,8 +3984,8 @@ scenarios = [
                             action.File("/tmp/received/21-1/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(1),
-                    action.ExpectCancel([1], False),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
                 ]
@@ -4040,19 +4014,6 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.FinishTransferCanceled(0, True)),
-                    action.WaitForAnotherPeer(),
-                    # new transfer
-                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
-                    action.Wait(
-                        event.Queued(
-                            1,
-                            {
-                                event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
-                                ),
-                            },
-                        )
-                    ),
                     action.Wait(event.Start(1, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -4089,25 +4050,14 @@ scenarios = [
                     action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
-                    action.CancelTransferRequest(0),
-                    action.Wait(event.FinishTransferCanceled(0, False)),
-                    # new transfer
-                    action.ModifyFile(
-                        f"/tmp/received/21-2/{FILES['testfile-big'].id}.dropdl-part"
-                    ),
+                    action.CancelTransferFile(0, FILES["testfile-big"].id),
                     action.Wait(
-                        event.Receive(
-                            1,
-                            "172.20.0.5",
-                            {
-                                event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
-                                ),
-                            },
-                        )
+                        event.FinishFileCanceled(0, FILES["testfile-big"].id, False)
                     ),
+                    # new transfer
+                    action.ModifyFile("/tmp/received/21-2/*.dropdl-part"),
                     action.Download(
-                        1,
+                        0,
                         FILES["testfile-big"].id,
                         "/tmp/received/21-2",
                     ),
@@ -4115,7 +4065,7 @@ scenarios = [
                     action.Wait(event.Progress(1, FILES["testfile-big"].id, 0)),
                     action.Wait(
                         event.FinishFileDownloaded(
-                            1,
+                            0,
                             FILES["testfile-big"].id,
                             "/tmp/received/21-2/testfile-big",
                         )
@@ -4125,8 +4075,8 @@ scenarios = [
                             action.File("/tmp/received/21-2/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(1),
-                    action.ExpectCancel([1], False),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
                 ]
@@ -4164,41 +4114,23 @@ scenarios = [
                         [
                             event.Start(0, FILES["nested/big/testfile-01"].id),
                             event.Start(0, FILES["nested/big/testfile-02"].id),
-                        ]
-                    ),
-                    action.Wait(event.FinishTransferCanceled(0, True)),
-                    # new transfer
-                    action.NewTransfer("172.20.0.15", ["/tmp/nested"]),
-                    action.Wait(
-                        event.Queued(
-                            1,
-                            {
-                                event.File(
-                                    FILES["nested/big/testfile-01"].id,
-                                    "nested/big/testfile-01",
-                                    10485760,
-                                ),
-                                event.File(
-                                    FILES["nested/big/testfile-02"].id,
-                                    "nested/big/testfile-02",
-                                    10485760,
-                                ),
-                            },
-                        )
-                    ),
-                    action.WaitRacy(
-                        [
-                            event.Start(1, FILES["nested/big/testfile-01"].id),
-                            event.Start(1, FILES["nested/big/testfile-02"].id),
+                            event.FinishFileCanceled(
+                                0, FILES["nested/big/testfile-01"].id, True
+                            ),
+                            event.FinishFileCanceled(
+                                0, FILES["nested/big/testfile-02"].id, True
+                            ),
+                            event.Start(0, FILES["nested/big/testfile-01"].id),
+                            event.Start(0, FILES["nested/big/testfile-02"].id),
                             event.FinishFileUploaded(
-                                1, FILES["nested/big/testfile-01"].id
+                                0, FILES["nested/big/testfile-01"].id
                             ),
                             event.FinishFileUploaded(
-                                1, FILES["nested/big/testfile-02"].id
+                                0, FILES["nested/big/testfile-02"].id
                             ),
                         ]
                     ),
-                    action.ExpectCancel([1], True),
+                    action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
                 ]
@@ -4247,57 +4179,48 @@ scenarios = [
                             event.Progress(0, FILES["nested/big/testfile-02"].id),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
-                    action.Wait(event.FinishTransferCanceled(0, False)),
-                    # new transfer
-                    action.Wait(
-                        event.Receive(
-                            1,
-                            "172.20.0.5",
-                            {
-                                event.File(
-                                    FILES["nested/big/testfile-01"].id,
-                                    "nested/big/testfile-01",
-                                    10485760,
-                                ),
-                                event.File(
-                                    FILES["nested/big/testfile-02"].id,
-                                    "nested/big/testfile-02",
-                                    10485760,
-                                ),
-                            },
-                        )
+                    action.CancelTransferFile(0, FILES["nested/big/testfile-01"].id),
+                    action.CancelTransferFile(0, FILES["nested/big/testfile-02"].id),
+                    action.WaitRacy(
+                        [
+                            event.FinishFileCanceled(
+                                0, FILES["nested/big/testfile-01"].id, False
+                            ),
+                            event.FinishFileCanceled(
+                                0, FILES["nested/big/testfile-02"].id, False
+                            ),
+                        ]
                     ),
                     action.Download(
-                        1,
+                        0,
                         FILES["nested/big/testfile-01"].id,
                         "/tmp/received/21-3",
                     ),
                     action.WaitForResume(
-                        1,
+                        0,
                         FILES["nested/big/testfile-01"].id,
-                        f"/tmp/received/21-3/{FILES['nested/big/testfile-01'].id}.dropdl-part",
+                        f"/tmp/received/21-3/*{FILES['nested/big/testfile-01'].id}.dropdl-part",
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
-                            1,
+                            0,
                             FILES["nested/big/testfile-01"].id,
                             "/tmp/received/21-3/nested/big/testfile-01",
                         )
                     ),
                     action.Download(
-                        1,
+                        0,
                         FILES["nested/big/testfile-02"].id,
                         "/tmp/received/21-3",
                     ),
                     action.WaitForResume(
-                        1,
+                        0,
                         FILES["nested/big/testfile-02"].id,
-                        f"/tmp/received/21-3/{FILES['nested/big/testfile-02'].id}.dropdl-part",
+                        f"/tmp/received/21-3/*{FILES['nested/big/testfile-02'].id}.dropdl-part",
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
-                            1,
+                            0,
                             FILES["nested/big/testfile-02"].id,
                             "/tmp/received/21-3/nested/big/testfile-02",
                         )
@@ -4740,9 +4663,7 @@ scenarios = [
                         "/tmp/received/25",
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
-                    action.DeleteFile(
-                        f"/tmp/received/25/{FILES['testfile-big'].id}.dropdl-part"
-                    ),
+                    action.DeleteFile("/tmp/received/25/*.dropdl-part"),
                     action.Wait(
                         event.FinishFileFailed(0, FILES["testfile-big"].id, Error.IO, 2)
                     ),
@@ -6060,118 +5981,7 @@ scenarios = [
         },
     ),
     Scenario(
-        "scenario31",
-        "Send the same file with two different transfer into the same directory. Expect no errors",
-        {
-            "ren": ActionList(
-                [
-                    action.Start("172.20.0.5"),
-                    action.WaitForAnotherPeer(),
-                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
-                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
-                    action.WaitRacy(
-                        [
-                            event.Queued(
-                                0,
-                                {
-                                    event.File(
-                                        FILES["testfile-small"].id,
-                                        "testfile-small",
-                                        1048576,
-                                    ),
-                                },
-                            ),
-                            event.Queued(
-                                1,
-                                {
-                                    event.File(
-                                        FILES["testfile-small"].id,
-                                        "testfile-small",
-                                        1048576,
-                                    ),
-                                },
-                            ),
-                            event.Start(
-                                0,
-                                FILES["testfile-small"].id,
-                            ),
-                            event.Start(
-                                1,
-                                FILES["testfile-small"].id,
-                            ),
-                            event.FinishFileUploaded(
-                                0,
-                                FILES["testfile-small"].id,
-                            ),
-                            event.FinishFileUploaded(
-                                1,
-                                FILES["testfile-small"].id,
-                            ),
-                        ],
-                    ),
-                    action.ExpectCancel([0, 1], True),
-                    action.NoEvent(),
-                    action.Stop(),
-                ]
-            ),
-            "stimpy": ActionList(
-                [
-                    action.Start("172.20.0.15"),
-                    action.WaitRacy(
-                        [
-                            event.Receive(
-                                0,
-                                "172.20.0.5",
-                                {
-                                    event.File(
-                                        FILES["testfile-small"].id,
-                                        "testfile-small",
-                                        1048576,
-                                    ),
-                                },
-                            ),
-                            event.Receive(
-                                1,
-                                "172.20.0.5",
-                                {
-                                    event.File(
-                                        FILES["testfile-small"].id,
-                                        "testfile-small",
-                                        1048576,
-                                    ),
-                                },
-                            ),
-                        ]
-                    ),
-                    action.Download(
-                        0,
-                        FILES["testfile-small"].id,
-                        "/tmp/received/31/",
-                    ),
-                    action.Download(
-                        1,
-                        FILES["testfile-small"].id,
-                        "/tmp/received/31/",
-                    ),
-                    # We cannot predict the final path of files from each transfer so we cannot wait for specific event
-                    action.DrainEvents(4),
-                    action.CheckDownloadedFiles(
-                        [
-                            action.File("/tmp/received/31/testfile-small", 1048576),
-                            action.File("/tmp/received/31/testfile-small(1)", 1048576),
-                        ],
-                    ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
-                    action.ExpectCancel([0, 1], False),
-                    action.NoEvent(),
-                    action.Stop(),
-                ]
-            ),
-        },
-    ),
-    Scenario(
-        "scenario32-1",
+        "scenario31-1",
         "Remove file on sending side. Expect file not being present in the sender JSON output",
         {
             "ren": ActionList(
@@ -6297,7 +6107,7 @@ scenarios = [
         },
     ),
     Scenario(
-        "scenario32-2",
+        "scenario31-2",
         "Remove file on receiver side. Expect file not being present in the receiver JSON output",
         {
             "ren": ActionList(
@@ -6416,6 +6226,117 @@ scenarios = [
                     ),
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario32",
+        "Send the same file with two different transfer into the same directory. Expect no errors",
+        {
+            "ren": ActionList(
+                [
+                    action.Start("172.20.0.5"),
+                    action.WaitForAnotherPeer(),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
+                    action.WaitRacy(
+                        [
+                            event.Queued(
+                                0,
+                                {
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                            event.Queued(
+                                1,
+                                {
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                            event.Start(
+                                0,
+                                FILES["testfile-small"].id,
+                            ),
+                            event.Start(
+                                1,
+                                FILES["testfile-small"].id,
+                            ),
+                            event.FinishFileUploaded(
+                                0,
+                                FILES["testfile-small"].id,
+                            ),
+                            event.FinishFileUploaded(
+                                1,
+                                FILES["testfile-small"].id,
+                            ),
+                        ],
+                    ),
+                    action.ExpectCancel([0, 1], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Start("172.20.0.15"),
+                    action.WaitRacy(
+                        [
+                            event.Receive(
+                                0,
+                                "172.20.0.5",
+                                {
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                            event.Receive(
+                                1,
+                                "172.20.0.5",
+                                {
+                                    event.File(
+                                        FILES["testfile-small"].id,
+                                        "testfile-small",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                        ]
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-small"].id,
+                        "/tmp/received/31/",
+                    ),
+                    action.Download(
+                        1,
+                        FILES["testfile-small"].id,
+                        "/tmp/received/31/",
+                    ),
+                    # We cannot predict the final path of files from each transfer so we cannot wait for specific event
+                    action.DrainEvents(4),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File("/tmp/received/31/testfile-small", 1048576),
+                            action.File("/tmp/received/31/testfile-small(1)", 1048576),
+                        ],
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest(1),
+                    action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
                 ]


### PR DESCRIPTION
This PR changes the way the names of temp files are created. It uses the Android approach where the transfer UUID is attached to the name.
This basically disables the resumes across different transfers but that's OK, since those are deprecated anyway in favor of auto retries.
I've also had to modify the resume test cases to happen inside a single transfer - which turned out to be buggy (cases 21-1, 21-2, 21-3)