### PR TITLE
Ensure `Paused` events are emited when stop() is called

### DIFF
--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -30,7 +30,6 @@ pub trait HandlerLoop {
         text: String,
     ) -> anyhow::Result<()>;
     async fn on_stop(&mut self);
-    async fn on_conn_break(&mut self);
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration>;
 }

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -352,16 +352,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         futures::future::join_all(tasks).await;
     }
 
-    async fn on_conn_break(&mut self) {
-        debug!(self.logger, "Waiting for background jobs to pause");
-
-        let tasks = self.tasks.drain().map(|(_, task)| async move {
-            task.events.pause().await;
-        });
-
-        futures::future::join_all(tasks).await;
-    }
-
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
         Some(
             self.state
@@ -375,6 +365,15 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping client handler");
+
+        let jobs = std::mem::take(&mut self.tasks);
+        tokio::spawn(async move {
+            let tasks = jobs.into_values().map(|task| async move {
+                task.events.pause().await;
+            });
+
+            futures::future::join_all(tasks).await;
+        });
     }
 }
 

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -39,9 +39,7 @@ pub trait HandlerLoop {
     async fn on_text_msg(&mut self, ws: &mut WebSocket, text: &str) -> anyhow::Result<()>;
     async fn on_bin_msg(&mut self, ws: &mut WebSocket, bytes: Vec<u8>) -> anyhow::Result<()>;
 
-    async fn on_stop(&mut self);
     async fn finalize_success(self);
-    async fn on_conn_break(&mut self);
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration>;
 }

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -356,6 +356,16 @@ impl HandlerLoop<'_> {
             }
         }
     }
+
+    async fn on_stop(&mut self) {
+        debug!(self.logger, "Stopping silently");
+
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.cancel_silent().await;
+        });
+
+        futures::future::join_all(tasks).await;
+    }
 }
 
 #[async_trait::async_trait]
@@ -493,17 +503,10 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn on_stop(&mut self) {
-        debug!(self.logger, "Waiting for background jobs to finish");
+    async fn finalize_success(mut self) {
+        debug!(self.logger, "Finalizing");
+        self.on_stop().await;
 
-        let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.cancel_silent().await;
-        });
-
-        futures::future::join_all(tasks).await;
-    }
-
-    async fn finalize_success(self) {
         let files = self
             .state
             .storage
@@ -525,16 +528,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         }
     }
 
-    async fn on_conn_break(&mut self) {
-        debug!(self.logger, "Waiting for background jobs to pause");
-
-        let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.pause().await;
-        });
-
-        futures::future::join_all(tasks).await;
-    }
-
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
         Some(
             self.state
@@ -548,6 +541,15 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 impl Drop for HandlerLoop<'_> {
     fn drop(&mut self) {
         debug!(self.logger, "Stopping server handler");
+
+        let jobs = std::mem::take(&mut self.jobs);
+        tokio::spawn(async move {
+            let tasks = jobs.into_values().map(|task| async move {
+                task.events.pause().await;
+            });
+
+            futures::future::join_all(tasks).await;
+        });
     }
 }
 


### PR DESCRIPTION
Emitting events in the handlers `Drop` implementation ensures they are constantly emitted.
This is a preparation for storing progress in the events, so test fixes and including the file progress in the events are going to be included in subsequent PRs