### PR TITLE
Make Rejected, Success and Failure a file terminal states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "rusqlite_migration",
  "serde",
  "slog",
+ "strum",
  "thiserror",
  "tokio",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ async-trait = "0.1.68"
 base64 = "0.21.0"
 uuid = { version = "1.3", features = ["v4", "serde"] }
 url = { version = "2.4.0", features = ["serde"] }
+strum = { version = "0.24.1", features = ["derive"] }

--- a/drop-core/src/status.rs
+++ b/drop-core/src/status.rs
@@ -25,6 +25,8 @@ pub enum Status {
     FileChecksumMismatch = 33,
     FileRejected = 34,
     FilePaused = 35,
+    FileFailed = 36,
+    FileFinished = 37,
 }
 
 impl serde::Serialize for Status {

--- a/drop-storage/Cargo.toml
+++ b/drop-storage/Cargo.toml
@@ -15,6 +15,7 @@ uuid = { workspace = true }
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 url = { workspace = true }
 tokio = { workspace = true }
+strum = { workspace = true }
 
 # Force bundled sqlite on linux, let moose choose on other platforms
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/drop-storage/migrations/003-retries/up.sql
+++ b/drop-storage/migrations/003-retries/up.sql
@@ -20,7 +20,6 @@ CREATE TABLE IF NOT EXISTS sync_outgoing_files (
   sync_id INTEGER NOT NULL,
   path_id INTEGER NOT NULL,
   local_state INTEGER NOT NULL,
-  remote_state INTEGER NOT NULL,
   PRIMARY KEY(sync_id, path_id)
   FOREIGN KEY(sync_id) REFERENCES sync_transfer(sync_id) ON DELETE CASCADE ON UPDATE CASCADE
   FOREIGN KEY(path_id) REFERENCES outgoing_paths(id) ON DELETE CASCADE ON UPDATE CASCADE
@@ -30,7 +29,6 @@ CREATE TABLE IF NOT EXISTS sync_incoming_files (
   sync_id INTEGER NOT NULL,
   path_id INTEGER NOT NULL,
   local_state INTEGER NOT NULL,
-  remote_state INTEGER NOT NULL,
   PRIMARY KEY(sync_id, path_id)
   FOREIGN KEY(sync_id) REFERENCES sync_transfer(sync_id) ON DELETE CASCADE ON UPDATE CASCADE
   FOREIGN KEY(path_id) REFERENCES incoming_paths(id) ON DELETE CASCADE ON UPDATE CASCADE

--- a/drop-storage/src/lib.rs
+++ b/drop-storage/src/lib.rs
@@ -10,7 +10,7 @@ use rusqlite_migration::Migrations;
 use slog::{error, trace, warn, Logger};
 use tokio::sync::Mutex;
 use types::{
-    DbTransferType, IncomingFileToRetry, IncomingPath, IncomingPathStateEvent,
+    DbTransferType, FileSyncState, IncomingFileToRetry, IncomingPath, IncomingPathStateEvent,
     IncomingPathStateEventData, IncomingTransferToRetry, OutgoingFileToRetry, OutgoingPath,
     OutgoingPathStateEvent, OutgoingPathStateEventData, TempFileLocation, Transfer, TransferFiles,
     TransferIncomingPath, TransferOutgoingPath, TransferStateEvent,
@@ -176,10 +176,65 @@ impl Storage {
         &self,
         transfer_id: Uuid,
         file_id: &str,
-    ) -> Option<sync::File> {
+    ) -> Option<FileSyncState> {
+        let tid = transfer_id.to_string();
+
         let task = async {
-            let conn = self.conn.lock().await;
-            sync::outgoing_file_state(&conn, transfer_id, file_id)
+            let mut conn = self.conn.lock().await;
+
+            let conn = conn.transaction()?;
+
+            let sync = sync::outgoing_file_state(&conn, transfer_id, file_id)?;
+
+            let sync = if let Some(sync) = sync {
+                sync
+            } else {
+                return Ok::<_, Error>(None);
+            };
+
+            let res = conn.query_row(
+                r#"
+                SELECT
+                    EXISTS (
+                        SELECT 1
+                        FROM outgoing_path_failed_states opfs
+                        INNER JOIN outgoing_paths op ON op.id = opfs.path_id
+                        WHERE op.transfer_id = ?1 AND op.path_hash = ?2
+                        LIMIT 1
+                    ) as is_failed,
+                    EXISTS (
+                        SELECT 1
+                        FROM outgoing_path_completed_states opcs
+                        INNER JOIN outgoing_paths op ON op.id = opcs.path_id
+                        WHERE op.transfer_id = ?1 AND op.path_hash = ?2
+                        LIMIT 1
+                    ) as is_completed,
+                    EXISTS (
+                        SELECT 1
+                        FROM outgoing_path_reject_states oprs
+                        INNER JOIN outgoing_paths op ON op.id = oprs.path_id
+                        WHERE op.transfer_id = ?1 AND op.path_hash = ?2
+                        LIMIT 1
+                    ) as is_rejected
+                "#,
+                params![tid, file_id],
+                |r| {
+                    let is_failed = r.get("is_failed")?;
+                    let is_success = r.get("is_completed")?;
+                    let is_rejected = r.get("is_rejected")?;
+
+                    Ok(FileSyncState {
+                        sync,
+                        is_rejected,
+                        is_success,
+                        is_failed,
+                    })
+                },
+            )?;
+
+            conn.commit()?;
+
+            Ok::<_, Error>(Some(res))
         };
 
         match task.await {
@@ -223,10 +278,64 @@ impl Storage {
         &self,
         transfer_id: Uuid,
         file_id: &str,
-    ) -> Option<sync::File> {
+    ) -> Option<FileSyncState> {
+        let tid = transfer_id.to_string();
+
         let task = async {
-            let conn = self.conn.lock().await;
-            sync::incoming_file_state(&conn, transfer_id, file_id)
+            let mut conn = self.conn.lock().await;
+
+            let conn = conn.transaction()?;
+
+            let sync = sync::incoming_file_state(&conn, transfer_id, file_id)?;
+            let sync = if let Some(sync) = sync {
+                sync
+            } else {
+                return Ok::<_, Error>(None);
+            };
+
+            let res = conn.query_row(
+                r#"
+                SELECT
+                    EXISTS (
+                        SELECT 1
+                        FROM incoming_path_failed_states ipfs
+                        INNER JOIN incoming_paths ip ON ip.id = ipfs.path_id
+                        WHERE ip.transfer_id = ?1 AND ip.path_hash = ?2
+                        LIMIT 1
+                    ) as is_failed,
+                    EXISTS (
+                        SELECT 1
+                        FROM incoming_path_completed_states ipcs
+                        INNER JOIN incoming_paths ip ON ip.id = ipcs.path_id
+                        WHERE ip.transfer_id = ?1 AND ip.path_hash = ?2
+                        LIMIT 1
+                    ) as is_completed,
+                    EXISTS (
+                        SELECT 1
+                        FROM incoming_path_reject_states iprs
+                        INNER JOIN incoming_paths ip ON ip.id = iprs.path_id
+                        WHERE ip.transfer_id = ?1 AND ip.path_hash = ?2
+                        LIMIT 1
+                    ) as is_rejected
+                "#,
+                params![tid, file_id],
+                |r| {
+                    let is_failed = r.get("is_failed")?;
+                    let is_success = r.get("is_completed")?;
+                    let is_rejected = r.get("is_rejected")?;
+
+                    Ok(FileSyncState {
+                        sync,
+                        is_rejected,
+                        is_success,
+                        is_failed,
+                    })
+                },
+            )?;
+
+            conn.commit()?;
+
+            Ok::<_, Error>(Some(res))
         };
 
         match task.await {

--- a/drop-storage/src/sync.rs
+++ b/drop-storage/src/sync.rs
@@ -59,12 +59,6 @@ pub struct Transfer {
     pub is_outgoing: bool,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct File {
-    pub remote_state: FileState,
-    pub local_state: FileState,
-}
-
 #[derive(Debug, Clone)]
 pub struct FileInFlight {
     pub base_dir: String,
@@ -88,8 +82,8 @@ pub(super) fn insert_transfer(
     if is_incoming {
         conn.execute(
             r#"
-                INSERT INTO sync_incoming_files (sync_id, path_id, local_state, remote_state)
-                SELECT st.sync_id, ip.id, ?2, ?2
+                INSERT INTO sync_incoming_files (sync_id, path_id, local_state)
+                SELECT st.sync_id, ip.id, ?2
                 FROM transfers t
                 INNER JOIN sync_transfer st ON t.id = st.transfer_id
                 INNER JOIN incoming_paths ip ON t.id = ip.transfer_id
@@ -100,8 +94,8 @@ pub(super) fn insert_transfer(
     } else {
         conn.execute(
             r#"
-                INSERT INTO sync_outgoing_files (sync_id, path_id, local_state, remote_state)
-                SELECT st.sync_id, ip.id, ?2, ?2
+                INSERT INTO sync_outgoing_files (sync_id, path_id, local_state)
+                SELECT st.sync_id, ip.id, ?2
                 FROM transfers t
                 INNER JOIN sync_transfer st ON t.id = st.transfer_id
                 INNER JOIN outgoing_paths ip ON t.id = ip.transfer_id
@@ -181,17 +175,17 @@ pub(super) fn transfer_clear(conn: &Connection, transfer_id: Uuid) -> super::Res
     Ok(if count > 0 { Some(()) } else { None })
 }
 
-pub(super) fn outgoing_file_state(
+pub(super) fn outgoing_file_local_state(
     conn: &Connection,
     transfer_id: Uuid,
     file_id: &str,
-) -> super::Result<Option<File>> {
+) -> super::Result<Option<FileState>> {
     let tid = transfer_id.to_string();
 
     let res = conn
         .query_row(
             r#"
-            SELECT sof.local_state, sof.remote_state
+            SELECT sof.local_state
             FROM sync_outgoing_files sof
             INNER JOIN sync_transfer st USING(sync_id)
             INNER JOIN transfers t ON t.id = st.transfer_id
@@ -199,12 +193,7 @@ pub(super) fn outgoing_file_state(
             WHERE st.transfer_id = ?1 AND op.path_hash = ?2
             "#,
             params![tid, file_id],
-            |r| {
-                Ok(File {
-                    remote_state: r.get(1)?,
-                    local_state: r.get(0)?,
-                })
-            },
+            |r| r.get(0),
         )
         .optional()?;
 
@@ -237,57 +226,6 @@ pub(super) fn outgoing_file_set_local_state(
     Ok(if count > 0 { Some(()) } else { None })
 }
 
-pub(super) fn outgoing_file_set_remote_state(
-    conn: &Connection,
-    transfer_id: Uuid,
-    file_id: &str,
-    state: FileState,
-) -> super::Result<Option<()>> {
-    let tid = transfer_id.to_string();
-
-    let count = conn.execute(
-        r#"
-        UPDATE sync_outgoing_files
-        SET remote_state = ?3
-        WHERE ROWID IN (
-            SELECT sof.ROWID
-            FROM sync_outgoing_files sof
-            INNER JOIN sync_transfer st USING(sync_id)
-            INNER JOIN transfers t ON t.id = st.transfer_id
-            INNER JOIN outgoing_paths op ON t.id = op.transfer_id AND sof.path_id = op.id
-            WHERE st.transfer_id = ?1 AND op.path_hash = ?2
-        )
-        "#,
-        params![tid, file_id, state],
-    )?;
-    Ok(if count > 0 { Some(()) } else { None })
-}
-
-pub(super) fn outgoing_files_to_reject(
-    conn: &Connection,
-    transfer_id: Uuid,
-) -> super::Result<Vec<String>> {
-    let tid = transfer_id.to_string();
-
-    let res = conn
-        .prepare(
-            r#"
-        SELECT DISTINCT op.path_hash
-        FROM sync_outgoing_files sof
-        INNER JOIN sync_transfer st USING(sync_id)
-        INNER JOIN outgoing_paths op ON op.id = sof.path_id 
-        INNER JOIN outgoing_path_reject_states oprs ON op.ip = oprs.path_id 
-        WHERE st.transfer_id = ?1
-            AND sof.local_state = ?2
-            AND NOT sof.remote_state = sof.local_state
-        "#,
-        )?
-        .query_map(params![tid, FileState::Terminal], |r| r.get(0))?
-        .collect::<QueryResult<_>>()?;
-
-    Ok(res)
-}
-
 pub(super) fn incoming_files_in_flight(
     conn: &Connection,
     transfer_id: Uuid,
@@ -312,31 +250,6 @@ pub(super) fn incoming_files_in_flight(
                 file_id: r.get(1)?,
             })
         })?
-        .collect::<QueryResult<_>>()?;
-
-    Ok(res)
-}
-
-pub(super) fn incoming_files_to_reject(
-    conn: &Connection,
-    transfer_id: Uuid,
-) -> super::Result<Vec<String>> {
-    let tid = transfer_id.to_string();
-
-    let res = conn
-        .prepare(
-            r#"
-        SELECT DISTINCT ip.path_hash
-        FROM sync_incoming_files sif
-        INNER JOIN sync_transfer st USING(sync_id)
-        INNER JOIN incoming_paths ip ON ip.id = sif.path_id 
-        INNER JOIN incoming_path_reject_states iprs ON ip.ip = iprs.path_id 
-        WHERE st.transfer_id = ?1
-            AND sif.local_state = ?2
-            AND NOT sif.remote_state = sif.local_state
-        "#,
-        )?
-        .query_map(params![tid, FileState::Terminal], |r| r.get(0))?
         .collect::<QueryResult<_>>()?;
 
     Ok(res)
@@ -390,17 +303,17 @@ pub(super) fn start_incoming_file(
     Ok(if count > 0 { Some(()) } else { None })
 }
 
-pub(super) fn incoming_file_state(
+pub(super) fn incoming_file_local_state(
     conn: &Connection,
     transfer_id: Uuid,
     file_id: &str,
-) -> super::Result<Option<File>> {
+) -> super::Result<Option<FileState>> {
     let tid = transfer_id.to_string();
 
     let res = conn
         .query_row(
             r#"
-            SELECT sif.local_state, sif.remote_state
+            SELECT sif.local_state
             FROM sync_incoming_files sif
             INNER JOIN sync_transfer st USING(sync_id)
             INNER JOIN transfers t ON t.id = st.transfer_id
@@ -408,12 +321,7 @@ pub(super) fn incoming_file_state(
             WHERE st.transfer_id = ?1 AND ip.path_hash = ?2
             "#,
             params![tid, file_id],
-            |r| {
-                Ok(File {
-                    remote_state: r.get(1)?,
-                    local_state: r.get(0)?,
-                })
-            },
+            |r| r.get(0),
         )
         .optional()?;
 
@@ -432,32 +340,6 @@ pub(super) fn incoming_file_set_local_state(
         r#"
         UPDATE sync_incoming_files
         SET local_state = ?3
-        WHERE ROWID IN (
-            SELECT sif.ROWID
-            FROM sync_incoming_files sif
-            INNER JOIN sync_transfer st USING(sync_id)
-            INNER JOIN transfers t ON t.id = st.transfer_id
-            INNER JOIN incoming_paths ip ON t.id = ip.transfer_id AND sif.path_id = ip.id
-            WHERE st.transfer_id = ?1 AND ip.path_hash = ?2
-        )
-        "#,
-        params![tid, file_id, state],
-    )?;
-    Ok(if count > 0 { Some(()) } else { None })
-}
-
-pub(super) fn incoming_file_set_remote_state(
-    conn: &Connection,
-    transfer_id: Uuid,
-    file_id: &str,
-    state: FileState,
-) -> super::Result<Option<()>> {
-    let tid = transfer_id.to_string();
-
-    let count = conn.execute(
-        r#"
-        UPDATE sync_incoming_files
-        SET remote_state = ?3
         WHERE ROWID IN (
             SELECT sif.ROWID
             FROM sync_incoming_files sif

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -173,7 +173,7 @@ pub struct TempFileLocation {
 }
 
 pub struct FileSyncState {
-    pub sync: sync::File,
+    pub sync: sync::FileState,
     pub is_rejected: bool,
     pub is_success: bool,
     pub is_failed: bool,

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use chrono::NaiveDateTime;
 use serde::Serialize;
 
+use crate::sync;
+
 type TransferId = uuid::Uuid;
 type FileId = String;
 
@@ -168,6 +170,13 @@ pub struct OutgoingTransferToRetry {
 pub struct TempFileLocation {
     pub file_id: String,
     pub base_path: String,
+}
+
+pub struct FileSyncState {
+    pub sync: sync::File,
+    pub is_rejected: bool,
+    pub is_success: bool,
+    pub is_failed: bool,
 }
 
 #[derive(Debug)]

--- a/drop-transfer/Cargo.toml
+++ b/drop-transfer/Cargo.toml
@@ -36,7 +36,7 @@ serde_json = "1.0.96"
 sha-1 = "0.10"
 sha2 = "0.10.6"
 slog = { workspace = true }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { workspace = true }
 thiserror = "1.0"
 tokio = { workspace = true }
 tokio-tungstenite = "0.18.0"

--- a/drop-transfer/src/error.rs
+++ b/drop-transfer/src/error.rs
@@ -2,6 +2,8 @@ use std::io::Error as IoError;
 
 use tokio_tungstenite::tungstenite;
 
+use crate::manager::FileTerminalState;
+
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Operation was canceled")]
@@ -46,8 +48,8 @@ pub enum Error {
     StorageError,
     #[error("Checksum validation failed")]
     ChecksumMismatch,
-    #[error("File is rejected")]
-    Rejected,
+    #[error("File in mismatched state: {0:?}")]
+    FileStateMismatch(FileTerminalState),
 }
 
 impl Error {
@@ -98,7 +100,9 @@ impl From<&Error> for u32 {
             Error::AuthenticationFailed => Status::AuthenticationFailed as _,
             Error::StorageError => Status::StorageError as _,
             Error::ChecksumMismatch => Status::FileChecksumMismatch as _,
-            Error::Rejected => Status::FileRejected as _,
+            Error::FileStateMismatch(FileTerminalState::Rejected) => Status::FileRejected as _,
+            Error::FileStateMismatch(FileTerminalState::Completed) => Status::FileFinished as _,
+            Error::FileStateMismatch(FileTerminalState::Failed) => Status::FileFailed as _,
         }
     }
 }

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -163,8 +163,9 @@ impl Service {
 
         if started {
             validate_dest_path(parent_dir)?;
+
             state
-                .start_download(&self.state.storage, file_id, parent_dir, &self.logger)
+                .start_download(&self.state.storage, file_id, parent_dir)
                 .await?;
         }
 

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -7,6 +7,7 @@ use std::{
 
 use drop_analytics::Moose;
 use drop_config::DropConfig;
+use drop_core::Status;
 use drop_storage::Storage;
 use slog::{debug, Logger};
 use tokio::sync::{mpsc, Semaphore};
@@ -181,7 +182,7 @@ impl Service {
             .await?;
 
         if let Some(res) = res {
-            res.events.cancel_silent().await;
+            res.events.stop_silent(Status::Canceled).await;
 
             self.state
                 .event_tx
@@ -204,18 +205,7 @@ impl Service {
                 .await
             {
                 Ok(res) => {
-                    res.events.cancelled_on_rejection().await;
-
-                    self.state
-                        .event_tx
-                        .send(crate::Event::FileUploadRejected {
-                            transfer_id,
-                            file_id: file,
-                            by_peer: false,
-                        })
-                        .await
-                        .expect("Event channel should be open");
-
+                    res.events.rejected(false).await;
                     return Ok(());
                 }
                 Err(crate::Error::BadTransfer) => (),
@@ -230,18 +220,7 @@ impl Service {
                 .await
             {
                 Ok(res) => {
-                    res.events.cancelled_on_rejection().await;
-
-                    self.state
-                        .event_tx
-                        .send(crate::Event::FileDownloadRejected {
-                            transfer_id,
-                            file_id: file,
-                            by_peer: false,
-                        })
-                        .await
-                        .expect("Event channel should be open");
-
+                    res.events.rejected(false).await;
                     return Ok(());
                 }
                 Err(crate::Error::BadTransfer) => (),
@@ -262,7 +241,10 @@ impl Service {
                 .await
             {
                 Ok(res) => {
-                    futures::future::join_all(res.events.iter().map(|ev| ev.cancel_silent())).await;
+                    futures::future::join_all(
+                        res.events.iter().map(|ev| ev.stop_silent(Status::Canceled)),
+                    )
+                    .await;
 
                     self.state
                         .event_tx
@@ -284,7 +266,10 @@ impl Service {
                 .await
             {
                 Ok(res) => {
-                    futures::future::join_all(res.events.iter().map(|ev| ev.cancel_silent())).await;
+                    futures::future::join_all(
+                        res.events.iter().map(|ev| ev.stop_silent(Status::Canceled)),
+                    )
+                    .await;
 
                     self.state
                         .event_tx

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -31,6 +31,7 @@ pub trait HandlerInit {
 #[async_trait::async_trait]
 pub trait HandlerLoop {
     async fn issue_reject(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
+    async fn issue_faliure(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
 
     async fn on_close(&mut self, by_peer: bool);
     async fn on_text_msg(

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -6,14 +6,8 @@ use tokio_tungstenite::tungstenite::Message;
 use super::WebSocket;
 use crate::{ws, FileId, OutgoingTransfer};
 
-#[derive(Debug)]
-pub enum Ack {
-    Finished(FileId),
-}
-
 pub struct MsgToSend {
     pub msg: Message,
-    pub ack: Option<Ack>,
 }
 
 #[async_trait::async_trait]
@@ -59,9 +53,6 @@ where
     T: Into<Message>,
 {
     fn from(value: T) -> Self {
-        Self {
-            msg: value.into(),
-            ack: None,
-        }
+        Self { msg: value.into() }
     }
 }

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -25,7 +25,7 @@ pub trait HandlerInit {
 #[async_trait::async_trait]
 pub trait HandlerLoop {
     async fn issue_reject(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
-    async fn issue_faliure(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
+    async fn issue_failure(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
 
     async fn on_close(&mut self, by_peer: bool);
     async fn on_text_msg(

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -529,7 +529,7 @@ async fn on_req(
             handler.issue_reject(socket, file.clone()).await?;
         }
         ClientReq::Fail { file } => {
-            handler.issue_faliure(socket, file.clone()).await?;
+            handler.issue_failure(socket, file.clone()).await?;
         }
         ClientReq::Close => {
             debug!(logger, "Stopping client connection gracefuly");

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -127,7 +127,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
             if let Some(file) = self.xfer.file_by_subpath(&file_id) {
                 self.state
                     .transfer_manager
-                    .outgoing_ensure_file_not_rejected(self.xfer.id(), file.id())
+                    .outgoing_ensure_file_not_terminated(self.xfer.id(), file.id())
                     .await?;
             }
 

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -271,7 +271,7 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         Ok(())
     }
 
-    async fn issue_faliure(
+    async fn issue_failure(
         &mut self,
         socket: &mut WebSocket,
         file_id: FileId,

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{
     file::FileSubPath,
+    manager::FileTerminalState,
     protocol::v2,
     service::State,
     tasks::AliveGuard,
@@ -126,7 +127,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
             if let Err(err) = self
                 .state
                 .transfer_manager
-                .outgoing_finish_recv(self.xfer.id(), file.id(), true)
+                .outgoing_terminal_recv(self.xfer.id(), file.id(), FileTerminalState::Completed)
                 .await
             {
                 warn!(self.logger, "Failed to accept file as done: {err}");
@@ -212,7 +213,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                 match self
                     .state
                     .transfer_manager
-                    .outgoing_finish_recv(self.xfer.id(), file.id(), false)
+                    .outgoing_terminal_recv(self.xfer.id(), file.id(), FileTerminalState::Failed)
                     .await
                 {
                     Err(err) => {

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -19,6 +19,7 @@ use super::{
     WebSocket,
 };
 use crate::{
+    manager::FileTerminalState,
     protocol::v4,
     service::State,
     tasks::AliveGuard,
@@ -126,7 +127,7 @@ impl HandlerLoop<'_> {
         if let Err(err) = self
             .state
             .transfer_manager
-            .outgoing_finish_recv(self.xfer.id(), &file_id, true)
+            .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Completed)
             .await
         {
             warn!(self.logger, "Failed to accept file as done: {err}");
@@ -307,7 +308,7 @@ impl HandlerLoop<'_> {
             match self
                 .state
                 .transfer_manager
-                .outgoing_finish_recv(self.xfer.id(), &file_id, false)
+                .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Failed)
                 .await
             {
                 Err(err) => {

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -142,7 +142,7 @@ impl HandlerLoop<'_> {
             let make_report = async {
                 state
                     .transfer_manager
-                    .outgoing_ensure_file_not_rejected(xfer.id(), &file_id)
+                    .outgoing_ensure_file_not_terminated(xfer.id(), &file_id)
                     .await?;
 
                 let checksum = xfer.files()[&file_id].checksum(limit).await?;
@@ -185,7 +185,7 @@ impl HandlerLoop<'_> {
         let start = async {
             self.state
                 .transfer_manager
-                .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
+                .outgoing_ensure_file_not_terminated(self.xfer.id(), &file_id)
                 .await?;
 
             let start = || {

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -339,7 +339,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn issue_faliure(
+    async fn issue_failure(
         &mut self,
         socket: &mut WebSocket,
         file_id: FileId,

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -177,7 +177,7 @@ impl HandlerLoop<'_> {
             let make_report = async {
                 state
                     .transfer_manager
-                    .outgoing_ensure_file_not_rejected(xfer.id(), &file_id)
+                    .outgoing_ensure_file_not_terminated(xfer.id(), &file_id)
                     .await?;
 
                 let checksum = xfer.files()[&file_id].checksum(limit).await?;
@@ -222,7 +222,7 @@ impl HandlerLoop<'_> {
         let start = async {
             self.state
                 .transfer_manager
-                .outgoing_ensure_file_not_rejected(self.xfer.id(), &file_id)
+                .outgoing_ensure_file_not_terminated(self.xfer.id(), &file_id)
                 .await?;
 
             let start = || {

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use anyhow::Context;
+use drop_core::Status;
 use futures::SinkExt;
 use slog::{debug, error, info, warn};
 use tokio::{
@@ -115,37 +116,36 @@ impl HandlerLoop<'_> {
         }
     }
 
-    async fn on_reject(&mut self, file_id: FileId, by_peer: bool) {
-        info!(self.logger, "Rejecting file {file_id}, by_peer?: {by_peer}");
+    async fn on_reject(&mut self, file_id: FileId) {
+        info!(self.logger, "on reject file {file_id}");
 
-        if by_peer {
-            if let Err(err) = self
-                .state
-                .transfer_manager
-                .outgoing_rejection_recv(self.xfer.id(), &file_id)
-                .await
-            {
+        match self
+            .state
+            .transfer_manager
+            .outgoing_rejection_recv(self.xfer.id(), &file_id)
+            .await
+        {
+            Err(err) => {
                 error!(self.logger, "Failed to handler file rejection: {err}");
             }
+            Ok(res) => res.events.rejected(true).await,
         }
 
-        if let Some(task) = self.tasks.remove(&file_id) {
+        self.stop_task(&file_id, Status::FileRejected).await;
+    }
+
+    async fn stop_task(&mut self, file_id: &FileId, status: Status) {
+        if let Some(task) = self.tasks.remove(file_id) {
             if !task.job.is_finished() {
-                task.job.abort();
-                task.events.cancelled_on_rejection().await;
-            }
-        }
+                debug!(
+                    self.logger,
+                    "Aborting upload job: {}:{file_id}",
+                    self.xfer.id()
+                );
 
-        if by_peer {
-            self.state
-                .event_tx
-                .send(crate::Event::FileUploadRejected {
-                    transfer_id: self.xfer.id(),
-                    file_id,
-                    by_peer,
-                })
-                .await
-                .expect("Event channel should be open");
+                task.job.abort();
+                task.events.stop_silent(status).await;
+            }
         }
     }
 
@@ -198,7 +198,7 @@ impl HandlerLoop<'_> {
 
                 let checksum = xfer.files()[&file_id].checksum(limit).await?;
 
-                anyhow::Ok(prot::ReportChsum {
+                crate::Result::Ok(prot::ReportChsum {
                     file: file_id.clone(),
                     limit,
                     checksum,
@@ -214,17 +214,22 @@ impl HandlerLoop<'_> {
                 Err(err) => {
                     error!(logger, "Failed to report checksum: {:?}", err);
 
-                    if let Err(err) = state
+                    let msg = err.to_string();
+
+                    match state
                         .transfer_manager
                         .outgoing_failure_post(xfer.id(), &file_id)
                         .await
                     {
-                        warn!(logger, "Failed to post failure {err:?}");
+                        Err(err) => {
+                            warn!(logger, "Failed to post failure {err:?}");
+                        }
+                        Ok(res) => res.events.failed(err).await,
                     }
 
                     let msg = prot::Error {
                         file: Some(file_id.clone()),
-                        msg: err.to_string(),
+                        msg,
                     };
                     let _ = msg_tx
                         .send(MsgToSend {
@@ -316,28 +321,25 @@ impl HandlerLoop<'_> {
         );
 
         if let Some(file_id) = file_id {
-            if let Err(err) = self
+            match self
                 .state
                 .transfer_manager
                 .outgoing_finish_recv(self.xfer.id(), &file_id, false)
                 .await
             {
-                warn!(self.logger, "Failed to accept failure: {err}");
-            }
-
-            if let Some(task) = self.tasks.remove(&file_id) {
-                if !task.job.is_finished() {
-                    task.job.abort();
+                Err(err) => {
+                    warn!(self.logger, "Failed to accept failure: {err}");
                 }
-
-                task.events
-                    .failed(crate::Error::BadTransferState(format!(
-                        "Receiver reported an error: {msg}"
-                    )))
-                    .await;
-
-                self.done.insert(file_id);
+                Ok(res) => {
+                    res.events
+                        .failed(crate::Error::BadTransferState(format!(
+                            "Receiver reported an error: {msg}"
+                        )))
+                        .await;
+                }
             }
+
+            self.stop_task(&file_id, Status::BadTransferState).await;
         }
     }
 }
@@ -354,11 +356,21 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         });
         socket.send(Message::from(&msg)).await?;
 
-        self.state
-            .transfer_manager
-            .outgoing_rejection_ack(self.xfer.id(), &file_id)
-            .await?;
-        self.on_reject(file_id, false).await;
+        self.stop_task(&file_id, Status::FileRejected).await;
+
+        Ok(())
+    }
+
+    async fn issue_faliure(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let msg = prot::ClientMsg::Error(prot::Error {
+            file: Some(file_id),
+            msg: String::from("File failed elsewhere"),
+        });
+        socket.send(Message::from(&msg)).await?;
 
         Ok(())
     }
@@ -406,7 +418,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
                 self.on_start(socket, jobs, file, offset).await?
             }
             prot::ServerMsg::Cancel(prot::Cancel { file }) => self.on_cancel(file, true).await,
-            prot::ServerMsg::Reject(prot::Reject { file }) => self.on_reject(file, true).await,
+            prot::ServerMsg::Reject(prot::Reject { file }) => self.on_reject(file).await,
         }
         Ok(())
     }
@@ -415,7 +427,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         debug!(self.logger, "Waiting for background jobs to finish");
 
         let tasks = self.tasks.drain().map(|(_, task)| async move {
-            task.events.cancel_silent().await;
+            task.events.stop_silent(Status::Canceled).await;
         });
 
         futures::future::join_all(tasks).await;

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -6,17 +6,24 @@ use std::{
 
 use anyhow::Context;
 use futures::SinkExt;
-use slog::{debug, error, info};
+use slog::{debug, error, info, warn};
 use tokio::{
     sync::mpsc::Sender,
     task::{AbortHandle, JoinSet},
 };
 use tokio_tungstenite::tungstenite::Message;
 
-use super::{handler, WebSocket};
+use super::{
+    handler::{self, MsgToSend},
+    WebSocket,
+};
 use crate::{
-    protocol::v5 as prot, service::State, tasks::AliveGuard, transfer::Transfer,
-    ws::events::FileEventTx, FileId, OutgoingTransfer,
+    protocol::v5 as prot,
+    service::State,
+    tasks::AliveGuard,
+    transfer::Transfer,
+    ws::{client::handler::Ack, events::FileEventTx},
+    FileId, OutgoingTransfer,
 };
 
 pub struct HandlerInit<'a> {
@@ -29,7 +36,7 @@ pub struct HandlerLoop<'a> {
     state: &'a Arc<State>,
     logger: &'a slog::Logger,
     alive: &'a AliveGuard,
-    upload_tx: Sender<Message>,
+    upload_tx: Sender<MsgToSend>,
     tasks: HashMap<FileId, FileTask>,
     done: HashSet<FileId>,
     xfer: Arc<OutgoingTransfer>,
@@ -41,7 +48,7 @@ struct FileTask {
 }
 
 struct Uploader {
-    sink: Sender<Message>,
+    sink: Sender<MsgToSend>,
     file_id: FileId,
     offset: u64,
 }
@@ -75,7 +82,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
         Ok(())
     }
 
-    fn upgrade(self, upload_tx: Sender<Message>, xfer: Arc<OutgoingTransfer>) -> Self::Loop {
+    fn upgrade(self, upload_tx: Sender<MsgToSend>, xfer: Arc<OutgoingTransfer>) -> Self::Loop {
         let Self {
             state,
             logger,
@@ -149,6 +156,15 @@ impl HandlerLoop<'_> {
     }
 
     async fn on_done(&mut self, file_id: FileId) {
+        if let Err(err) = self
+            .state
+            .transfer_manager
+            .outgoing_finish_recv(self.xfer.id(), &file_id, true)
+            .await
+        {
+            warn!(self.logger, "Failed to accept file as done: {err}");
+        }
+
         if let Some(task) = self.tasks.remove(&file_id) {
             task.events.success().await;
         } else if !self.done.contains(&file_id) {
@@ -192,18 +208,29 @@ impl HandlerLoop<'_> {
             match make_report.await {
                 Ok(report) => {
                     let _ = msg_tx
-                        .send(Message::from(&prot::ClientMsg::ReportChsum(report)))
+                        .send(MsgToSend::from(&prot::ClientMsg::ReportChsum(report)))
                         .await;
                 }
                 Err(err) => {
                     error!(logger, "Failed to report checksum: {:?}", err);
 
+                    if let Err(err) = state
+                        .transfer_manager
+                        .outgoing_failure_post(xfer.id(), &file_id)
+                        .await
+                    {
+                        warn!(logger, "Failed to post failure {err:?}");
+                    }
+
                     let msg = prot::Error {
-                        file: Some(file_id),
+                        file: Some(file_id.clone()),
                         msg: err.to_string(),
                     };
                     let _ = msg_tx
-                        .send(Message::from(&prot::ClientMsg::Error(msg)))
+                        .send(MsgToSend {
+                            msg: Message::from(&prot::ClientMsg::Error(msg)),
+                            ack: Some(Ack::Finished(file_id)),
+                        })
                         .await;
                 }
             }
@@ -289,6 +316,15 @@ impl HandlerLoop<'_> {
         );
 
         if let Some(file_id) = file_id {
+            if let Err(err) = self
+                .state
+                .transfer_manager
+                .outgoing_finish_recv(self.xfer.id(), &file_id, false)
+                .await
+            {
+                warn!(self.logger, "Failed to accept failure: {err}");
+            }
+
             if let Some(task) = self.tasks.remove(&file_id) {
                 if !task.job.is_finished() {
                     task.job.abort();
@@ -418,7 +454,10 @@ impl handler::Uploader for Uploader {
         };
 
         self.sink
-            .send(Message::from(msg))
+            .send(MsgToSend {
+                msg: Message::from(msg),
+                ack: None,
+            })
             .await
             .map_err(|_| crate::Error::Canceled)?;
 
@@ -431,7 +470,13 @@ impl handler::Uploader for Uploader {
             msg,
         });
 
-        let _ = self.sink.send(Message::from(&msg)).await;
+        let _ = self
+            .sink
+            .send(MsgToSend {
+                msg: Message::from(&msg),
+                ack: Some(Ack::Finished(self.file_id.clone())),
+            })
+            .await;
     }
 
     fn offset(&self) -> u64 {

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -358,7 +358,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn issue_faliure(
+    async fn issue_failure(
         &mut self,
         socket: &mut WebSocket,
         file_id: FileId,

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -19,6 +19,7 @@ use super::{
     WebSocket,
 };
 use crate::{
+    manager::FileTerminalState,
     protocol::v5 as prot,
     service::State,
     tasks::AliveGuard,
@@ -122,7 +123,7 @@ impl HandlerLoop<'_> {
         match self
             .state
             .transfer_manager
-            .outgoing_rejection_recv(self.xfer.id(), &file_id)
+            .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Rejected)
             .await
         {
             Err(err) => {
@@ -159,7 +160,7 @@ impl HandlerLoop<'_> {
         if let Err(err) = self
             .state
             .transfer_manager
-            .outgoing_finish_recv(self.xfer.id(), &file_id, true)
+            .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Completed)
             .await
         {
             warn!(self.logger, "Failed to accept file as done: {err}");
@@ -324,7 +325,7 @@ impl HandlerLoop<'_> {
             match self
                 .state
                 .transfer_manager
-                .outgoing_finish_recv(self.xfer.id(), &file_id, false)
+                .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Failed)
                 .await
             {
                 Err(err) => {

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -44,6 +44,8 @@ pub trait HandlerLoop {
     ) -> anyhow::Result<()>;
     async fn issue_cancel(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
     async fn issue_reject(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
+    async fn issue_failure(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
+    async fn issue_done(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
 
     async fn on_close(&mut self, by_peer: bool);
     async fn on_text_msg(&mut self, ws: &mut WebSocket, text: &str) -> anyhow::Result<()>;

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -5,14 +5,8 @@ use warp::ws::{Message, WebSocket};
 
 use crate::{transfer::IncomingTransfer, utils::Hidden, ws, FileId};
 
-#[derive(Debug)]
-pub enum Ack {
-    Finished(FileId),
-}
-
 pub struct MsgToSend {
     pub msg: Message,
-    pub ack: Option<Ack>,
 }
 
 #[async_trait::async_trait]
@@ -83,9 +77,6 @@ where
     T: Into<Message>,
 {
     fn from(value: T) -> Self {
-        Self {
-            msg: value.into(),
-            ack: None,
-        }
+        Self { msg: value.into() }
     }
 }

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -206,7 +206,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finish_download(self.xfer.id(), file_id)
+                        .incoming_download_cancel(self.xfer.id(), file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::Context;
 use drop_config::DropConfig;
+use drop_core::Status;
 use futures::{SinkExt, StreamExt};
 use sha1::Digest;
 use slog::{debug, error, warn};
@@ -176,6 +177,26 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         }
     }
 
+    async fn stop_task(&mut self, file_subpath: &FileSubPath, status: Status) {
+        if let Some(FileTask {
+            job: task,
+            events,
+            chunks_tx: _,
+        }) = self.jobs.remove(file_subpath)
+        {
+            if !task.is_finished() {
+                debug!(
+                    self.logger,
+                    "Aborting download job: {}:{file_subpath:?}",
+                    self.xfer.id()
+                );
+
+                task.abort();
+                events.stop_silent(status).await;
+            }
+        }
+    }
+
     async fn on_error(&mut self, file: Option<FileSubPath>, msg: String) {
         error!(
             self.logger,
@@ -184,53 +205,26 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
 
         if let Some(file) = file {
             if let Some(file) = self.xfer.file_by_subpath(&file) {
-                if let Err(err) = self
+                match self
                     .state
                     .transfer_manager
                     .incoming_failure_recv(self.xfer.id(), file.id())
                     .await
                 {
-                    warn!(self.logger, "Failed to accept failure: {err}");
-                }
-            }
-
-            if let Some(FileTask {
-                job: task,
-                events,
-                chunks_tx: _,
-            }) = self.jobs.remove(&file)
-            {
-                if !task.is_finished() {
-                    let file_id = self
-                        .xfer
-                        .file_by_subpath(&file)
-                        .expect("File should be there since we have a task registered")
-                        .id();
-
-                    debug!(
-                        self.logger,
-                        "Aborting download job: {}:{file_id}",
-                        self.xfer.id()
-                    );
-
-                    task.abort();
-
-                    if let Err(err) = self
-                        .state
-                        .transfer_manager
-                        .incoming_download_cancel(self.xfer.id(), file_id)
-                        .await
-                    {
-                        warn!(self.logger, "Failed to store download finish: {err}");
+                    Err(err) => {
+                        warn!(self.logger, "Failed to accept failure: {err}");
                     }
-
-                    events
-                        .failed(crate::Error::BadTransferState(format!(
-                            "Sender reported an error: {msg}"
-                        )))
-                        .await;
+                    Ok(res) => {
+                        res.events
+                            .failed(crate::Error::BadTransferState(format!(
+                                "Sender reported an error: {msg}"
+                            )))
+                            .await;
+                    }
                 }
             }
+
+            self.stop_task(&file, Status::FileRejected).await;
         }
     }
 
@@ -238,7 +232,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
         debug!(self.logger, "Stopping silently");
 
         let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.cancel_silent().await;
+            task.events.stop_silent(Status::Canceled).await;
         });
 
         futures::future::join_all(tasks).await;
@@ -338,23 +332,45 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         });
         socket.send(Message::from(&msg)).await?;
 
-        self.state
-            .transfer_manager
-            .incoming_rejection_ack(self.xfer.id(), &file_id)
-            .await?;
+        self.stop_task(&file_subpath, Status::FileRejected).await;
 
-        if let Some(FileTask {
-            job: task,
-            events,
-            chunks_tx: _,
-        }) = self.jobs.remove(&file_subpath)
-        {
-            if !task.is_finished() {
-                task.abort();
-                events.cancelled_on_rejection().await;
-            }
-        }
+        Ok(())
+    }
 
+    async fn issue_failure(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let file_subpath = if let Some(file) = self.xfer.files().get(&file_id) {
+            file.subpath().clone()
+        } else {
+            warn!(self.logger, "Missing file with ID: {file_id:?}");
+            return Ok(());
+        };
+
+        let msg = v2::ServerMsg::Error(v2::Error {
+            file: Some(file_subpath),
+            msg: String::from("File failed elsewhere"),
+        });
+        socket.send(Message::from(&msg)).await?;
+
+        Ok(())
+    }
+
+    async fn issue_done(&mut self, socket: &mut WebSocket, file_id: FileId) -> anyhow::Result<()> {
+        let file = if let Some(file) = self.xfer.files().get(&file_id) {
+            file
+        } else {
+            warn!(self.logger, "Missing file with ID: {file_id:?}");
+            return Ok(());
+        };
+
+        let msg = v2::ServerMsg::Done(v2::Progress {
+            bytes_transfered: file.size(),
+            file: file.subpath().clone(),
+        });
+        socket.send(Message::from(&msg)).await?;
         Ok(())
     }
 

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -22,6 +22,7 @@ use warp::ws::{Message, WebSocket};
 use super::handler::{self, Ack, MsgToSend};
 use crate::{
     file::FileSubPath,
+    manager::FileTerminalState,
     protocol::v2,
     service::State,
     tasks::AliveGuard,
@@ -208,7 +209,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                 match self
                     .state
                     .transfer_manager
-                    .incoming_failure_recv(self.xfer.id(), file.id())
+                    .incoming_terminal_recv(self.xfer.id(), file.id(), FileTerminalState::Failed)
                     .await
                 {
                     Err(err) => {

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -14,7 +14,7 @@ use tokio::{
 };
 use warp::ws::{Message, WebSocket};
 
-use super::handler;
+use super::handler::{self, Ack, MsgToSend};
 use crate::{
     file,
     protocol::v4,
@@ -37,7 +37,7 @@ pub struct HandlerLoop<'a> {
     state: Arc<State>,
     logger: &'a slog::Logger,
     alive: &'a AliveGuard,
-    msg_tx: Sender<Message>,
+    msg_tx: Sender<MsgToSend>,
     xfer: Arc<IncomingTransfer>,
     jobs: HashMap<FileId, FileTask>,
     checksums: HashMap<FileId, Arc<AsyncCell<[u8; 32]>>>,
@@ -46,7 +46,7 @@ pub struct HandlerLoop<'a> {
 struct Downloader {
     logger: slog::Logger,
     file_id: FileId,
-    msg_tx: Sender<Message>,
+    msg_tx: Sender<MsgToSend>,
     csum_rx: mpsc::Receiver<v4::ReportChsum>,
     full_csum: Arc<AsyncCell<[u8; 32]>>,
     offset: u64,
@@ -112,7 +112,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
         mut self,
         ws: &mut WebSocket,
         jobs: &mut JoinSet<()>,
-        msg_tx: Sender<Message>,
+        msg_tx: Sender<MsgToSend>,
         xfer: Arc<IncomingTransfer>,
     ) -> Option<Self::Loop> {
         let task = async {
@@ -249,6 +249,15 @@ impl HandlerLoop<'_> {
         );
 
         if let Some(file_id) = file_id {
+            if let Err(err) = self
+                .state
+                .transfer_manager
+                .incoming_failure_recv(self.xfer.id(), &file_id)
+                .await
+            {
+                warn!(self.logger, "Failed to accept failure: {err}");
+            }
+
             if let Some(FileTask {
                 job: task,
                 events,
@@ -530,7 +539,17 @@ impl Drop for HandlerLoop<'_> {
 impl Downloader {
     async fn send(&mut self, msg: impl Into<Message>) -> crate::Result<()> {
         self.msg_tx
-            .send(msg.into())
+            .send(msg.into().into())
+            .await
+            .map_err(|_| crate::Error::Canceled)
+    }
+
+    async fn send_with_ack(&mut self, msg: impl Into<Message>, ack: Ack) -> crate::Result<()> {
+        self.msg_tx
+            .send(MsgToSend {
+                msg: msg.into(),
+                ack: Some(ack),
+            })
             .await
             .map_err(|_| crate::Error::Canceled)
     }
@@ -648,18 +667,24 @@ impl handler::Downloader for Downloader {
     }
 
     async fn done(&mut self, bytes: u64) -> crate::Result<()> {
-        self.send(&v4::ServerMsg::Done(v4::Done {
-            file: self.file_id.clone(),
-            bytes_transfered: bytes,
-        }))
+        self.send_with_ack(
+            &v4::ServerMsg::Done(v4::Done {
+                file: self.file_id.clone(),
+                bytes_transfered: bytes,
+            }),
+            Ack::Finished(self.file_id.clone()),
+        )
         .await
     }
 
     async fn error(&mut self, msg: String) -> crate::Result<()> {
-        self.send(&v4::ServerMsg::Error(v4::Error {
-            file: Some(self.file_id.clone()),
-            msg,
-        }))
+        self.send_with_ack(
+            &v4::ServerMsg::Error(v4::Error {
+                file: Some(self.file_id.clone()),
+                msg,
+            }),
+            Ack::Finished(self.file_id.clone()),
+        )
         .await
     }
 

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -268,7 +268,7 @@ impl HandlerLoop<'_> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finish_download(self.xfer.id(), &file_id)
+                        .incoming_download_cancel(self.xfer.id(), &file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::Context;
 use async_cell::sync::AsyncCell;
 use drop_config::DropConfig;
+use drop_core::Status;
 use futures::{SinkExt, StreamExt};
 use slog::{debug, error, info, warn};
 use tokio::{
@@ -242,6 +243,27 @@ impl HandlerLoop<'_> {
         }
     }
 
+    async fn stop_task(&mut self, file_id: &FileId, status: Status) {
+        if let Some(FileTask {
+            job: task,
+            events,
+            chunks_tx: _,
+            csum_tx: _,
+        }) = self.jobs.remove(file_id)
+        {
+            if !task.is_finished() {
+                debug!(
+                    self.logger,
+                    "Aborting download job: {}:{file_id}",
+                    self.xfer.id()
+                );
+
+                task.abort();
+                events.stop_silent(status).await;
+            }
+        }
+    }
+
     async fn on_error(&mut self, file_id: Option<FileId>, msg: String) {
         error!(
             self.logger,
@@ -249,47 +271,25 @@ impl HandlerLoop<'_> {
         );
 
         if let Some(file_id) = file_id {
-            if let Err(err) = self
+            match self
                 .state
                 .transfer_manager
                 .incoming_failure_recv(self.xfer.id(), &file_id)
                 .await
             {
-                warn!(self.logger, "Failed to accept failure: {err}");
-            }
-
-            if let Some(FileTask {
-                job: task,
-                events,
-                chunks_tx: _,
-                csum_tx: _,
-            }) = self.jobs.remove(&file_id)
-            {
-                if !task.is_finished() {
-                    debug!(
-                        self.logger,
-                        "Aborting download job: {}:{file_id}",
-                        self.xfer.id()
-                    );
-
-                    task.abort();
-
-                    if let Err(err) = self
-                        .state
-                        .transfer_manager
-                        .incoming_download_cancel(self.xfer.id(), &file_id)
-                        .await
-                    {
-                        warn!(self.logger, "Failed to store download finish: {err}");
-                    }
-
-                    events
+                Err(err) => {
+                    warn!(self.logger, "Failed to accept failure: {err}");
+                }
+                Ok(res) => {
+                    res.events
                         .failed(crate::Error::BadTransferState(format!(
                             "Sender reported an error: {msg}"
                         )))
                         .await;
                 }
             }
+
+            self.stop_task(&file_id, Status::BadTransferState).await;
         }
     }
 
@@ -330,7 +330,7 @@ impl HandlerLoop<'_> {
         debug!(self.logger, "Stopping silently");
 
         let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.cancel_silent().await;
+            task.events.stop_silent(Status::Canceled).await;
         });
 
         futures::future::join_all(tasks).await;
@@ -419,31 +419,37 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         socket: &mut WebSocket,
         file_id: FileId,
     ) -> anyhow::Result<()> {
-        debug!(self.logger, "ServerHandler::issue_cancel");
-
         let msg = v4::ServerMsg::Cancel(v4::Cancel {
             file: file_id.clone(),
         });
         socket.send(Message::from(&msg)).await?;
 
-        self.state
-            .transfer_manager
-            .incoming_rejection_ack(self.xfer.id(), &file_id)
-            .await?;
+        self.stop_task(&file_id, Status::FileRejected).await;
+        Ok(())
+    }
 
-        if let Some(FileTask {
-            job: task,
-            events,
-            chunks_tx: _,
-            csum_tx: _,
-        }) = self.jobs.remove(&file_id)
-        {
-            if !task.is_finished() {
-                task.abort();
-                events.cancelled_on_rejection().await;
-            }
-        }
+    async fn issue_failure(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let msg = v4::ServerMsg::Error(v4::Error {
+            file: Some(file_id),
+            msg: String::from("File failed elsewhere"),
+        });
+        socket.send(Message::from(&msg)).await?;
 
+        Ok(())
+    }
+
+    async fn issue_done(&mut self, socket: &mut WebSocket, file_id: FileId) -> anyhow::Result<()> {
+        let file = self.xfer.files().get(&file_id).context("Invalid file")?;
+
+        let msg = v4::ServerMsg::Done(v4::Done {
+            file: file_id,
+            bytes_transfered: file.size(),
+        });
+        socket.send(Message::from(&msg)).await?;
         Ok(())
     }
 

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -18,6 +18,7 @@ use warp::ws::{Message, WebSocket};
 use super::handler::{self, Ack, MsgToSend};
 use crate::{
     file,
+    manager::FileTerminalState,
     protocol::v4,
     service::State,
     tasks::AliveGuard,
@@ -274,7 +275,7 @@ impl HandlerLoop<'_> {
             match self
                 .state
                 .transfer_manager
-                .incoming_failure_recv(self.xfer.id(), &file_id)
+                .incoming_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Failed)
                 .await
             {
                 Err(err) => {

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -18,6 +18,7 @@ use warp::ws::{Message, WebSocket};
 use super::handler::{self, Ack, MsgToSend};
 use crate::{
     file::{self, FileToRecv},
+    manager::FileTerminalState,
     protocol::v5 as prot,
     service::State,
     tasks::AliveGuard,
@@ -249,7 +250,7 @@ impl HandlerLoop<'_> {
         match self
             .state
             .transfer_manager
-            .incoming_rejection_recv(self.xfer.id(), &file_id)
+            .incoming_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Rejected)
             .await
         {
             Err(err) => {
@@ -292,7 +293,7 @@ impl HandlerLoop<'_> {
             match self
                 .state
                 .transfer_manager
-                .incoming_failure_recv(self.xfer.id(), &file_id)
+                .incoming_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Failed)
                 .await
             {
                 Err(err) => {

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -6,6 +6,7 @@ use std::{
 use anyhow::Context;
 use async_cell::sync::AsyncCell;
 use drop_config::DropConfig;
+use drop_core::Status;
 use futures::{SinkExt, StreamExt};
 use slog::{debug, error, info, warn};
 use tokio::{
@@ -242,43 +243,42 @@ impl HandlerLoop<'_> {
         }
     }
 
-    async fn on_reject(&mut self, file_id: FileId, by_peer: bool) {
-        info!(self.logger, "Rejecting file {file_id}, by_peer?: {by_peer}");
+    async fn on_reject(&mut self, file_id: FileId) {
+        info!(self.logger, "On reject file {file_id}");
 
-        if by_peer {
-            if let Err(err) = self
-                .state
-                .transfer_manager
-                .incoming_rejection_recv(self.xfer.id(), &file_id)
-                .await
-            {
+        match self
+            .state
+            .transfer_manager
+            .incoming_rejection_recv(self.xfer.id(), &file_id)
+            .await
+        {
+            Err(err) => {
                 error!(self.logger, "Failed to handler file rejection: {err}");
             }
+            Ok(res) => res.events.rejected(true).await,
         }
 
+        self.stop_task(&file_id, Status::FileRejected).await;
+    }
+
+    async fn stop_task(&mut self, file_id: &FileId, status: Status) {
         if let Some(FileTask {
             job: task,
             events,
             chunks_tx: _,
             csum_tx: _,
-        }) = self.jobs.remove(&file_id)
+        }) = self.jobs.remove(file_id)
         {
             if !task.is_finished() {
-                task.abort();
-                events.cancelled_on_rejection().await;
-            }
-        }
+                debug!(
+                    self.logger,
+                    "Aborting download job: {}:{file_id}",
+                    self.xfer.id()
+                );
 
-        if by_peer {
-            self.state
-                .event_tx
-                .send(crate::Event::FileDownloadRejected {
-                    transfer_id: self.xfer.id(),
-                    file_id,
-                    by_peer,
-                })
-                .await
-                .expect("Event channel should be open");
+                task.abort();
+                events.stop_silent(status).await;
+            }
         }
     }
 
@@ -289,47 +289,25 @@ impl HandlerLoop<'_> {
         );
 
         if let Some(file_id) = file_id {
-            if let Err(err) = self
+            match self
                 .state
                 .transfer_manager
                 .incoming_failure_recv(self.xfer.id(), &file_id)
                 .await
             {
-                warn!(self.logger, "Failed to accept failure: {err}");
-            }
-
-            if let Some(FileTask {
-                job: task,
-                events,
-                chunks_tx: _,
-                csum_tx: _,
-            }) = self.jobs.remove(&file_id)
-            {
-                if !task.is_finished() {
-                    debug!(
-                        self.logger,
-                        "Aborting download job: {}:{file_id}",
-                        self.xfer.id()
-                    );
-
-                    task.abort();
-
-                    if let Err(err) = self
-                        .state
-                        .transfer_manager
-                        .incoming_download_cancel(self.xfer.id(), &file_id)
-                        .await
-                    {
-                        warn!(self.logger, "Failed to store download finish: {err}");
-                    }
-
-                    events
+                Err(err) => {
+                    warn!(self.logger, "Failed to accept failure: {err}");
+                }
+                Ok(res) => {
+                    res.events
                         .failed(crate::Error::BadTransferState(format!(
                             "Sender reported an error: {msg}"
                         )))
                         .await;
                 }
             }
+
+            self.stop_task(&file_id, Status::BadTransferState).await;
         }
     }
 
@@ -370,7 +348,7 @@ impl HandlerLoop<'_> {
         debug!(self.logger, "Stopping silently");
 
         let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.cancel_silent().await;
+            task.events.stop_silent(Status::Canceled).await;
         });
 
         futures::future::join_all(tasks).await;
@@ -464,12 +442,32 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         });
         socket.send(Message::from(&msg)).await?;
 
-        self.state
-            .transfer_manager
-            .incoming_rejection_ack(self.xfer.id(), &file_id)
-            .await?;
-        self.on_reject(file_id, false).await;
+        self.stop_task(&file_id, Status::FileRejected).await;
+        Ok(())
+    }
 
+    async fn issue_failure(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+    ) -> anyhow::Result<()> {
+        let msg = prot::ServerMsg::Error(prot::Error {
+            file: Some(file_id),
+            msg: String::from("File failed elsewhere"),
+        });
+        socket.send(Message::from(&msg)).await?;
+
+        Ok(())
+    }
+
+    async fn issue_done(&mut self, socket: &mut WebSocket, file_id: FileId) -> anyhow::Result<()> {
+        let file = self.xfer.files().get(&file_id).context("Invalid file")?;
+
+        let msg = prot::ServerMsg::Done(prot::Done {
+            file: file_id,
+            bytes_transfered: file.size(),
+        });
+        socket.send(Message::from(&msg)).await?;
         Ok(())
     }
 
@@ -498,7 +496,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             prot::ClientMsg::Error(prot::Error { file, msg }) => self.on_error(file, msg).await,
             prot::ClientMsg::Cancel(prot::Cancel { file }) => self.on_cancel(file, true).await,
             prot::ClientMsg::ReportChsum(report) => self.on_checksum(report).await,
-            prot::ClientMsg::Reject(prot::Reject { file }) => self.on_reject(file, true).await,
+            prot::ClientMsg::Reject(prot::Reject { file }) => self.on_reject(file).await,
         }
         Ok(())
     }

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -308,7 +308,7 @@ impl HandlerLoop<'_> {
                     if let Err(err) = self
                         .state
                         .transfer_manager
-                        .incoming_finish_download(self.xfer.id(), &file_id)
+                        .incoming_download_cancel(self.xfer.id(), &file_id)
                         .await
                     {
                         warn!(self.logger, "Failed to store download finish: {err}");

--- a/test/drop_test/error.py
+++ b/test/drop_test/error.py
@@ -36,3 +36,6 @@ class Error(IntEnum):
     DB_LOST = (32,)
     FILE_CHECKSUM_MISMATCH = (33,)
     FILE_REJECTED = (34,)
+    FILE_PAUSED = (35,)
+    FILE_FAILED = (36,)
+    FILE_FINISHED = (37,)


### PR DESCRIPTION
This is an attempt to:
* make Rejected, Success, and Failure a terminal state
* do not allow operations on terminated files
* emit events appropriately upon state transition
* sync state transitions upon transfer restoration

A bulk of work is done in the `TransferManager` and the database. The server and client handlers code is basically just adjusted to the changes