### PR TITLE
Allow constructing outgoing files without the access to the file system.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "hyper",
  "infer",
  "libc",
+ "once_cell",
  "serde",
  "serde_json",
  "sha-1",
@@ -1081,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "packed_simd_2"

--- a/drop-transfer/Cargo.toml
+++ b/drop-transfer/Cargo.toml
@@ -46,6 +46,7 @@ warp = { version = "0.3.4", default-features = false, features = ["websocket"] }
 walkdir = "2.3.3"
 async_cell = "0.2.2"
 governor = { version = "0.5.1", default-features = false, features = ["dashmap", "std"] }
+once_cell = "1.18.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"

--- a/drop-transfer/src/file/reader/path.rs
+++ b/drop-transfer/src/file/reader/path.rs
@@ -1,4 +1,10 @@
-use std::{fs, io, path::Path};
+#[cfg(unix)]
+use std::os::unix::prelude::*;
+use std::{
+    fs::{self, OpenOptions},
+    io,
+    path::Path,
+};
 
 // Reads a file from the given path
 pub struct FileReader {
@@ -7,8 +13,14 @@ pub struct FileReader {
 }
 
 impl FileReader {
-    pub fn new(path: &Path) -> crate::Result<Self> {
-        let file = fs::File::open(path)?;
+    pub fn new(path: &Path) -> io::Result<Self> {
+        let mut options = OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        options.custom_flags(libc::O_NOFOLLOW);
+
+        let file = options.open(path)?;
+
         Ok(Self { file, pos: 0 })
     }
 }

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -540,7 +540,7 @@ impl TransferManager {
         Ok(())
     }
 
-    pub async fn incoming_finsh_download(
+    pub async fn incoming_finish_download(
         &self,
         transfer_id: Uuid,
         file_id: &FileId,

--- a/drop-transfer/src/ws/events.rs
+++ b/drop-transfer/src/ws/events.rs
@@ -80,17 +80,6 @@ impl<T: Transfer> FileEventTx<T> {
             .expect("Event channel shouldn't be closed");
     }
 
-    /// Emits the event even when the file upload is not started
-    pub async fn emit_force(&self, event: Event) {
-        self.inner
-            .read()
-            .await
-            .tx
-            .send(event)
-            .await
-            .expect("Event channel shouldn't be closed");
-    }
-
     async fn stop(&self, event: Event, status: Result<(), i32>) {
         let mut lock = self.inner.write().await;
 

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -628,7 +628,7 @@ impl FileXferTask {
 
                 if let Err(err) = state
                     .transfer_manager
-                    .incoming_finsh_download(self.xfer.id(), self.file.id())
+                    .incoming_finish_download(self.xfer.id(), self.file.id())
                     .await
                 {
                     warn!(logger, "Failed to store download finish: {err}");

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -602,13 +602,7 @@ impl FileXferTask {
                 return;
             }
             Err(err) => {
-                events
-                    .emit_force(crate::Event::FileDownloadFailed(
-                        self.xfer.clone(),
-                        self.file.id().clone(),
-                        err,
-                    ))
-                    .await;
+                events.failed(err).await;
                 return;
             }
         };
@@ -618,8 +612,6 @@ impl FileXferTask {
                 offset,
                 tmp_location,
             } => {
-                events.start(self.base_dir.to_string_lossy()).await;
-
                 let result = self
                     .stream_file(
                         StreamCtx {
@@ -806,6 +798,8 @@ async fn start_download(
         .transfer_manager
         .incoming_file_events(job.xfer.id(), job.file.id())
         .await?;
+
+    events.start(job.base_dir.to_string_lossy()).await;
 
     let job = {
         let events = events.clone();

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -192,7 +192,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                     let file_id = self
                         .xfer
                         .file_by_subpath(&file)
-                        .expect("File should be there sice we have a task registered")
+                        .expect("File should be there since we have a task registered")
                         .id();
 
                     debug!(
@@ -206,7 +206,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finsh_download(self.xfer.id(), file_id)
+                        .incoming_finish_download(self.xfer.id(), file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -189,7 +189,28 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
             }) = self.jobs.remove(&file)
             {
                 if !task.is_finished() {
+                    let file_id = self
+                        .xfer
+                        .file_by_subpath(&file)
+                        .expect("File should be there sice we have a task registered")
+                        .id();
+
+                    debug!(
+                        self.logger,
+                        "Aborting download job: {}:{file_id}",
+                        self.xfer.id()
+                    );
+
                     task.abort();
+
+                    if let Err(err) = self
+                        .state
+                        .transfer_manager
+                        .incoming_finsh_download(self.xfer.id(), file_id)
+                        .await
+                    {
+                        warn!(self.logger, "Failed to store download finish: {err}");
+                    }
 
                     events
                         .failed(crate::Error::BadTransferState(format!(

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -268,7 +268,7 @@ impl HandlerLoop<'_> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finsh_download(self.xfer.id(), &file_id)
+                        .incoming_finish_download(self.xfer.id(), &file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -257,7 +257,23 @@ impl HandlerLoop<'_> {
             }) = self.jobs.remove(&file_id)
             {
                 if !task.is_finished() {
+                    debug!(
+                        self.logger,
+                        "Aborting download job: {}:{file_id}",
+                        self.xfer.id()
+                    );
+
                     task.abort();
+
+                    if let Err(err) = self
+                        .state
+                        .transfer_manager
+                        .incoming_finsh_download(self.xfer.id(), &file_id)
+                        .await
+                    {
+                        warn!(self.logger, "Failed to store download finish: {err}");
+                    }
+
                     events
                         .failed(crate::Error::BadTransferState(format!(
                             "Sender reported an error: {msg}"

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -297,7 +297,23 @@ impl HandlerLoop<'_> {
             }) = self.jobs.remove(&file_id)
             {
                 if !task.is_finished() {
+                    debug!(
+                        self.logger,
+                        "Aborting download job: {}:{file_id}",
+                        self.xfer.id()
+                    );
+
                     task.abort();
+
+                    if let Err(err) = self
+                        .state
+                        .transfer_manager
+                        .incoming_finsh_download(self.xfer.id(), &file_id)
+                        .await
+                    {
+                        warn!(self.logger, "Failed to store download finish: {err}");
+                    }
+
                     events
                         .failed(crate::Error::BadTransferState(format!(
                             "Sender reported an error: {msg}"

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -308,7 +308,7 @@ impl HandlerLoop<'_> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finsh_download(self.xfer.id(), &file_id)
+                        .incoming_finish_download(self.xfer.id(), &file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -753,7 +753,7 @@ fn crate_fd_callback(
         drop(guard);
 
         if res < 0 {
-            debug!(logger, "FD callback failed for {uri:?}");
+            warn!(logger, "FD callback failed for {uri:?}");
             None
         } else {
             Some(res)

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -454,6 +454,20 @@ class ModifyFile(Action):
         return f"ModifyFile({self._file})"
 
 
+class DeleteFileFromFS(Action):
+    def __init__(self, file_glob: str):
+        self._file = file_glob
+
+    async def run(self, drop: ffi.Drop):
+        file_list = glob.glob(self._file)
+        file = file_list[0]
+
+        os.remove(file)
+
+    def __str__(self):
+        return f"DeleteFileFromFS({self._file})"
+
+
 class CompareTrees(Action):
     def __init__(self, out_dir: Path, tree: list[File]):
         self._out_dir = out_dir

--- a/test/run.py
+++ b/test/run.py
@@ -67,7 +67,7 @@ def cleanup_files(files: typing.Dict):
         ) as proc:
             proc.communicate()
             if proc.returncode != 0:
-                raise Exception("Couldn't create a testfile")
+                print(f"Couldn't remove a testfile {name}")
 
 
 async def main():

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -6758,7 +6758,7 @@ scenarios = [
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
                     action.DeleteFileFromFS("/tmp/testfile-big"),
-                    # restrat
+                    # restart
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-13-ren.sqlite"),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -6623,7 +6623,7 @@ scenarios = [
         },
     ),
     Scenario(
-        "scenario29-12",
+        "scenario29-11",
         "Send a transfer request, wait for it to arrive, stop the sender, reject on the receiver, start the sender, expect the transfer to not be resumed",
         {
             "ren": ActionList(
@@ -6679,7 +6679,7 @@ scenarios = [
         },
     ),
     Scenario(
-        "scenario29-11",
+        "scenario29-12",
         "Send a transfer request, wait for it to arrive, stop the sender, cancel on the receiver, start the sender, expect the transfer to not be resumed",
         {
             "ren": ActionList(
@@ -6723,6 +6723,84 @@ scenarios = [
                         )
                     ),
                     action.Sleep(1),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario29-13",
+        "Send a transfer request, start transfer and then stop the sender. Then remove transfered file and start the sender. Expect proper transfer restoration and file transfer failure",
+        {
+            "ren": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Start("172.20.0.5", dbpath="/tmp/db/29-13-ren.sqlite"),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    # wait for the initial progress indicating that we start from the beginning
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
+                    # make sure we have received something, so that we have non-empty tmp file
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id)),
+                    action.Stop(),
+                    action.DeleteFileFromFS("/tmp/testfile-big"),
+                    # restrat
+                    action.Start("172.20.0.5", dbpath="/tmp/db/29-13-ren.sqlite"),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.Start("172.20.0.15", dbpath="/tmp/db/29-11-stimpy.sqlite"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0, FILES["testfile-big"].id, "/tmp/received/29-13/"
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileFailed(
+                            0, FILES["testfile-big"].id, Error.BAD_TRANSFER_STATE
+                        )
+                    ),
+                    # Try to download it again
+                    action.Download(
+                        0, FILES["testfile-big"].id, "/tmp/received/29-13/"
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileFailed(
+                            0, FILES["testfile-big"].id, Error.BAD_TRANSFER_STATE
+                        )
+                    ),
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),


### PR DESCRIPTION
This allows for a fairly easy reconstruction of transfer from the database upon instance startup. Previously when restoring a file failed the whole transfer was ignored since it wasn't possible to restore its data structure. With these changes, the structure is restored and the file system is only consulted during the regular operation of the connection handler.

Additionally, I've found a bug with failed and started events sometimes being not emitted on the server side