### PR TITLE
Verify moose events/in-memory database in integration tests

### DIFF
--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -106,7 +106,7 @@ impl File for FileToRecv {
     }
 
     fn mime_type(&self) -> &str {
-        ""
+        UNKNOWN_STR
     }
 }
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -231,9 +231,9 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": "*",
                             "info": {
-                                "mime_type": "",
-                                "extension": "",
-                                "size_kb": 0
+                                "mime_type": "unknown",
+                                "extension": "unknown",
+                                "size_kb": 10240
                             }
                         }""",
                             """{
@@ -243,9 +243,9 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": "*",
                             "info": {
-                                "mime_type": "",
-                                "extension": "",
-                                "size_kb": 0
+                                "mime_type": "unknown",
+                                "extension": "unknown",
+                                "size_kb": 10240
                             }
                         }""",
                             """{
@@ -255,9 +255,9 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": "*",
                             "info": {
-                                "mime_type": "",
-                                "extension": "",
-                                "size_kb": 0
+                                "mime_type": "unknown",
+                                "extension": "unknown",
+                                "size_kb": 10240
                             }
                         }""",
                             """{
@@ -3605,9 +3605,9 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": "*",
                             "info": {
-                                "mime_type": "",
-                                "extension": "",
-                                "size_kb": 0
+                                "mime_type": "unknown",
+                                "extension": "unknown",
+                                "size_kb": 10240
                             }
                         }""",
                             """{
@@ -3617,9 +3617,9 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": "*",
                             "info": {
-                                "mime_type": "",
-                                "extension": "",
-                                "size_kb": 0
+                                "mime_type": "unknown",
+                                "extension": "unknown",
+                                "size_kb": 10240
                             }
                         }""",
                             """{


### PR DESCRIPTION
Beefed up the test for insufficient permissions to also check the actual database as well

Also fixed the inconsistency with incoming file `mime_type` and fixed tests after merging main into dev