### PR TITLE
Introduce a channel for signaling that the client tasks are finished.…

### DIFF
--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -763,12 +763,18 @@ impl IncomingState {
         storage: &Storage,
         file_id: &FileId,
         parent_dir: &Path,
+        logger: &Logger,
     ) -> crate::Result<()> {
-        storage.start_incoming_file(
-            self.xfer.id(),
-            file_id.as_ref(),
-            &parent_dir.to_string_lossy(),
-        )?;
+        if storage
+            .start_incoming_file(
+                self.xfer.id(),
+                file_id.as_ref(),
+                &parent_dir.to_string_lossy(),
+            )?
+            .is_none()
+        {
+            warn!(logger, "Failed to store started file state into the DB");
+        }
 
         self.file_sync
             .get_mut(file_id)

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -9,7 +9,10 @@ use anyhow::Context;
 use drop_config::DropConfig;
 use drop_storage::{sync, Storage};
 use slog::{error, info, warn, Logger};
-use tokio::sync::{mpsc::UnboundedSender, Mutex};
+use tokio::sync::{
+    mpsc::{self, UnboundedSender},
+    Mutex,
+};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -918,7 +921,12 @@ impl DirMapping {
     }
 }
 
-pub(crate) async fn resume(state: &Arc<State>, stop: CancellationToken, logger: &Logger) {
+pub(crate) async fn resume(
+    state: &Arc<State>,
+    stop: CancellationToken,
+    alive_sender: &mpsc::Sender<()>,
+    logger: &Logger,
+) {
     let incoming = {
         let state = state.clone();
         let logger = logger.clone();
@@ -930,7 +938,8 @@ pub(crate) async fn resume(state: &Arc<State>, stop: CancellationToken, logger: 
     let outgoing = {
         let state = state.clone();
         let logger = logger.clone();
-        tokio::task::spawn_blocking(move || restore_outgoing(&state, &stop, &logger))
+        let alive_sender = alive_sender.clone();
+        tokio::task::spawn_blocking(move || restore_outgoing(&state, &stop, &alive_sender, &logger))
     };
 
     match incoming.await {
@@ -1056,6 +1065,7 @@ fn restore_incoming(
 fn restore_outgoing(
     state: &Arc<State>,
     stop: &CancellationToken,
+    alive_sender: &mpsc::Sender<()>,
     logger: &Logger,
 ) -> HashMap<Uuid, OutgoingState> {
     let transfers = match state.storage.outgoing_transfers_to_resume() {
@@ -1162,7 +1172,7 @@ fn restore_outgoing(
             let state = state.clone();
             let xfer = xstate.xfer.clone();
 
-            ws::client::run(state, xfer, logger)
+            ws::client::run(state, xfer, alive_sender.clone(), logger)
         };
 
         tokio::spawn(async move {

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -265,7 +265,7 @@ impl Service {
 
             let mut task = || {
                 validate_dest_path(parent_dir)?;
-                state.start_download(&self.state.storage, file_id, parent_dir)?;
+                state.start_download(&self.state.storage, file_id, parent_dir, &self.logger)?;
                 Ok(())
             };
 

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -48,7 +48,12 @@ struct RunContext<'a> {
     xfer: &'a Arc<OutgoingTransfer>,
 }
 
-pub(crate) async fn run(state: Arc<State>, xfer: Arc<OutgoingTransfer>, logger: Logger) {
+pub(crate) async fn run(
+    state: Arc<State>,
+    xfer: Arc<OutgoingTransfer>,
+    _alive_guard: mpsc::Sender<()>,
+    logger: Logger,
+) {
     loop {
         let cf = connect_to_peer(&state, &xfer, &logger).await;
         if cf.is_break() {


### PR DESCRIPTION
… Await for it in the stop() method

So I guess it fixes the panic/crash at the end of tests. But still, the libdrop can hang for some reason.