### PR TITLE
Remove unnecesary and confusing config parameters

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 * Allow removing file only upon reaching one Rejected, Failed or Finished state
 * Disallow re-downloading file after reaching Rejected, Failed or Finished state within single transfer
 * Include `bytes_sent/bytes_received` JSON field per file in the storage output
+* Remove `transfer_idle_lifetime_ms` and `connection_max_retry_interval_ms` config parameters
 
 ---
 <br>

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -10,8 +10,6 @@ pub struct Config {
 pub struct DropConfig {
     pub dir_depth_limit: usize,
     pub transfer_file_limit: usize,
-    pub connection_max_retry_interval: Duration,
-    pub transfer_idle_lifetime: Duration,
     pub storage_path: String,
     pub max_uploads_in_flight: usize,
     pub max_reqs_per_sec: u32,
@@ -22,8 +20,6 @@ impl Default for DropConfig {
         Self {
             dir_depth_limit: 5,
             transfer_file_limit: 1000,
-            connection_max_retry_interval: Duration::from_secs(10),
-            transfer_idle_lifetime: Duration::from_secs(60),
             storage_path: "libdrop.sqlite".to_string(),
             max_uploads_in_flight: 4,
             max_reqs_per_sec: 50,
@@ -38,9 +34,6 @@ pub struct MooseConfig {
 }
 
 pub const PORT: u16 = 49111;
-
-impl DropConfig {
-    pub fn ping_interval(&self) -> Duration {
-        self.transfer_idle_lifetime / 2
-    }
-}
+pub const TRANFER_IDLE_LIFETIME: Duration = Duration::new(60, 0);
+pub const PING_INTERVAL: Duration = Duration::new(30, 0);
+pub const CONNECTION_MAX_RETRY_INTERVAL: Duration = Duration::new(10, 0);

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -156,7 +156,7 @@ async fn establish_ws_conn(
     ip: IpAddr,
     logger: &Logger,
 ) -> crate::Result<Option<(WebSocket, protocol::Version)>> {
-    let mut socket = tcp_connect(state, ip, logger).await;
+    let mut socket = tcp_connect(ip, logger).await;
 
     let mut versions_to_try = [
         protocol::Version::V5,
@@ -258,7 +258,7 @@ async fn make_request(
     Err(err)
 }
 
-async fn tcp_connect(state: &State, ip: IpAddr, logger: &Logger) -> TcpStream {
+async fn tcp_connect(ip: IpAddr, logger: &Logger) -> TcpStream {
     let mut sleep_time = Duration::from_millis(200);
 
     loop {
@@ -275,10 +275,7 @@ async fn tcp_connect(state: &State, ip: IpAddr, logger: &Logger) -> TcpStream {
                 tokio::time::sleep(sleep_time).await;
 
                 // Exponential backoff but with upper limit
-                sleep_time = state
-                    .config
-                    .connection_max_retry_interval
-                    .min(sleep_time * 2);
+                sleep_time = drop_config::CONNECTION_MAX_RETRY_INTERVAL.min(sleep_time * 2);
             }
         }
     }

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -101,7 +101,7 @@ impl<'a, const PING: bool> handler::HandlerInit for HandlerInit<'a, PING> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        ws::utils::Pinger::<PING>::new(self.state)
+        ws::utils::Pinger::<PING>::new()
     }
 }
 
@@ -347,12 +347,7 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
         if PING {
-            Some(
-                self.state
-                    .config
-                    .transfer_idle_lifetime
-                    .saturating_sub(last_recv_elapsed),
-            )
+            Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
         } else {
             None
         }

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -98,7 +98,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        tokio::time::interval(self.state.config.ping_interval())
+        tokio::time::interval(drop_config::PING_INTERVAL)
     }
 }
 
@@ -412,12 +412,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     }
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
-        Some(
-            self.state
-                .config
-                .transfer_idle_lifetime
-                .saturating_sub(last_recv_elapsed),
-        )
+        Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
     }
 }
 

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -98,7 +98,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        tokio::time::interval(self.state.config.ping_interval())
+        tokio::time::interval(drop_config::PING_INTERVAL)
     }
 }
 
