### PR TITLE
Use regex for matching the scenario names in the test runner

### DIFF
--- a/test/runner.py
+++ b/test/runner.py
@@ -7,6 +7,7 @@ import os
 import json
 import time
 import math
+import re
 
 STDERR_ERR_PATTERNS = [
     ["drop-storage", "ERROR"],
@@ -20,15 +21,13 @@ def run():
     scenarios = []
     if "SCENARIO" in os.environ:
         name = os.environ["SCENARIO"]
+        pattern = re.compile(name)
 
-        found = False
         for s in all_scenarios:
-            if s.id() == name:
-                found = True
-                scenarios = [s]
-                break
+            if pattern.fullmatch(s.id()):
+                scenarios.append(s)
 
-        if not found:
+        if len(scenarios) == 0:
             print(f"Unrecognized scenario: {name}")
             exit(1)
     else:


### PR DESCRIPTION
It enables things like running all 19-* test cases. Useful when testing only a slice of functionality, since a full test is always run on the CI