### PR TITLE
tests: fix segfault

### DIFF
--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -496,6 +496,12 @@ class Drop:
 
         return ctypes.string_at(version).decode("utf-8")
 
+    def __del__(self):
+        err = self._lib.norddrop_destroy(self._instance)
+        if err != 0:
+            err_type = LibResult(err).name
+            raise Exception(f"norddrop_destory has failed with code: {err}({err_type})")
+
 
 class IncomingRequestEntry:
     def __init__(self, id, path):

--- a/test/run.py
+++ b/test/run.py
@@ -101,15 +101,19 @@ async def main():
     drop = ffi.Drop(lib, ffi.KeysCtx(runner))
     logger.info(f"NordDrop version: {drop.version}")
 
+    exit_code = 0
     try:
         await script.run(runner, drop)
         logger.info("Action completed properly")
         cleanup_files(config.FILES)
-        sys.exit(0)
     except Exception as e:
         logger.critical(f"Action didn't complete as expected: {e}")
         cleanup_files(config.FILES)
-        sys.exit(1)
+        exit_code = 1
+
+    del drop
+
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Looking at the stack traces of core dumps it seems that the crashes are happening because some tokio tasks are still running at the ferry end of test execution and they try to call into Python code which is probably non-existent anymore.
The way to ensure the tasks are closed is to drop the tokio runtime but it only happens in the `norddrop_destory()` call, which btw should be called by the integration at the end of the operation.
So I just run the `norddrop_destory()` at the end of the test execution and it seems to work.

A similar error was happening before we introduced the `Stop()` action in the tests. Then it was the server task crashing the runner which is stopped in the `norddrop_stop()` call. Now it's the client tasks, which are signaled to finish in the `norddrop_stop()` call but are not awaited for.