### PR TITLE
Identify and fix causes of a very long time it takes to finish stop() call

### DIFF
--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -7,7 +7,7 @@ use std::{
     fs::{
         OpenOptions, {self},
     },
-    io::{self, Read},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -272,17 +272,32 @@ impl FileToSend {
     }
 
     /// Calculate sha2 of a file. This is a blocking operation
-    pub(crate) fn checksum(&self, limit: u64) -> crate::Result<[u8; 32]> {
+    pub(crate) async fn checksum(&self, limit: u64) -> crate::Result<[u8; 32]> {
         let reader = reader::open(&self.source)?;
         let mut reader = io::BufReader::new(reader).take(limit);
-        let csum = checksum(&mut reader)?;
+        let csum = checksum(&mut reader).await?;
         Ok(csum)
     }
 }
 
-pub fn checksum(reader: &mut impl io::Read) -> io::Result<[u8; 32]> {
+pub async fn checksum(reader: &mut impl io::Read) -> io::Result<[u8; 32]> {
     let mut csum = sha2::Sha256::new();
-    io::copy(reader, &mut csum)?;
+
+    let mut buf = vec![0u8; 8 * 1024]; // 8kB buffer
+
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+
+        csum.write_all(&buf[..n])?;
+
+        // Since these are all blocking operation we need to give tokio runtime a
+        // timeslice
+        tokio::task::yield_now().await;
+    }
+
     Ok(csum.finalize().into())
 }
 
@@ -297,14 +312,14 @@ mod tests {
     const TEST: &[u8] = b"abc";
     const EXPECTED: &[u8] = b"\xba\x78\x16\xbf\x8f\x01\xcf\xea\x41\x41\x40\xde\x5d\xae\x22\x23\xb0\x03\x61\xa3\x96\x17\x7a\x9c\xb4\x10\xff\x61\xf2\x00\x15\xad";
 
-    #[test]
-    fn checksum() {
-        let csum = super::checksum(&mut &TEST[..]).unwrap();
+    #[tokio::test]
+    async fn checksum() {
+        let csum = super::checksum(&mut &TEST[..]).await.unwrap();
         assert_eq!(csum.as_slice(), EXPECTED);
     }
 
-    #[test]
-    fn file_checksum() {
+    #[tokio::test]
+    async fn file_checksum() {
         use std::io::Write;
 
         use drop_config::DropConfig;
@@ -319,7 +334,7 @@ mod tests {
 
             assert_eq!(size, TEST.len() as u64);
 
-            file.checksum(size).unwrap()
+            file.checksum(size).await.unwrap()
         };
 
         assert_eq!(csum.as_slice(), EXPECTED);

--- a/drop-transfer/src/lib.rs
+++ b/drop-transfer/src/lib.rs
@@ -7,6 +7,7 @@ mod protocol;
 mod quarantine;
 pub mod service;
 mod storage_dispatch;
+mod tasks;
 pub mod transfer;
 pub mod utils;
 mod ws;

--- a/drop-transfer/src/tasks.rs
+++ b/drop-transfer/src/tasks.rs
@@ -1,0 +1,27 @@
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+pub struct AliveGuard(mpsc::Sender<()>);
+
+pub struct AliveWaiter(AliveGuard, mpsc::Receiver<()>);
+
+impl AliveWaiter {
+    pub fn new() -> Self {
+        let (send, recv) = mpsc::channel(1);
+        Self(AliveGuard(send), recv)
+    }
+
+    pub fn guard(&self) -> AliveGuard {
+        self.0.clone()
+    }
+
+    pub async fn wait_for_all(self) {
+        // Drop the sender and wait for the receiver to get the notification about last
+        // sender being dropped. Based on <https://tokio.rs/tokio/topics/shutdown>
+
+        let Self(guard, mut recv) = self;
+        drop(guard);
+
+        let _ = recv.recv().await;
+    }
+}

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -1,6 +1,6 @@
 use std::{sync::Arc, time::Duration};
 
-use tokio::sync::mpsc::Sender;
+use tokio::{sync::mpsc::Sender, task::JoinSet};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::WebSocket;
@@ -23,7 +23,12 @@ pub trait HandlerLoop {
     async fn issue_reject(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
 
     async fn on_close(&mut self, by_peer: bool);
-    async fn on_text_msg(&mut self, ws: &mut WebSocket, text: String) -> anyhow::Result<()>;
+    async fn on_text_msg(
+        &mut self,
+        ws: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
+        text: String,
+    ) -> anyhow::Result<()>;
     async fn on_stop(&mut self);
     async fn on_conn_break(&mut self);
 

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -124,7 +124,7 @@ impl HandlerLoop<'_> {
                 .await?;
 
             let xfile = &self.xfer.files()[&file_id];
-            let checksum = tokio::task::block_in_place(|| xfile.checksum(limit))?;
+            let checksum = xfile.checksum(limit).await?;
 
             anyhow::Ok(v4::ReportChsum {
                 file: file_id.clone(),

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -7,23 +7,28 @@ use std::{
 use anyhow::Context;
 use futures::SinkExt;
 use slog::{debug, error};
-use tokio::{sync::mpsc::Sender, task::JoinHandle};
+use tokio::{
+    sync::mpsc::Sender,
+    task::{AbortHandle, JoinSet},
+};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::{handler, WebSocket};
 use crate::{
-    protocol::v4, service::State, transfer::Transfer, ws::events::FileEventTx, FileId,
-    OutgoingTransfer,
+    protocol::v4, service::State, tasks::AliveGuard, transfer::Transfer, ws::events::FileEventTx,
+    FileId, OutgoingTransfer,
 };
 
 pub struct HandlerInit<'a> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
 }
 
 pub struct HandlerLoop<'a> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
     upload_tx: Sender<Message>,
     tasks: HashMap<FileId, FileTask>,
     done: HashSet<FileId>,
@@ -31,7 +36,7 @@ pub struct HandlerLoop<'a> {
 }
 
 struct FileTask {
-    job: JoinHandle<()>,
+    job: AbortHandle,
     events: Arc<FileEventTx<OutgoingTransfer>>,
 }
 
@@ -42,8 +47,16 @@ struct Uploader {
 }
 
 impl<'a> HandlerInit<'a> {
-    pub(crate) fn new(state: &'a Arc<State>, logger: &'a slog::Logger) -> Self {
-        Self { state, logger }
+    pub(crate) fn new(
+        state: &'a Arc<State>,
+        logger: &'a slog::Logger,
+        alive: &'a AliveGuard,
+    ) -> Self {
+        Self {
+            state,
+            logger,
+            alive,
+        }
     }
 }
 
@@ -63,10 +76,15 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn upgrade(self, upload_tx: Sender<Message>, xfer: Arc<OutgoingTransfer>) -> Self::Loop {
-        let Self { state, logger } = self;
+        let Self {
+            state,
+            logger,
+            alive,
+        } = self;
 
         HandlerLoop {
             state,
+            alive,
             logger,
             upload_tx,
             xfer,
@@ -111,55 +129,56 @@ impl HandlerLoop<'_> {
         self.done.insert(file_id);
     }
 
-    async fn on_checksum(
-        &mut self,
-        socket: &mut WebSocket,
-        file_id: FileId,
-        limit: u64,
-    ) -> anyhow::Result<()> {
-        let f = async {
-            self.state
-                .transfer_manager
-                .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
-                .await?;
+    async fn on_checksum(&mut self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
+        let state = self.state.clone();
+        let msg_tx = self.upload_tx.clone();
+        let xfer = self.xfer.clone();
+        let logger = self.logger.clone();
+        let alive = self.alive.clone();
 
-            let xfile = &self.xfer.files()[&file_id];
-            let checksum = xfile.checksum(limit).await?;
+        let task = async move {
+            let _guard = alive;
 
-            anyhow::Ok(v4::ReportChsum {
-                file: file_id.clone(),
-                limit,
-                checksum,
-            })
+            let make_report = async {
+                state
+                    .transfer_manager
+                    .outgoing_ensure_file_not_rejected(xfer.id(), &file_id)
+                    .await?;
+
+                let checksum = xfer.files()[&file_id].checksum(limit).await?;
+
+                anyhow::Ok(v4::ReportChsum {
+                    file: file_id.clone(),
+                    limit,
+                    checksum,
+                })
+            };
+
+            match make_report.await {
+                Ok(report) => {
+                    let _ = msg_tx
+                        .send(Message::from(&v4::ClientMsg::ReportChsum(report)))
+                        .await;
+                }
+                Err(err) => {
+                    error!(logger, "Failed to report checksum: {:?}", err);
+
+                    let msg = v4::Error {
+                        file: Some(file_id),
+                        msg: err.to_string(),
+                    };
+                    let _ = msg_tx.send(Message::from(&v4::ClientMsg::Error(msg))).await;
+                }
+            }
         };
 
-        match f.await {
-            Ok(report) => {
-                socket
-                    .send(Message::from(&v4::ClientMsg::ReportChsum(report)))
-                    .await
-                    .context("Failed to send checksum report")?;
-            }
-            Err(err) => {
-                error!(self.logger, "Failed to report checksum: {:?}", err);
-
-                let msg = v4::Error {
-                    file: Some(file_id),
-                    msg: err.to_string(),
-                };
-                socket
-                    .send(Message::from(&v4::ClientMsg::Error(msg)))
-                    .await
-                    .context("Failed to report error")?;
-            }
-        }
-
-        Ok(())
+        jobs.spawn(task);
     }
 
     async fn on_start(
         &mut self,
         socket: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         file_id: FileId,
         offset: u64,
     ) -> anyhow::Result<()> {
@@ -169,36 +188,39 @@ impl HandlerLoop<'_> {
                 .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
                 .await?;
 
+            let start = || {
+                let uploader = Uploader {
+                    sink: self.upload_tx.clone(),
+                    file_id: file_id.clone(),
+                    offset,
+                };
+                let state = self.state.clone();
+                let alive = self.alive.clone();
+                let logger = self.logger.clone();
+                let xfer = self.xfer.clone();
+                let file_id = file_id.clone();
+
+                async move {
+                    let (job, events) =
+                        super::start_upload(jobs, state, alive, logger, uploader, xfer, file_id)
+                            .await?;
+
+                    anyhow::Ok(FileTask { job, events })
+                }
+            };
+
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
                     let task = o.into_mut();
 
                     if task.job.is_finished() {
-                        *task = FileTask::start(
-                            self.state.clone(),
-                            self.logger,
-                            self.upload_tx.clone(),
-                            self.xfer.clone(),
-                            file_id.clone(),
-                            offset,
-                        )
-                        .await?;
+                        *task = start().await?;
                     } else {
                         anyhow::bail!("Transfer already in progress");
                     }
                 }
                 Entry::Vacant(v) => {
-                    let task = FileTask::start(
-                        self.state.clone(),
-                        self.logger,
-                        self.upload_tx.clone(),
-                        self.xfer.clone(),
-                        file_id.clone(),
-                        offset,
-                    )
-                    .await?;
-
-                    v.insert(task);
+                    v.insert(start().await?);
                 }
             };
 
@@ -289,7 +311,12 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         }
     }
 
-    async fn on_text_msg(&mut self, socket: &mut WebSocket, text: String) -> anyhow::Result<()> {
+    async fn on_text_msg(
+        &mut self,
+        socket: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
+        text: String,
+    ) -> anyhow::Result<()> {
         let msg: v4::ServerMsg =
             serde_json::from_str(&text).context("Failed to deserialize server message")?;
 
@@ -304,10 +331,10 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             }) => self.on_done(file).await,
             v4::ServerMsg::Error(v4::Error { file, msg }) => self.on_error(file, msg).await,
             v4::ServerMsg::ReqChsum(v4::ReqChsum { file, limit }) => {
-                self.on_checksum(socket, file, limit).await?
+                self.on_checksum(jobs, file, limit).await
             }
             v4::ServerMsg::Start(v4::Start { file, offset }) => {
-                self.on_start(socket, file, offset).await?
+                self.on_start(socket, jobs, file, offset).await?
             }
             v4::ServerMsg::Cancel(v4::Cancel { file }) => self.on_cancel(file, true).await,
         }
@@ -318,12 +345,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_stop(&mut self) {
         debug!(self.logger, "Waiting for background jobs to finish");
 
-        let tasks = self.tasks.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.cancel_silent().await;
-            }
+        let tasks = self.tasks.drain().map(|(_, task)| async move {
+            task.events.cancel_silent().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -332,12 +355,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_conn_break(&mut self) {
         debug!(self.logger, "Waiting for background jobs to pause");
 
-        let tasks = self.tasks.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.pause().await;
-            }
+        let tasks = self.tasks.drain().map(|(_, task)| async move {
+            task.events.pause().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -356,7 +375,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping client handler");
-        self.tasks.values().for_each(|task| task.job.abort());
     }
 }
 
@@ -387,39 +405,5 @@ impl handler::Uploader for Uploader {
 
     fn offset(&self) -> u64 {
         self.offset
-    }
-}
-
-impl FileTask {
-    async fn start(
-        state: Arc<State>,
-        logger: &slog::Logger,
-        sink: Sender<Message>,
-        xfer: Arc<OutgoingTransfer>,
-        file_id: FileId,
-        offset: u64,
-    ) -> anyhow::Result<Self> {
-        let events = state
-            .transfer_manager
-            .outgoing_file_events(xfer.id(), &file_id)
-            .await?;
-
-        let uploader = Uploader {
-            sink,
-            file_id: file_id.clone(),
-            offset,
-        };
-
-        let job = super::start_upload(
-            state,
-            logger.clone(),
-            Arc::clone(&events),
-            uploader,
-            xfer,
-            file_id,
-        )
-        .await?;
-
-        Ok(Self { job, events })
     }
 }

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -7,23 +7,28 @@ use std::{
 use anyhow::Context;
 use futures::SinkExt;
 use slog::{debug, error, info};
-use tokio::{sync::mpsc::Sender, task::JoinHandle};
+use tokio::{
+    sync::mpsc::Sender,
+    task::{AbortHandle, JoinSet},
+};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::{handler, WebSocket};
 use crate::{
-    protocol::v5 as prot, service::State, transfer::Transfer, ws::events::FileEventTx, FileId,
-    OutgoingTransfer,
+    protocol::v5 as prot, service::State, tasks::AliveGuard, transfer::Transfer,
+    ws::events::FileEventTx, FileId, OutgoingTransfer,
 };
 
 pub struct HandlerInit<'a> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
 }
 
 pub struct HandlerLoop<'a> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
     upload_tx: Sender<Message>,
     tasks: HashMap<FileId, FileTask>,
     done: HashSet<FileId>,
@@ -31,7 +36,7 @@ pub struct HandlerLoop<'a> {
 }
 
 struct FileTask {
-    job: JoinHandle<()>,
+    job: AbortHandle,
     events: Arc<FileEventTx<OutgoingTransfer>>,
 }
 
@@ -42,8 +47,16 @@ struct Uploader {
 }
 
 impl<'a> HandlerInit<'a> {
-    pub(crate) fn new(state: &'a Arc<State>, logger: &'a slog::Logger) -> Self {
-        Self { state, logger }
+    pub(crate) fn new(
+        state: &'a Arc<State>,
+        logger: &'a slog::Logger,
+        alive: &'a AliveGuard,
+    ) -> Self {
+        Self {
+            state,
+            logger,
+            alive,
+        }
     }
 }
 
@@ -63,10 +76,15 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn upgrade(self, upload_tx: Sender<Message>, xfer: Arc<OutgoingTransfer>) -> Self::Loop {
-        let Self { state, logger } = self;
+        let Self {
+            state,
+            logger,
+            alive,
+        } = self;
 
         HandlerLoop {
             state,
+            alive,
             logger,
             upload_tx,
             xfer,
@@ -146,56 +164,58 @@ impl HandlerLoop<'_> {
         self.done.insert(file_id);
     }
 
-    async fn on_checksum(
-        &mut self,
-        socket: &mut WebSocket,
-        file_id: FileId,
-        limit: u64,
-    ) -> anyhow::Result<()> {
-        let f = async {
-            self.state
-                .transfer_manager
-                .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
-                .await?;
+    async fn on_checksum(&self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
+        let state = self.state.clone();
+        let msg_tx = self.upload_tx.clone();
+        let xfer = self.xfer.clone();
+        let logger = self.logger.clone();
+        let alive = self.alive.clone();
 
-            let xfile = &self.xfer.files()[&file_id];
-            let checksum = xfile.checksum(limit).await?;
+        let task = async move {
+            let _guard = alive;
 
-            anyhow::Ok(prot::ReportChsum {
-                file: file_id.clone(),
+            let make_report = async {
+                state
+                    .transfer_manager
+                    .outgoing_ensure_file_not_rejected(xfer.id(), &file_id)
+                    .await?;
 
-                limit,
-                checksum,
-            })
+                let checksum = xfer.files()[&file_id].checksum(limit).await?;
+
+                anyhow::Ok(prot::ReportChsum {
+                    file: file_id.clone(),
+                    limit,
+                    checksum,
+                })
+            };
+
+            match make_report.await {
+                Ok(report) => {
+                    let _ = msg_tx
+                        .send(Message::from(&prot::ClientMsg::ReportChsum(report)))
+                        .await;
+                }
+                Err(err) => {
+                    error!(logger, "Failed to report checksum: {:?}", err);
+
+                    let msg = prot::Error {
+                        file: Some(file_id),
+                        msg: err.to_string(),
+                    };
+                    let _ = msg_tx
+                        .send(Message::from(&prot::ClientMsg::Error(msg)))
+                        .await;
+                }
+            }
         };
 
-        match f.await {
-            Ok(report) => {
-                socket
-                    .send(Message::from(&prot::ClientMsg::ReportChsum(report)))
-                    .await
-                    .context("Failed to send checksum report")?;
-            }
-            Err(err) => {
-                error!(self.logger, "Failed to report checksum: {:?}", err);
-
-                let msg = prot::Error {
-                    file: Some(file_id),
-                    msg: err.to_string(),
-                };
-                socket
-                    .send(Message::from(&prot::ClientMsg::Error(msg)))
-                    .await
-                    .context("Failed to report error")?;
-            }
-        }
-
-        Ok(())
+        jobs.spawn(task);
     }
 
     async fn on_start(
         &mut self,
         socket: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         file_id: FileId,
         offset: u64,
     ) -> anyhow::Result<()> {
@@ -205,36 +225,39 @@ impl HandlerLoop<'_> {
                 .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
                 .await?;
 
+            let start = || {
+                let uploader = Uploader {
+                    sink: self.upload_tx.clone(),
+                    file_id: file_id.clone(),
+                    offset,
+                };
+                let state = self.state.clone();
+                let alive = self.alive.clone();
+                let logger = self.logger.clone();
+                let xfer = self.xfer.clone();
+                let file_id = file_id.clone();
+
+                async move {
+                    let (job, events) =
+                        super::start_upload(jobs, state, alive, logger, uploader, xfer, file_id)
+                            .await?;
+
+                    anyhow::Ok(FileTask { job, events })
+                }
+            };
+
             match self.tasks.entry(file_id.clone()) {
                 Entry::Occupied(o) => {
                     let task = o.into_mut();
 
                     if task.job.is_finished() {
-                        *task = FileTask::start(
-                            self.state.clone(),
-                            self.logger,
-                            self.upload_tx.clone(),
-                            self.xfer.clone(),
-                            file_id.clone(),
-                            offset,
-                        )
-                        .await?;
+                        *task = start().await?;
                     } else {
                         anyhow::bail!("Transfer already in progress");
                     }
                 }
                 Entry::Vacant(v) => {
-                    let task = FileTask::start(
-                        self.state.clone(),
-                        self.logger,
-                        self.upload_tx.clone(),
-                        self.xfer.clone(),
-                        file_id.clone(),
-                        offset,
-                    )
-                    .await?;
-
-                    v.insert(task);
+                    v.insert(start().await?);
                 }
             };
 
@@ -321,7 +344,12 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         }
     }
 
-    async fn on_text_msg(&mut self, socket: &mut WebSocket, text: String) -> anyhow::Result<()> {
+    async fn on_text_msg(
+        &mut self,
+        socket: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
+        text: String,
+    ) -> anyhow::Result<()> {
         let msg: prot::ServerMsg =
             serde_json::from_str(&text).context("Failed to deserialize server message")?;
 
@@ -336,10 +364,10 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             }) => self.on_done(file).await,
             prot::ServerMsg::Error(prot::Error { file, msg }) => self.on_error(file, msg).await,
             prot::ServerMsg::ReqChsum(prot::ReqChsum { file, limit }) => {
-                self.on_checksum(socket, file, limit).await?
+                self.on_checksum(jobs, file, limit).await
             }
             prot::ServerMsg::Start(prot::Start { file, offset }) => {
-                self.on_start(socket, file, offset).await?
+                self.on_start(socket, jobs, file, offset).await?
             }
             prot::ServerMsg::Cancel(prot::Cancel { file }) => self.on_cancel(file, true).await,
             prot::ServerMsg::Reject(prot::Reject { file }) => self.on_reject(file, true).await,
@@ -350,12 +378,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_stop(&mut self) {
         debug!(self.logger, "Waiting for background jobs to finish");
 
-        let tasks = self.tasks.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.cancel_silent().await;
-            }
+        let tasks = self.tasks.drain().map(|(_, task)| async move {
+            task.events.cancel_silent().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -364,12 +388,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_conn_break(&mut self) {
         debug!(self.logger, "Waiting for background jobs to pause");
 
-        let tasks = self.tasks.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.pause().await;
-            }
+        let tasks = self.tasks.drain().map(|(_, task)| async move {
+            task.events.pause().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -387,7 +407,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping client handler");
-        self.tasks.values().for_each(|task| task.job.abort());
     }
 }
 
@@ -418,39 +437,5 @@ impl handler::Uploader for Uploader {
 
     fn offset(&self) -> u64 {
         self.offset
-    }
-}
-
-impl FileTask {
-    async fn start(
-        state: Arc<State>,
-        logger: &slog::Logger,
-        sink: Sender<Message>,
-        xfer: Arc<OutgoingTransfer>,
-        file_id: FileId,
-        offset: u64,
-    ) -> anyhow::Result<Self> {
-        let events = state
-            .transfer_manager
-            .outgoing_file_events(xfer.id(), &file_id)
-            .await?;
-
-        let uploader = Uploader {
-            sink,
-            file_id: file_id.clone(),
-            offset,
-        };
-
-        let job = super::start_upload(
-            state,
-            logger.clone(),
-            Arc::clone(&events),
-            uploader,
-            xfer,
-            file_id,
-        )
-        .await?;
-
-        Ok(Self { job, events })
     }
 }

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -159,7 +159,7 @@ impl HandlerLoop<'_> {
                 .await?;
 
             let xfile = &self.xfer.files()[&file_id];
-            let checksum = tokio::task::block_in_place(|| xfile.checksum(limit))?;
+            let checksum = xfile.checksum(limit).await?;
 
             anyhow::Ok(prot::ReportChsum {
                 file: file_id.clone(),

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::PathBuf, sync::Arc, time::Duration};
 
-use tokio::sync::mpsc::Sender;
+use tokio::{sync::mpsc::Sender, task::JoinSet};
 use warp::ws::{Message, WebSocket};
 
 use crate::{transfer::IncomingTransfer, utils::Hidden, ws, FileId};
@@ -16,6 +16,7 @@ pub trait HandlerInit {
     async fn upgrade(
         self,
         ws: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         msg_tx: Sender<Message>,
         xfer: Arc<IncomingTransfer>,
     ) -> Option<Self::Loop>;
@@ -28,6 +29,7 @@ pub trait HandlerLoop {
     async fn issue_download(
         &mut self,
         ws: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         task: super::FileXferTask,
     ) -> anyhow::Result<()>;
     async fn issue_cancel(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -17,7 +17,7 @@ use std::{
 use anyhow::Context;
 use drop_auth::Nonce;
 use futures::{SinkExt, StreamExt};
-use handler::{Downloader, HandlerInit, HandlerLoop, Request};
+use handler::{Downloader, HandlerInit, HandlerLoop};
 use hyper::StatusCode;
 use slog::{debug, error, info, warn, Logger};
 use tokio::{
@@ -25,7 +25,7 @@ use tokio::{
         mpsc::{self, UnboundedReceiver},
         Mutex,
     },
-    task::JoinHandle,
+    task::{AbortHandle, JoinSet},
 };
 use tokio_util::sync::CancellationToken;
 use warp::{
@@ -33,16 +33,17 @@ use warp::{
     Filter,
 };
 
-use super::events::FileEventTx;
+use super::{events::FileEventTx, IncomingFileEventTx};
 use crate::{
     auth,
     file::{self, FileToRecv},
     protocol,
     quarantine::PathExt,
     service::State,
+    tasks::AliveGuard,
     transfer::{IncomingTransfer, Transfer},
     utils::Hidden,
-    ws::Pinger,
+    ws::{server::handler::Request, Pinger},
     Error, Event, File, FileId,
 };
 
@@ -124,9 +125,11 @@ pub(crate) fn spawn(
     }
 
     let service = {
-        let stop = stop.clone();
         let logger = logger.clone();
         let nonces = nonce_store.clone();
+        let alive = alive.clone();
+        let stop = stop.clone();
+
         let rate_limiter = Arc::new(governor::RateLimiter::dashmap(governor::Quota::per_second(
             state
                 .config
@@ -188,6 +191,7 @@ pub(crate) fn spawn(
             .map(
                 move |version: protocol::Version, peer: SocketAddr, ws: warp::ws::Ws| {
                     let state = Arc::clone(&state);
+                    let alive = alive.clone();
                     let stop = stop.clone();
                     let logger = logger.clone();
 
@@ -203,19 +207,29 @@ pub(crate) fn spawn(
 
                         match version {
                             protocol::Version::V1 => {
-                                ctx.run(v2::HandlerInit::<false>::new(peer.ip(), &state, &logger))
-                                    .await
+                                ctx.run(v2::HandlerInit::<false>::new(
+                                    peer.ip(),
+                                    &state,
+                                    &logger,
+                                    &alive,
+                                ))
+                                .await
                             }
                             protocol::Version::V2 => {
-                                ctx.run(v2::HandlerInit::<true>::new(peer.ip(), &state, &logger))
-                                    .await
+                                ctx.run(v2::HandlerInit::<true>::new(
+                                    peer.ip(),
+                                    &state,
+                                    &logger,
+                                    &alive,
+                                ))
+                                .await
                             }
                             protocol::Version::V4 => {
-                                ctx.run(v4::HandlerInit::new(peer.ip(), state, &logger))
+                                ctx.run(v4::HandlerInit::new(peer.ip(), state, &logger, &alive))
                                     .await
                             }
                             protocol::Version::V5 => {
-                                ctx.run(v5::HandlerInit::new(peer.ip(), state, &logger))
+                                ctx.run(v5::HandlerInit::new(peer.ip(), state, &logger, &alive))
                                     .await
                             }
                         }
@@ -356,12 +370,16 @@ async fn handle_client(
     let mut ping = handler.pinger();
 
     let (send_tx, mut send_rx) = mpsc::channel(2);
-    let mut handler =
-        if let Some(handler) = handler.upgrade(&mut socket, send_tx, xfer.clone()).await {
-            handler
-        } else {
-            return;
-        };
+    let mut jobs = JoinSet::new();
+
+    let mut handler = if let Some(handler) = handler
+        .upgrade(&mut socket, &mut jobs, send_tx, xfer.clone())
+        .await
+    {
+        handler
+    } else {
+        return;
+    };
 
     let mut last_recv = Instant::now();
 
@@ -372,7 +390,7 @@ async fn handle_client(
 
                 // API request
                 req = req_rx.recv() => {
-                    if on_req(&mut socket, &mut handler, req, logger).await?.is_break() {
+                    if on_req(&mut socket, &mut jobs, &mut handler, req, logger).await?.is_break() {
                         break;
                     }
                 },
@@ -431,6 +449,8 @@ async fn handle_client(
 
         handler.finalize_success().await;
     }
+
+    jobs.shutdown().await;
 }
 
 impl FileXferTask {
@@ -726,12 +746,13 @@ async fn init_client_handler(
 
 async fn on_req(
     socket: &mut WebSocket,
+    jobs: &mut JoinSet<()>,
     handler: &mut impl HandlerLoop,
     req: Option<ServerReq>,
     logger: &Logger,
 ) -> anyhow::Result<ControlFlow<()>> {
     match req.context("API channel broken")? {
-        ServerReq::Download { task } => handler.issue_download(socket, *task).await?,
+        ServerReq::Download { task } => handler.issue_download(socket, jobs, *task).await?,
         ServerReq::Cancel { file } => handler.issue_cancel(socket, file).await?,
         ServerReq::Reject { file } => handler.issue_reject(socket, file).await?,
         ServerReq::Close => {
@@ -770,4 +791,30 @@ async fn on_recv(
     }
 
     anyhow::Ok(ControlFlow::Continue(()))
+}
+
+async fn start_download(
+    jobs: &mut JoinSet<()>,
+    guard: AliveGuard,
+    state: Arc<State>,
+    job: FileXferTask,
+    downloader: impl Downloader + Send + 'static,
+    stream: UnboundedReceiver<Vec<u8>>,
+    logger: Logger,
+) -> anyhow::Result<(AbortHandle, Arc<IncomingFileEventTx>)> {
+    let events = state
+        .transfer_manager
+        .incoming_file_events(job.xfer.id(), job.file.id())
+        .await?;
+
+    let job = {
+        let events = events.clone();
+
+        jobs.spawn(async move {
+            let _guard = guard;
+            job.run(state, events, downloader, stream, logger).await;
+        })
+    };
+
+    Ok((job, events))
 }

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -636,11 +636,11 @@ impl FileXferTask {
 
 impl TmpFileState {
     // Blocking operation
-    fn load(path: &Path) -> io::Result<Self> {
+    async fn load(path: &Path) -> io::Result<Self> {
         let file = fs::File::open(path)?;
 
         let meta = file.metadata()?;
-        let csum = file::checksum(&mut io::BufReader::new(file))?;
+        let csum = file::checksum(&mut io::BufReader::new(file)).await?;
         Ok(TmpFileState { meta, csum })
     }
 }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -515,7 +515,7 @@ impl handler::Downloader for Downloader {
         );
 
         // Check if we can resume the temporary file
-        match tokio::task::block_in_place(|| super::TmpFileState::load(&tmp_location.0)) {
+        match super::TmpFileState::load(&tmp_location.0).await {
             Ok(super::TmpFileState { meta, csum }) => {
                 debug!(
                     self.logger,
@@ -616,11 +616,8 @@ impl handler::Downloader for Downloader {
     }
 
     async fn validate(&mut self, path: &Hidden<PathBuf>) -> crate::Result<()> {
-        let csum = tokio::task::block_in_place(|| {
-            let file = std::fs::File::open(&path.0)?;
-            let csum = file::checksum(&mut io::BufReader::new(file))?;
-            crate::Result::Ok(csum)
-        })?;
+        let file = std::fs::File::open(&path.0)?;
+        let csum = file::checksum(&mut io::BufReader::new(file)).await?;
 
         if self.full_csum.get().await != csum {
             return Err(crate::Error::ChecksumMismatch);

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -10,7 +10,7 @@ use futures::{SinkExt, StreamExt};
 use slog::{debug, error, info, warn};
 use tokio::{
     sync::mpsc::{self, Sender, UnboundedSender},
-    task::JoinHandle,
+    task::{AbortHandle, JoinSet},
 };
 use warp::ws::{Message, WebSocket};
 
@@ -19,6 +19,7 @@ use crate::{
     file,
     protocol::v4,
     service::State,
+    tasks::AliveGuard,
     transfer::{IncomingTransfer, Transfer},
     utils::Hidden,
     ws::events::FileEventTx,
@@ -29,11 +30,13 @@ pub struct HandlerInit<'a> {
     peer: IpAddr,
     state: Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
 }
 
 pub struct HandlerLoop<'a> {
     state: Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
     msg_tx: Sender<Message>,
     xfer: Arc<IncomingTransfer>,
     jobs: HashMap<FileId, FileTask>,
@@ -50,18 +53,24 @@ struct Downloader {
 }
 
 struct FileTask {
-    job: JoinHandle<()>,
+    job: AbortHandle,
     chunks_tx: UnboundedSender<Vec<u8>>,
     events: Arc<FileEventTx<IncomingTransfer>>,
     csum_tx: mpsc::Sender<v4::ReportChsum>,
 }
 
 impl<'a> HandlerInit<'a> {
-    pub(crate) fn new(peer: IpAddr, state: Arc<State>, logger: &'a slog::Logger) -> Self {
+    pub(crate) fn new(
+        peer: IpAddr,
+        state: Arc<State>,
+        logger: &'a slog::Logger,
+        alive: &'a AliveGuard,
+    ) -> Self {
         Self {
             peer,
             state,
             logger,
+            alive,
         }
     }
 }
@@ -102,6 +111,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     async fn upgrade(
         mut self,
         ws: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         msg_tx: Sender<Message>,
         xfer: Arc<IncomingTransfer>,
     ) -> Option<Self::Loop> {
@@ -147,6 +157,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             peer: _,
             state,
             logger,
+            alive,
         } = self;
 
         // task responsible for requesting the checksum
@@ -154,8 +165,11 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             let msg_tx = msg_tx.clone();
             let logger = logger.clone();
             let xfer = xfer.clone();
+            let guard = alive.clone();
 
             async move {
+                let _guard = guard;
+
                 for xfile in to_fetch.into_iter().filter_map(|id| xfer.files().get(&id)) {
                     let msg = v4::ReqChsum {
                         file: xfile.id().clone(),
@@ -168,7 +182,8 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
                 }
             }
         };
-        tokio::spawn(req_file_checksums);
+
+        jobs.spawn(req_file_checksums);
 
         Some(HandlerLoop {
             state,
@@ -177,6 +192,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             jobs: HashMap::new(),
             logger,
             checksums,
+            alive,
         })
     }
 
@@ -291,6 +307,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn issue_download(
         &mut self,
         _: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         task: super::FileXferTask,
     ) -> anyhow::Result<()> {
         let is_running = self
@@ -308,17 +325,39 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             .context("Missing file checksum cell")?
             .clone();
 
+        let (chunks_tx, chunks_rx) = mpsc::unbounded_channel();
+        let (csum_tx, csum_rx) = mpsc::channel(4);
+
+        let downloader = Downloader {
+            file_id: task.file.id().clone(),
+            msg_tx: self.msg_tx.clone(),
+            logger: self.logger.clone(),
+            csum_rx,
+            full_csum: full_csum_cell,
+            offset: 0,
+        };
+
         let file_id = task.file.id().clone();
-        let state = FileTask::start(
-            self.msg_tx.clone(),
+        let (job, events) = super::start_download(
+            jobs,
+            self.alive.clone(),
             self.state.clone(),
             task,
-            full_csum_cell,
+            downloader,
+            chunks_rx,
             self.logger.clone(),
         )
         .await?;
 
-        self.jobs.insert(file_id, state);
+        self.jobs.insert(
+            file_id,
+            FileTask {
+                job,
+                chunks_tx,
+                events,
+                csum_tx,
+            },
+        );
 
         Ok(())
     }
@@ -415,12 +454,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_stop(&mut self) {
         debug!(self.logger, "Waiting for background jobs to finish");
 
-        let tasks = self.jobs.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.cancel_silent().await;
-            }
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.cancel_silent().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -451,12 +486,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_conn_break(&mut self) {
         debug!(self.logger, "Waiting for background jobs to pause");
 
-        let tasks = self.jobs.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.pause().await;
-            }
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.pause().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -475,7 +506,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping server handler");
-        self.jobs.values().for_each(|task| task.job.abort());
     }
 }
 
@@ -624,41 +654,6 @@ impl handler::Downloader for Downloader {
         }
 
         Ok(())
-    }
-}
-
-impl FileTask {
-    async fn start(
-        msg_tx: Sender<Message>,
-        state: Arc<State>,
-        task: super::FileXferTask,
-        full_csum: Arc<AsyncCell<[u8; 32]>>,
-        logger: slog::Logger,
-    ) -> anyhow::Result<Self> {
-        let events = state
-            .transfer_manager
-            .incoming_file_events(task.xfer.id(), task.file.id())
-            .await?;
-
-        let (chunks_tx, chunks_rx) = mpsc::unbounded_channel();
-        let (csum_tx, csum_rx) = mpsc::channel(4);
-
-        let downloader = Downloader {
-            file_id: task.file.id().clone(),
-            msg_tx,
-            logger: logger.clone(),
-            csum_rx,
-            full_csum,
-            offset: 0,
-        };
-        let job = tokio::spawn(task.run(state, Arc::clone(&events), downloader, chunks_rx, logger));
-
-        Ok(Self {
-            job,
-            chunks_tx,
-            events,
-            csum_tx,
-        })
     }
 }
 

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -10,7 +10,7 @@ use futures::{SinkExt, StreamExt};
 use slog::{debug, error, info, warn};
 use tokio::{
     sync::mpsc::{self, Sender, UnboundedSender},
-    task::JoinHandle,
+    task::{AbortHandle, JoinSet},
 };
 use warp::ws::{Message, WebSocket};
 
@@ -19,6 +19,7 @@ use crate::{
     file::{self, FileToRecv},
     protocol::v5 as prot,
     service::State,
+    tasks::AliveGuard,
     transfer::{IncomingTransfer, Transfer},
     utils::Hidden,
     ws::events::FileEventTx,
@@ -29,11 +30,13 @@ pub struct HandlerInit<'a> {
     peer: IpAddr,
     state: Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
 }
 
 pub struct HandlerLoop<'a> {
     state: Arc<State>,
     logger: &'a slog::Logger,
+    alive: &'a AliveGuard,
     msg_tx: Sender<Message>,
     xfer: Arc<IncomingTransfer>,
     jobs: HashMap<FileId, FileTask>,
@@ -50,18 +53,24 @@ struct Downloader {
 }
 
 struct FileTask {
-    job: JoinHandle<()>,
+    job: AbortHandle,
     chunks_tx: UnboundedSender<Vec<u8>>,
     events: Arc<FileEventTx<IncomingTransfer>>,
     csum_tx: mpsc::Sender<prot::ReportChsum>,
 }
 
 impl<'a> HandlerInit<'a> {
-    pub(crate) fn new(peer: IpAddr, state: Arc<State>, logger: &'a slog::Logger) -> Self {
+    pub(crate) fn new(
+        peer: IpAddr,
+        state: Arc<State>,
+        logger: &'a slog::Logger,
+        alive: &'a AliveGuard,
+    ) -> Self {
         Self {
             peer,
             state,
             logger,
+            alive,
         }
     }
 }
@@ -102,6 +111,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     async fn upgrade(
         mut self,
         ws: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         msg_tx: Sender<Message>,
         xfer: Arc<IncomingTransfer>,
     ) -> Option<Self::Loop> {
@@ -147,6 +157,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             peer: _,
             state,
             logger,
+            alive,
         } = self;
 
         // task responsible for requesting the checksum
@@ -154,8 +165,11 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             let msg_tx = msg_tx.clone();
             let logger = logger.clone();
             let xfer = xfer.clone();
+            let guard = alive.clone();
 
             async move {
+                let _guard = guard;
+
                 for xfile in to_fetch.into_iter().filter_map(|id| xfer.files().get(&id)) {
                     let msg = prot::ReqChsum {
                         file: xfile.id().clone(),
@@ -168,7 +182,8 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
                 }
             }
         };
-        tokio::spawn(req_file_checksums);
+
+        jobs.spawn(req_file_checksums);
 
         Some(HandlerLoop {
             state,
@@ -177,6 +192,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             jobs: HashMap::new(),
             logger,
             checksums,
+            alive,
         })
     }
 
@@ -331,6 +347,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn issue_download(
         &mut self,
         _: &mut WebSocket,
+        jobs: &mut JoinSet<()>,
         task: super::FileXferTask,
     ) -> anyhow::Result<()> {
         let is_running = self
@@ -348,17 +365,39 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             .context("Missing file checksum cell")?
             .clone();
 
+        let (chunks_tx, chunks_rx) = mpsc::unbounded_channel();
+        let (csum_tx, csum_rx) = mpsc::channel(4);
+
+        let downloader = Downloader {
+            file_id: task.file.id().clone(),
+            msg_tx: self.msg_tx.clone(),
+            logger: self.logger.clone(),
+            csum_rx,
+            full_csum: full_csum_cell,
+            offset: 0,
+        };
+
         let file_id = task.file.id().clone();
-        let state = FileTask::start(
-            self.msg_tx.clone(),
+        let (job, events) = super::start_download(
+            jobs,
+            self.alive.clone(),
             self.state.clone(),
             task,
-            full_csum_cell,
+            downloader,
+            chunks_rx,
             self.logger.clone(),
         )
         .await?;
 
-        self.jobs.insert(file_id, state);
+        self.jobs.insert(
+            file_id,
+            FileTask {
+                job,
+                chunks_tx,
+                events,
+                csum_tx,
+            },
+        );
 
         Ok(())
     }
@@ -441,12 +480,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_stop(&mut self) {
         debug!(self.logger, "Waiting for background jobs to finish");
 
-        let tasks = self.jobs.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.cancel_silent().await;
-            }
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.cancel_silent().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -477,12 +512,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     async fn on_conn_break(&mut self) {
         debug!(self.logger, "Waiting for background jobs to pause");
 
-        let tasks = self.jobs.drain().map(|(_, task)| {
-            task.job.abort();
-
-            async move {
-                task.events.pause().await;
-            }
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.pause().await;
         });
 
         futures::future::join_all(tasks).await;
@@ -501,7 +532,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping server handler");
-        self.jobs.values().for_each(|task| task.job.abort());
     }
 }
 
@@ -650,41 +680,6 @@ impl handler::Downloader for Downloader {
         }
 
         Ok(())
-    }
-}
-
-impl FileTask {
-    async fn start(
-        msg_tx: Sender<Message>,
-        state: Arc<State>,
-        task: super::FileXferTask,
-        full_csum: Arc<AsyncCell<[u8; 32]>>,
-        logger: slog::Logger,
-    ) -> anyhow::Result<Self> {
-        let events = state
-            .transfer_manager
-            .incoming_file_events(task.xfer.id(), task.file.id())
-            .await?;
-
-        let (chunks_tx, chunks_rx) = mpsc::unbounded_channel();
-        let (csum_tx, csum_rx) = mpsc::channel(4);
-
-        let downloader = Downloader {
-            file_id: task.file.id().clone(),
-            msg_tx,
-            logger: logger.clone(),
-            csum_rx,
-            full_csum,
-            offset: 0,
-        };
-        let job = tokio::spawn(task.run(state, Arc::clone(&events), downloader, chunks_rx, logger));
-
-        Ok(Self {
-            job,
-            chunks_tx,
-            events,
-            csum_tx,
-        })
     }
 }
 

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -618,3 +618,22 @@ class AssertMooseEvents(Action):
 
     def __str__(self):
         return f"AssertMooseEvents({','.join(self._expected_outputs)})"
+
+
+class EnsureTakesNoLonger(Action):
+    def __init__(self, action: Action, seconds: float):
+        self._action = action
+        self._secs = seconds
+
+    async def run(self, drop: ffi.Drop):
+        start = time.time()
+        await self._action.run(drop)
+        elapsed = time.time() - start
+
+        if elapsed > self._secs:
+            raise Exception(
+                f"Action took longer ({elapsed} s) than expected ({self._secs} s)"
+            )
+
+    def __str__(self):
+        return f"EnsureTakesNoLonger({self._action}, {self._secs})"

--- a/test/drop_test/scenario.py
+++ b/test/drop_test/scenario.py
@@ -1,4 +1,4 @@
-import typing, os
+import typing, os, time
 
 from . import action, ffi
 from .logger import logger
@@ -14,8 +14,15 @@ class ActionList:
         logger.info("Processing action list...")
         for k, v in enumerate(self._actions):
             logger.info(f"Running action {k+1}/{len(self._actions)}: {v}")
+            start = time.time()
+
             await v.run(drop)
-            logger.info(f"Action {k+1}/{len(self._actions)} completed: {v}")
+
+            elapsed = (time.time() - start) * 1000.0
+            logger.info(
+                f"Action {k+1}/{len(self._actions)} completed in {elapsed} ms: {v}"
+            )
+
         logger.info("Done processing actions")
 
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -2037,7 +2037,7 @@ scenarios = [
         },
     ),
     Scenario(
-        "scenario11",
+        "scenario11-1",
         "Send a bunch of file simultaneously and see if libdrop freezes",
         {
             "ren": ActionList(
@@ -2167,6 +2167,352 @@ scenarios = [
                     action.ExpectCancel([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], False),
                     action.NoEvent(),
                     action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario11-2",
+        "Initate a buch of transfers. Wait for some of then to start and then stop the sender. Expect immediate cancelation",
+        {
+            "ren": ActionList(
+                [
+                    action.Start("172.20.0.5"),
+                    action.Repeated(
+                        [
+                            action.NewTransfer(
+                                "172.20.0.15",
+                                [
+                                    "/tmp/testfile-bulk-01",
+                                    "/tmp/testfile-bulk-02",
+                                    "/tmp/testfile-bulk-03",
+                                    "/tmp/testfile-bulk-04",
+                                ],
+                            )
+                        ],
+                        4,
+                    ),
+                    # fmt: off
+                    action.WaitRacy([
+                        event.Queued(0, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(1, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(2, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(3, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                    ]),
+                    # fmt: on
+                    # fmt: off
+                    # Wait only for some of the files, let the rest requests arrive when we're in the stop() call
+                    action.Repeated([action.WaitForOneOf([
+                        event.Start(0, FILES["testfile-bulk-01"].id),
+                        event.Start(0, FILES["testfile-bulk-02"].id),
+                        event.Start(0, FILES["testfile-bulk-03"].id),
+                        event.Start(0, FILES["testfile-bulk-04"].id),
+                        event.Start(1, FILES["testfile-bulk-01"].id),
+                        event.Start(1, FILES["testfile-bulk-02"].id),
+                        event.Start(1, FILES["testfile-bulk-03"].id),
+                        event.Start(1, FILES["testfile-bulk-04"].id),
+                        event.Start(2, FILES["testfile-bulk-01"].id),
+                        event.Start(2, FILES["testfile-bulk-02"].id),
+                        event.Start(2, FILES["testfile-bulk-03"].id),
+                        event.Start(2, FILES["testfile-bulk-04"].id),
+                        event.Start(3, FILES["testfile-bulk-01"].id),
+                        event.Start(3, FILES["testfile-bulk-02"].id),
+                        event.Start(3, FILES["testfile-bulk-03"].id),
+                        event.Start(3, FILES["testfile-bulk-04"].id),
+                    ])], 4),
+                    # fmt: on
+                    action.EnsureTakesNoLonger(action.Stop(), seconds=1),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Start("172.20.0.15"),
+                    # fmt: off
+                    action.WaitRacy(
+                        [
+                            event.Receive(0, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(1, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(2, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(3, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                        ]
+                    ),
+                    # fmt: on
+                    # fmt: off
+                    action.Download(0, FILES["testfile-bulk-01"].id, "/tmp/received/11-2"),
+                    action.Download(0, FILES["testfile-bulk-02"].id, "/tmp/received/11-2"),
+                    action.Download(0, FILES["testfile-bulk-03"].id, "/tmp/received/11-2"),
+                    action.Download(0, FILES["testfile-bulk-04"].id, "/tmp/received/11-2"),
+                    action.Download(1, FILES["testfile-bulk-01"].id, "/tmp/received/11-2"),
+                    action.Download(1, FILES["testfile-bulk-02"].id, "/tmp/received/11-2"),
+                    action.Download(1, FILES["testfile-bulk-03"].id, "/tmp/received/11-2"),
+                    action.Download(1, FILES["testfile-bulk-04"].id, "/tmp/received/11-2"),
+                    action.Download(2, FILES["testfile-bulk-01"].id, "/tmp/received/11-2"),
+                    action.Download(2, FILES["testfile-bulk-02"].id, "/tmp/received/11-2"),
+                    action.Download(2, FILES["testfile-bulk-03"].id, "/tmp/received/11-2"),
+                    action.Download(2, FILES["testfile-bulk-04"].id, "/tmp/received/11-2"),
+                    action.Download(3, FILES["testfile-bulk-01"].id, "/tmp/received/11-2"),
+                    action.Download(3, FILES["testfile-bulk-02"].id, "/tmp/received/11-2"),
+                    action.Download(3, FILES["testfile-bulk-03"].id, "/tmp/received/11-2"),
+                    action.Download(3, FILES["testfile-bulk-04"].id, "/tmp/received/11-2"),
+                    # fmt: on
+                    # fmt: off
+                    action.Repeated([action.WaitForOneOf([
+                        event.Start(0, FILES["testfile-bulk-01"].id),
+                        event.Start(0, FILES["testfile-bulk-02"].id),
+                        event.Start(0, FILES["testfile-bulk-03"].id),
+                        event.Start(0, FILES["testfile-bulk-04"].id),
+                        event.Start(1, FILES["testfile-bulk-01"].id),
+                        event.Start(1, FILES["testfile-bulk-02"].id),
+                        event.Start(1, FILES["testfile-bulk-03"].id),
+                        event.Start(1, FILES["testfile-bulk-04"].id),
+                        event.Start(2, FILES["testfile-bulk-01"].id),
+                        event.Start(2, FILES["testfile-bulk-02"].id),
+                        event.Start(2, FILES["testfile-bulk-03"].id),
+                        event.Start(2, FILES["testfile-bulk-04"].id),
+                        event.Start(3, FILES["testfile-bulk-01"].id),
+                        event.Start(3, FILES["testfile-bulk-02"].id),
+                        event.Start(3, FILES["testfile-bulk-03"].id),
+                        event.Start(3, FILES["testfile-bulk-04"].id),
+                        event.Paused(0, FILES["testfile-bulk-01"].id),
+                        event.Paused(0, FILES["testfile-bulk-02"].id),
+                        event.Paused(0, FILES["testfile-bulk-03"].id),
+                        event.Paused(0, FILES["testfile-bulk-04"].id),
+                        event.Paused(1, FILES["testfile-bulk-01"].id),
+                        event.Paused(1, FILES["testfile-bulk-02"].id),
+                        event.Paused(1, FILES["testfile-bulk-03"].id),
+                        event.Paused(1, FILES["testfile-bulk-04"].id),
+                        event.Paused(2, FILES["testfile-bulk-01"].id),
+                        event.Paused(2, FILES["testfile-bulk-02"].id),
+                        event.Paused(2, FILES["testfile-bulk-03"].id),
+                        event.Paused(2, FILES["testfile-bulk-04"].id),
+                        event.Paused(3, FILES["testfile-bulk-01"].id),
+                        event.Paused(3, FILES["testfile-bulk-02"].id),
+                        event.Paused(3, FILES["testfile-bulk-03"].id),
+                        event.Paused(3, FILES["testfile-bulk-04"].id),
+                    ])], 10),
+                    # fmt: on
+                    action.EnsureTakesNoLonger(action.Stop(), seconds=1),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario11-3",
+        "Initate a buch of transfers. Wait for some of then to start and then stop the receiver. Expect immediate cancelation",
+        {
+            "ren": ActionList(
+                [
+                    action.Start("172.20.0.5"),
+                    action.Repeated(
+                        [
+                            action.NewTransfer(
+                                "172.20.0.15",
+                                [
+                                    "/tmp/testfile-bulk-01",
+                                    "/tmp/testfile-bulk-02",
+                                    "/tmp/testfile-bulk-03",
+                                    "/tmp/testfile-bulk-04",
+                                ],
+                            )
+                        ],
+                        4,
+                    ),
+                    # fmt: off
+                    action.WaitRacy([
+                        event.Queued(0, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(1, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(2, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                        event.Queued(3, {
+                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        }),
+                    ]),
+                    # fmt: on
+                    # fmt: off
+                    # Wait only for some of the files, let the rest requests arrive when we're in the stop() call
+                    action.Repeated([action.WaitForOneOf([
+                        event.Start(0, FILES["testfile-bulk-01"].id),
+                        event.Start(0, FILES["testfile-bulk-02"].id),
+                        event.Start(0, FILES["testfile-bulk-03"].id),
+                        event.Start(0, FILES["testfile-bulk-04"].id),
+                        event.Start(1, FILES["testfile-bulk-01"].id),
+                        event.Start(1, FILES["testfile-bulk-02"].id),
+                        event.Start(1, FILES["testfile-bulk-03"].id),
+                        event.Start(1, FILES["testfile-bulk-04"].id),
+                        event.Start(2, FILES["testfile-bulk-01"].id),
+                        event.Start(2, FILES["testfile-bulk-02"].id),
+                        event.Start(2, FILES["testfile-bulk-03"].id),
+                        event.Start(2, FILES["testfile-bulk-04"].id),
+                        event.Start(3, FILES["testfile-bulk-01"].id),
+                        event.Start(3, FILES["testfile-bulk-02"].id),
+                        event.Start(3, FILES["testfile-bulk-03"].id),
+                        event.Start(3, FILES["testfile-bulk-04"].id),
+                        event.Paused(0, FILES["testfile-bulk-01"].id),
+                        event.Paused(0, FILES["testfile-bulk-02"].id),
+                        event.Paused(0, FILES["testfile-bulk-03"].id),
+                        event.Paused(0, FILES["testfile-bulk-04"].id),
+                        event.Paused(1, FILES["testfile-bulk-01"].id),
+                        event.Paused(1, FILES["testfile-bulk-02"].id),
+                        event.Paused(1, FILES["testfile-bulk-03"].id),
+                        event.Paused(1, FILES["testfile-bulk-04"].id),
+                        event.Paused(2, FILES["testfile-bulk-01"].id),
+                        event.Paused(2, FILES["testfile-bulk-02"].id),
+                        event.Paused(2, FILES["testfile-bulk-03"].id),
+                        event.Paused(2, FILES["testfile-bulk-04"].id),
+                        event.Paused(3, FILES["testfile-bulk-01"].id),
+                        event.Paused(3, FILES["testfile-bulk-02"].id),
+                        event.Paused(3, FILES["testfile-bulk-03"].id),
+                        event.Paused(3, FILES["testfile-bulk-04"].id),
+                    ])], 10),
+                    # fmt: on
+                    action.EnsureTakesNoLonger(action.Stop(), seconds=1),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Start("172.20.0.15"),
+                    # fmt: off
+                    action.WaitRacy(
+                        [
+                            event.Receive(0, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(1, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(2, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                            event.Receive(3, "172.20.0.5", { 
+                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            }),
+                        ]
+                    ),
+                    # fmt: on
+                    # fmt: off
+                    action.Download(0, FILES["testfile-bulk-01"].id, "/tmp/received/11-3"),
+                    action.Download(0, FILES["testfile-bulk-02"].id, "/tmp/received/11-3"),
+                    action.Download(0, FILES["testfile-bulk-03"].id, "/tmp/received/11-3"),
+                    action.Download(0, FILES["testfile-bulk-04"].id, "/tmp/received/11-3"),
+                    action.Download(1, FILES["testfile-bulk-01"].id, "/tmp/received/11-3"),
+                    action.Download(1, FILES["testfile-bulk-02"].id, "/tmp/received/11-3"),
+                    action.Download(1, FILES["testfile-bulk-03"].id, "/tmp/received/11-3"),
+                    action.Download(1, FILES["testfile-bulk-04"].id, "/tmp/received/11-3"),
+                    action.Download(2, FILES["testfile-bulk-01"].id, "/tmp/received/11-3"),
+                    action.Download(2, FILES["testfile-bulk-02"].id, "/tmp/received/11-3"),
+                    action.Download(2, FILES["testfile-bulk-03"].id, "/tmp/received/11-3"),
+                    action.Download(2, FILES["testfile-bulk-04"].id, "/tmp/received/11-3"),
+                    action.Download(3, FILES["testfile-bulk-01"].id, "/tmp/received/11-3"),
+                    action.Download(3, FILES["testfile-bulk-02"].id, "/tmp/received/11-3"),
+                    action.Download(3, FILES["testfile-bulk-03"].id, "/tmp/received/11-3"),
+                    action.Download(3, FILES["testfile-bulk-04"].id, "/tmp/received/11-3"),
+                    # fmt: on
+                    # fmt: off
+                    action.Repeated([action.WaitForOneOf([
+                        event.Start(0, FILES["testfile-bulk-01"].id),
+                        event.Start(0, FILES["testfile-bulk-02"].id),
+                        event.Start(0, FILES["testfile-bulk-03"].id),
+                        event.Start(0, FILES["testfile-bulk-04"].id),
+                        event.Start(1, FILES["testfile-bulk-01"].id),
+                        event.Start(1, FILES["testfile-bulk-02"].id),
+                        event.Start(1, FILES["testfile-bulk-03"].id),
+                        event.Start(1, FILES["testfile-bulk-04"].id),
+                        event.Start(2, FILES["testfile-bulk-01"].id),
+                        event.Start(2, FILES["testfile-bulk-02"].id),
+                        event.Start(2, FILES["testfile-bulk-03"].id),
+                        event.Start(2, FILES["testfile-bulk-04"].id),
+                        event.Start(3, FILES["testfile-bulk-01"].id),
+                        event.Start(3, FILES["testfile-bulk-02"].id),
+                        event.Start(3, FILES["testfile-bulk-03"].id),
+                        event.Start(3, FILES["testfile-bulk-04"].id),
+                        event.Paused(0, FILES["testfile-bulk-01"].id),
+                        event.Paused(0, FILES["testfile-bulk-02"].id),
+                        event.Paused(0, FILES["testfile-bulk-03"].id),
+                        event.Paused(0, FILES["testfile-bulk-04"].id),
+                        event.Paused(1, FILES["testfile-bulk-01"].id),
+                        event.Paused(1, FILES["testfile-bulk-02"].id),
+                        event.Paused(1, FILES["testfile-bulk-03"].id),
+                        event.Paused(1, FILES["testfile-bulk-04"].id),
+                        event.Paused(2, FILES["testfile-bulk-01"].id),
+                        event.Paused(2, FILES["testfile-bulk-02"].id),
+                        event.Paused(2, FILES["testfile-bulk-03"].id),
+                        event.Paused(2, FILES["testfile-bulk-04"].id),
+                        event.Paused(3, FILES["testfile-bulk-01"].id),
+                        event.Paused(3, FILES["testfile-bulk-02"].id),
+                        event.Paused(3, FILES["testfile-bulk-03"].id),
+                        event.Paused(3, FILES["testfile-bulk-04"].id),
+                    ])], 4),
+                    # fmt: on
+                    action.EnsureTakesNoLonger(action.Stop(), seconds=1),
                 ]
             ),
         },


### PR DESCRIPTION
Main changes:
* Use `tokio::JoinSet<()>` for efficient tasks cancelation
* 'Asyncify' checksum computation
* Ensure the `stop()` timing with two test cases