### PR TITLE
Fix receiving peer cannot know after restarting which files where accepted

### DIFF
--- a/drop-storage/migrations/003-retries/up.sql
+++ b/drop-storage/migrations/003-retries/up.sql
@@ -74,3 +74,7 @@ DROP TABLE transfer_active_states;
 DROP TABLE outgoing_path_cancel_states;
 DROP TABLE incoming_path_cancel_states;
 
+
+-- changes regarding file pending states
+DROP TABLE outgoing_path_pending_states;
+

--- a/drop-storage/migrations/003-retries/up.sql
+++ b/drop-storage/migrations/003-retries/up.sql
@@ -78,3 +78,11 @@ DROP TABLE incoming_path_cancel_states;
 -- changes regarding file pending states
 DROP TABLE outgoing_path_pending_states;
 
+ALTER TABLE incoming_path_pending_states ADD COLUMN base_dir TEXT NOT NULL DEFAULT '';
+
+UPDATE incoming_path_pending_states SET base_dir = ipss.base_dir
+FROM (SELECT path_id, base_dir, MIN(created_at) FROM incoming_path_started_states GROUP BY path_id) as ipss
+WHERE incoming_path_pending_states.path_id = ipss.path_id;
+
+ALTER TABLE incoming_path_started_states DROP COLUMN base_dir;
+

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -18,8 +18,6 @@ where
 #[derive(Debug, Serialize)]
 #[serde(tag = "state")]
 pub enum OutgoingPathStateEventData {
-    #[serde(rename = "pending")]
-    Pending,
     #[serde(rename = "started")]
     Started { bytes_sent: i64 },
     #[serde(rename = "failed")]

--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -34,12 +34,9 @@ pub enum OutgoingPathStateEventData {
 #[serde(tag = "state")]
 pub enum IncomingPathStateEventData {
     #[serde(rename = "pending")]
-    Pending,
+    Pending { base_dir: String },
     #[serde(rename = "started")]
-    Started {
-        base_dir: String,
-        bytes_received: i64,
-    },
+    Started { bytes_received: i64 },
     #[serde(rename = "failed")]
     Failed {
         status_code: i64,

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -25,9 +25,9 @@ impl<'a> StorageDispatch<'a> {
                     .insert_outgoing_path_started_state(transfer.id(), file_id.as_ref())
                     .await
             }
-            crate::Event::FileDownloadStarted(transfer, file_id, base_dir) => {
+            crate::Event::FileDownloadStarted(transfer, file_id, ..) => {
                 self.storage
-                    .insert_incoming_path_started_state(transfer.id(), file_id.as_ref(), base_dir)
+                    .insert_incoming_path_started_state(transfer.id(), file_id.as_ref())
                     .await
             }
             crate::Event::FileDownloadSuccess(transfer, download) => {

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -171,13 +171,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -421,13 +421,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -456,13 +456,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -3186,13 +3186,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -5367,13 +5367,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received/28"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received/28"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -5543,13 +5543,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/received/29-1"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/received/29-1"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -5559,8 +5559,7 @@ scenarios = [
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": "*",
-                                        "base_dir": "/tmp/received/29-1"
+                                        "bytes_received": "*"
                                     },
                                     {
                                         "created_at": "*",
@@ -7201,13 +7200,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/recv/31-5"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/recv/31-5"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",
@@ -7328,13 +7327,13 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
+                                        "state": "pending",
+                                        "base_dir": "/tmp/recv/31-6"
                                     },
                                     {
                                         "created_at": "*",
                                         "state": "started",
-                                        "bytes_received": 0,
-                                        "base_dir": "/tmp/recv/31-6"
+                                        "bytes_received": 0
                                     },
                                     {
                                         "created_at": "*",

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -62,10 +62,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -293,10 +289,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -326,10 +318,6 @@ scenarios = [
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
                                 "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    },
                                     {
                                         "created_at": "*",
                                         "state": "started",
@@ -3095,10 +3083,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -4573,10 +4557,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -5311,10 +5291,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -5478,10 +5454,6 @@ scenarios = [
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
                                 "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    },
                                     {
                                         "created_at": "*",
                                         "state": "started",
@@ -6699,10 +6671,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "rejected",
                                         "by_peer": false
                                     }
@@ -6765,10 +6733,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "rejected",
                                         "by_peer": true
                                     }
@@ -6824,10 +6788,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "rejected",
                                         "by_peer": true
                                     }
@@ -6875,10 +6835,6 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
                                 "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    },
                                     {
                                         "created_at": "*",
                                         "state": "rejected",
@@ -6944,12 +6900,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -6972,12 +6923,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7018,12 +6964,7 @@ scenarios = [
                             {
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7070,12 +7011,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7116,12 +7052,7 @@ scenarios = [
                             {
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7143,12 +7074,7 @@ scenarios = [
                             {
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7200,10 +7126,6 @@ scenarios = [
                                 "bytes": 1048576,
                                 "bytes_sent": 1048576,
                                 "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    },
                                     {
                                         "created_at": "*",
                                         "state": "started",
@@ -7346,10 +7268,6 @@ scenarios = [
                                 "states": [
                                     {
                                         "created_at": "*",
-                                        "state": "pending"
-                                    },
-                                    {
-                                        "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
                                     },
@@ -7483,12 +7401,7 @@ scenarios = [
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
                                 "bytes_sent": 0,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7512,12 +7425,7 @@ scenarios = [
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
                                 "bytes_sent": 0,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7558,12 +7466,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
                                 "bytes_received": 0,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7586,12 +7489,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "bytes": 1048576,
                                 "bytes_received": 0,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""
@@ -7758,12 +7656,7 @@ scenarios = [
                                 "relative_path": "testfile-small",
                                 "base_path": "/tmp",
                                 "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "pending"
-                                    }
-                                ]
+                                "states": []
                             }
                         ]
                     }"""


### PR DESCRIPTION
This PR uses `Pending` states as a way to inform the app about the file being accepted.

What is more, I've decided that we can store `base_dir` for downloads in the `Pending` states table in contrast to the `Started` states table, since it's more tied to the `download()` call. Details in the commit message