### PR TITLE
Draft: optimize tests

### DIFF
--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -231,7 +231,7 @@ class WaitForAnotherPeer(Action):
         pass
 
     async def run(self, drop: ffi.Drop):
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.2)
 
     def __str__(self):
         return f"WaitForAnotherPeer"
@@ -290,7 +290,7 @@ class DrainEvents(Action):
 
 
 class NoEvent(Action):
-    def __init__(self, duration: int = 6):
+    def __init__(self, duration: int = 1):
         self._duration = duration
 
     async def run(self, drop: ffi.Drop):


### PR DESCRIPTION
An experimental branch to see if reduced delays still make tests pass. We currently wait 2 seconds in each testcase for peer to come online and also 6 seconds for NoEvents. We have 60 tests, this means we're spending `60*6 + 60*2 = 480s(8 minutes)` just there.