@@ -431,12 +431,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     }
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
-        Some(
-            self.state
-                .config
-                .transfer_idle_lifetime
-                .saturating_sub(last_recv_elapsed),
-        )
+        Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
     }
 }
 impl Drop for HandlerLoop<'_> {

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -134,7 +134,7 @@ impl<'a, const PING: bool> handler::HandlerInit for HandlerInit<'a, PING> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        ws::utils::Pinger::<PING>::new(self.state)
+        ws::utils::Pinger::<PING>::new()
     }
 }
 
@@ -393,12 +393,7 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
         if PING {
-            Some(
-                self.state
-                    .config
-                    .transfer_idle_lifetime
-                    .saturating_sub(last_recv_elapsed),
-            )
+            Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
         } else {
             None
         }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -199,7 +199,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        tokio::time::interval(self.state.config.ping_interval())
+        tokio::time::interval(drop_config::PING_INTERVAL)
     }
 }
 
@@ -500,12 +500,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     }
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
-        Some(
-            self.state
-                .config
-                .transfer_idle_lifetime
-                .saturating_sub(last_recv_elapsed),
-        )
+        Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
     }
 }
 

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -199,7 +199,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
     }
 
     fn pinger(&mut self) -> Self::Pinger {
-        tokio::time::interval(self.state.config.ping_interval())
+        tokio::time::interval(drop_config::PING_INTERVAL)
     }
 }
 
@@ -519,12 +519,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
     }
 
     fn recv_timeout(&mut self, last_recv_elapsed: Duration) -> Option<Duration> {
-        Some(
-            self.state
-                .config
-                .transfer_idle_lifetime
-                .saturating_sub(last_recv_elapsed),
-        )
+        Some(drop_config::TRANFER_IDLE_LIFETIME.saturating_sub(last_recv_elapsed))
     }
 }
 

--- a/drop-transfer/src/ws/utils.rs
+++ b/drop-transfer/src/ws/utils.rs
@@ -3,15 +3,13 @@ use std::time::Duration;
 use anyhow::Context;
 use futures::StreamExt;
 
