### PR TITLE
Store bytes transfered with paused and reject states

### DIFF
--- a/drop-storage/migrations/003-retries/up.sql
+++ b/drop-storage/migrations/003-retries/up.sql
@@ -47,3 +47,24 @@ CREATE TABLE IF NOT EXISTS sync_incoming_files_inflight (
  -- paths soft deletion
 ALTER TABLE incoming_paths ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT FALSE CHECK (is_deleted IN (FALSE, TRUE));
 ALTER TABLE outgoing_paths ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT FALSE CHECK (is_deleted IN (FALSE, TRUE));
+
+
+ -- storing progress
+ALTER TABLE incoming_path_reject_states ADD COLUMN bytes_received INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE outgoing_path_reject_states ADD COLUMN bytes_sent     INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS incoming_path_paused_states (
+  path_id INTEGER NOT NULL,
+  bytes_received INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  FOREIGN KEY(path_id) REFERENCES incoming_paths(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS outgoing_path_paused_states (
+  path_id INTEGER NOT NULL,
+  bytes_sent INTEGER NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+  FOREIGN KEY(path_id) REFERENCES outgoing_paths(id) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -275,6 +275,7 @@ pub struct OutgoingPath {
     pub relative_path: String,
     pub file_id: String,
     pub bytes: i64,
+    pub bytes_sent: i64,
     pub states: Vec<OutgoingPathStateEvent>,
 }
 
@@ -288,5 +289,6 @@ pub struct IncomingPath {
     pub relative_path: String,
     pub file_id: String,
     pub bytes: i64,
+    pub bytes_received: i64,
     pub states: Vec<IncomingPathStateEvent>,
 }

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -27,7 +27,9 @@ pub enum OutgoingPathStateEventData {
     #[serde(rename = "completed")]
     Completed,
     #[serde(rename = "rejected")]
-    Rejected { by_peer: bool },
+    Rejected { by_peer: bool, bytes_sent: i64 },
+    #[serde(rename = "paused")]
+    Paused { bytes_sent: i64 },
 }
 
 #[derive(Debug, Serialize)]
@@ -50,7 +52,9 @@ pub enum IncomingPathStateEventData {
     #[serde(rename = "completed")]
     Completed { final_path: String },
     #[serde(rename = "rejected")]
-    Rejected { by_peer: bool },
+    Rejected { by_peer: bool, bytes_received: i64 },
+    #[serde(rename = "paused")]
+    Paused { bytes_received: i64 },
 }
 
 #[derive(Debug, Serialize)]
@@ -222,6 +226,11 @@ pub enum Event {
         transfer_id: TransferId,
         file_id: FileId,
         by_peer: bool,
+    },
+    FilePaused {
+        transfer_type: TransferType,
+        transfer_id: TransferId,
+        file_id: FileId,
     },
 }
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3821,6 +3821,18 @@ scenarios = [
                     ),
                     action.WaitRacy(
                         [
+                            event.Start(
+                                0,
+                                FILES[
+                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                ].id,
+                            ),
+                            event.Start(
+                                1,
+                                FILES[
+                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                ].id,
+                            ),
                             event.FinishFileFailed(
                                 0,
                                 FILES[
@@ -3893,6 +3905,18 @@ scenarios = [
                     ),
                     action.WaitRacy(
                         [
+                            event.Start(
+                                0,
+                                FILES[
+                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                ].id,
+                            ),
+                            event.Start(
+                                1,
+                                FILES[
+                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
+                                ].id,
+                            ),
                             event.FinishFileFailed(
                                 0,
                                 FILES[
@@ -5718,6 +5742,7 @@ scenarios = [
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-1-ren.sqlite"),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -5730,6 +5755,55 @@ scenarios = [
                     ),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
+                    action.AssertTransfers(
+                        [
+                            """{
+                        "id": "*",
+                        "peer_id": "172.20.0.15",
+                        "created_at": "*",
+                        "states": [
+                            {
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": true
+                            }
+                        ],
+                        "type": "outgoing",
+                        "paths": [
+                            {
+                                "relative_path": "testfile-big",
+                                "base_path": "/tmp",
+                                "bytes": 10485760,
+                                "states": [
+                                    {
+                                        "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": 0
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "paused",
+                                        "bytes_sent": "*"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": "*"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
+                                    }
+                                ]
+                            }
+                        ]
+                    }"""
+                        ]
+                    ),
                     action.Stop(),
                 ]
             ),
@@ -5773,6 +5847,56 @@ scenarios = [
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
+                    action.AssertTransfers(
+                        [
+                            """{
+                        "id": "*",
+                        "peer_id": "172.20.0.5",
+                        "created_at": "*",
+                        "states": [
+                            {
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": false
+                            }
+                        ],
+                        "type": "incoming",
+                        "paths": [
+                            {
+                                "relative_path": "testfile-big",
+                                "bytes": 10485760,
+                                "states": [
+                                    {
+                                        "created_at": "*",
+                                        "state": "pending"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_received": 0,
+                                        "base_dir": "/tmp/received/29-1"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "paused",
+                                        "bytes_received": "*"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_received": "*",
+                                        "base_dir": "/tmp/received/29-1"
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
+                                    }
+                                ]
+                            }
+                        ]
+                    }"""
+                        ]
+                    ),
                     action.Stop(),
                 ]
             ),
@@ -5843,6 +5967,7 @@ scenarios = [
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     # start the receiver again
                     action.Start("172.20.0.15", dbpath="/tmp/db/29-2-stimpy.sqlite"),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -5915,6 +6040,7 @@ scenarios = [
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     action.WaitForAnotherPeer(),
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-3-ren.sqlite"),
@@ -6089,6 +6215,7 @@ scenarios = [
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     action.WaitForAnotherPeer(),
                     # start the receiver again
                     action.Start("172.20.0.15", dbpath="/tmp/db/29-4-stimpy.sqlite"),
@@ -6150,6 +6277,9 @@ scenarios = [
                         event.Progress(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
                     ),
                     action.Stop(),
+                    action.Wait(
+                        event.Paused(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
+                    ),
                     action.WaitForAnotherPeer(),
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-5-ren.sqlite"),
@@ -6649,6 +6779,7 @@ scenarios = [
                     # make sure we have received something, so that we have non-empty tmp file
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     action.DeleteFileFromFS("/tmp/testfile-big"),
                     # restart
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-13-ren.sqlite"),


### PR DESCRIPTION
@LukasPukenis this is the continuation of progress recovery.

I'm not sure about some things:
* is it better to provide global per file field "bytes_transfered" in the JSON API or leave it as it is, as progress inside each state change
* the same question but with the database itself, should we store progress globally or in the `*_states` tables

IMHO it might be beneficial to store and present in the JSON progress as a global per-file thing