### PR TITLE
Update developer logs for database creation

### DIFF
--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -667,64 +667,68 @@ fn open_database(
 ) -> Result<drop_storage::Storage> {
     match drop_storage::Storage::new(logger.clone(), dbpath) {
         Ok(storage) => return Ok(storage),
-        Err(err) => error!(logger, "Failed to open DB at \"{dbpath}\": {err}",),
-    }
+        Err(err) => {
+            error!(logger, "Failed to open DB at \"{dbpath}\": {err}",);
 
-    // If we can't even open the DB in memory, there is nothing else left to do,
-    // throw an error
-    if dbpath == ":memory:" {
-        let error = ffi::types::NORDDROP_RES_DB_ERROR;
-        let error_msg = "Failed to open in-memory DB";
-        moose.developer_exception(
-            error as i32,
-            "".to_string(),
-            error_msg.to_string(),
-            "Database Error".to_string(),
-        );
-
-        error!(logger, "{}", error_msg);
-        Err(error)
-    } else {
-        moose.developer_exception(
-            ffi::types::NORDDROP_RES_DB_ERROR as i32,
-            "Initial DB open failed, recreating".to_string(),
-            "Failed to open database".to_string(),
-            "Database Error".to_string(),
-        );
-        // Still problems? Let's try to delete the file, provided it's not in memory
-        warn!(logger, "Removing old DB file");
-        if let Err(err) = std::fs::remove_file(dbpath) {
-            let error_msg = format!("Failed to open DB and failed to remove it's file: {err}");
-            moose.developer_exception(
-                ffi::types::NORDDROP_RES_DB_ERROR as i32,
-                "".to_string(),
-                error_msg.to_string(),
-                "Database Error".to_string(),
-            );
-            error!(logger, "{}", error_msg);
-            // Try to at least open db in memory if the path doesn't work
-            return open_database(":memory:", events, logger, moose);
-        } else {
-            // Inform app that we wiped the old DB file
-            events.dispatch(types::Event::RuntimeError {
-                status: drop_core::Status::DbLost,
-            });
-        };
-
-        // Final try after cleaning up old DB file
-        match drop_storage::Storage::new(logger.clone(), dbpath) {
-            Ok(storage) => Ok(storage),
-            Err(err) => {
+            // If we can't even open the DB in memory, there is nothing else left to do,
+            // throw an error
+            if dbpath == ":memory:" {
                 let error = ffi::types::NORDDROP_RES_DB_ERROR;
-                let error_msg = format!("Failed to open DB after cleaning up old file: {err}");
                 moose.developer_exception(
                     error as i32,
-                    "".to_string(),
-                    error_msg.to_string(),
-                    "Database Error".to_string(),
+                    err.to_string(),
+                    "Failed to open in-memory DB".to_string(),
+                    "DB Error".to_string(),
                 );
-                error!(logger, "{}", error_msg);
+
                 Err(error)
+            } else {
+                moose.developer_exception(
+                    ffi::types::NORDDROP_RES_DB_ERROR as i32,
+                    "Initial DB open failed, recreating".to_string(),
+                    "Failed to open DB file".to_string(),
+                    "DB Error".to_string(),
+                );
+                // Still problems? Let's try to delete the file, provided it's not in memory
+                warn!(logger, "Removing old DB file");
+                if let Err(err) = std::fs::remove_file(dbpath) {
+                    moose.developer_exception(
+                        ffi::types::NORDDROP_RES_DB_ERROR as i32,
+                        err.to_string(),
+                        "Failed to remove old DB file".to_string(),
+                        "DB Error".to_string(),
+                    );
+                    error!(
+                        logger,
+                        "Failed to open DB and failed to remove it's file: {err}"
+                    );
+                    // Try to at least open db in memory if the path doesn't work
+                    return open_database(":memory:", events, logger, moose);
+                } else {
+                    // Inform app that we wiped the old DB file
+                    events.dispatch(types::Event::RuntimeError {
+                        status: drop_core::Status::DbLost,
+                    });
+                };
+
+                // Final try after cleaning up old DB file
+                match drop_storage::Storage::new(logger.clone(), dbpath) {
+                    Ok(storage) => Ok(storage),
+                    Err(err) => {
+                        let error = ffi::types::NORDDROP_RES_DB_ERROR;
+                        moose.developer_exception(
+                            error as i32,
+                            err.to_string(),
+                            "Failed to open DB after cleanup".to_string(),
+                            "Database Error".to_string(),
+                        );
+                        error!(
+                            logger,
+                            "Failed to open DB after cleaning up old file: {err}"
+                        );
+                        Err(error)
+                    }
+                }
             }
         }
     }

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -5071,8 +5071,8 @@ scenarios = [
                             "arbitrary_value": -1,
                             "code": 11,
                             "note": "Initial DB open failed, recreating",
-                            "message": "Failed to open database",
-                            "name": "Database Error"
+                            "message": "Failed to open DB file",
+                            "name": "DB Error"
                         }""",
                             """{
                             "type": "init",
@@ -5174,16 +5174,16 @@ scenarios = [
                             "arbitrary_value": -1,
                             "code": 11,
                             "note": "Initial DB open failed, recreating",
-                            "message": "Failed to open database",
-                            "name": "Database Error"
+                            "message": "Failed to open DB file",
+                            "name": "DB Error"
                         }""",
                             """{
                             "type": "exception",
                             "arbitrary_value": -1,
                             "code": 11,
-                            "note": "",
-                            "message": "Failed to open DB and failed to remove it's file: Permission denied (os error 13)",
-                            "name": "Database Error"
+                            "note": "Permission denied (os error 13)",
+                            "message": "Failed to remove old DB file",
+                            "name": "DB Error"
                         }""",
                             """{
                             "type": "init",


### PR DESCRIPTION
Since we decided to use the developer events to catch potential errors in the database creation process, to make the data aggregation step easier, I've shortened the error messages and made them static, so it would be easier to group the error stages and in addition, moved the actual error messages in the notes, allowing us to have finer grained detail on what went wrong, if we need it