-use crate::service::State;
-
 pub struct Pinger<const PING: bool = true> {
     interval: tokio::time::Interval,
 }
 
 impl<const PING: bool> Pinger<PING> {
-    pub(crate) fn new(state: &State) -> Self {
-        let interval = tokio::time::interval(state.config.ping_interval());
+    pub(crate) fn new() -> Self {
+        let interval = tokio::time::interval(drop_config::PING_INTERVAL);
         Self { interval }
     }
 }

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -294,14 +294,15 @@ enum norddrop_result norddrop_set_fd_resolver_callback(const struct norddrop *de
  * * `transfer_file_limit` - when aggregating files from the path, if this
  * limit is reached, an error is returned.
  *
- * * `transfer_idle_lifetime_ms` - this timeout plays a role in an already
- * established transfer as sometimes one peer might go offline with no notice.
- * This timeout controls the amount of time we will wait for any action from
- * the peer and after that, we will fail the transfer.
- *
  * * `moose_event_path` - moose database path.
  *
  * * `storage_path` - storage path for persistence engine.
+ *
+ * * `max_uploads_in_flight` (optional) - number of files that can be
+ *   simultaneously transmited within a single transfer.
+ *
+ * * `max_requests_per_sec` (optional) - max number of request allowed from a
+ *   peer before triggering DDoS protection.
  *
  * # Safety
  * The pointers provided must be valid

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use drop_transfer::{utils::Hidden, File as _, Transfer};
 use serde::{Deserialize, Serialize};
 
@@ -108,9 +106,6 @@ pub enum Event {
 pub struct Config {
     pub dir_depth_limit: usize,
     pub transfer_file_limit: usize,
-    #[serde(default = "default_connection_max_retry_interval_ms")]
-    pub connection_max_retry_interval_ms: u64,
-    pub transfer_idle_lifetime_ms: u64,
     pub moose_event_path: String,
     pub moose_prod: bool,
     pub storage_path: String,
@@ -118,10 +113,6 @@ pub struct Config {
     pub max_uploads_in_flight: usize,
     #[serde(default = "default_max_requests_per_sec")]
     pub max_requests_per_sec: u32,
-}
-
-const fn default_connection_max_retry_interval_ms() -> u64 {
-    10000
 }
 
 const fn default_max_files_in_flight() -> usize {
@@ -302,8 +293,6 @@ impl From<Config> for drop_config::Config {
         let Config {
             dir_depth_limit,
             transfer_file_limit,
-            connection_max_retry_interval_ms,
-            transfer_idle_lifetime_ms,
             moose_event_path,
             moose_prod,
             storage_path,
@@ -315,10 +304,6 @@ impl From<Config> for drop_config::Config {
             drop: drop_config::DropConfig {
                 dir_depth_limit,
                 transfer_file_limit,
-                connection_max_retry_interval: Duration::from_millis(
-                    connection_max_retry_interval_ms,
-                ),
-                transfer_idle_lifetime: Duration::from_millis(transfer_idle_lifetime_ms),
                 storage_path,
                 max_uploads_in_flight,
                 max_reqs_per_sec: max_requests_per_sec,
@@ -351,7 +336,6 @@ mod tests {
         "#;
 
         let cfg: Config = serde_json::from_str(json).expect("Failed to deserialize config");
-        assert_eq!(cfg.connection_max_retry_interval_ms, 10000);
         assert_eq!(cfg.max_uploads_in_flight, 4);
         assert_eq!(cfg.max_requests_per_sec, 50);
 
@@ -376,8 +360,6 @@ mod tests {
                 drop_config::DropConfig {
                     dir_depth_limit,
                     transfer_file_limit,
-                    transfer_idle_lifetime,
-                    connection_max_retry_interval,
                     storage_path,
                     max_uploads_in_flight,
                     max_reqs_per_sec,
@@ -387,8 +369,6 @@ mod tests {
 
         assert_eq!(dir_depth_limit, 10);
         assert_eq!(transfer_file_limit, 100);
-        assert_eq!(connection_max_retry_interval, Duration::from_millis(500));
-        assert_eq!(transfer_idle_lifetime, Duration::from_millis(2000));
         assert_eq!(event_path, "test/path");
         assert_eq!(storage_path, ":memory:");
         assert_eq!(max_uploads_in_flight, 16);

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -330,14 +330,15 @@ pub extern "C" fn norddrop_set_fd_resolver_callback(
 /// * `transfer_file_limit` - when aggregating files from the path, if this
 /// limit is reached, an error is returned.
 ///
-/// * `transfer_idle_lifetime_ms` - this timeout plays a role in an already
-/// established transfer as sometimes one peer might go offline with no notice.
-/// This timeout controls the amount of time we will wait for any action from
-/// the peer and after that, we will fail the transfer.
-///
 /// * `moose_event_path` - moose database path.
 ///
 /// * `storage_path` - storage path for persistence engine.
+///
+/// * `max_uploads_in_flight` (optional) - number of files that can be
+///   simultaneously transmited within a single transfer.
+///
+/// * `max_requests_per_sec` (optional) - max number of request allowed from a
+///   peer before triggering DDoS protection.
 ///
 /// # Safety
 /// The pointers provided must be valid


### PR DESCRIPTION
Removed params:
* `transfer_idle_lifetime_ms`
* `connection_max_retry_interval_ms`

There are still parameters like:
* `max_uploads_in_flight`
* `max_requests_per_sec`
which are even undocumented

@LukasPukenis what to do with them?
