### PR TITLE
More tests regarding FFI errors and resume behavior

### DIFF
--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -77,16 +77,16 @@ impl Service {
 
             let guard = waiter.guard();
 
-            manager::resume(&state, &logger, &guard, &stop).await;
             ws::server::spawn(
                 addr,
                 state.clone(),
                 auth,
                 logger.clone(),
                 stop.clone(),
-                guard,
+                guard.clone(),
             )?;
-
+            
+            manager::resume(&state, &logger, &guard, &stop).await;
             Ok(Self {
                 state,
                 stop,

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -85,7 +85,7 @@ impl Service {
                 stop.clone(),
                 guard.clone(),
             )?;
-            
+
             manager::resume(&state, &logger, &guard, &stop).await;
             Ok(Self {
                 state,

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -77,6 +77,10 @@ impl Service {
 
             let guard = waiter.guard();
 
+            state.storage.cleanup_garbage_transfers().await;
+
+            manager::restore_transfers_state(&state, &logger).await;
+
             ws::server::spawn(
                 addr,
                 state.clone(),
@@ -87,6 +91,7 @@ impl Service {
             )?;
 
             manager::resume(&state, &logger, &guard, &stop).await;
+
             Ok(Self {
                 state,
                 stop,

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -10,6 +10,7 @@ import typing
 import json
 import time
 import glob
+import socket
 
 from . import event, ffi
 from .logger import logger
@@ -67,6 +68,22 @@ class Action:
 
     async def run(self, drop: ffi.Drop):
         raise NotImplementedError("run() on base Action class")
+
+
+class ListenOnPort(Action):
+    def __init__(self, addr: str):
+        self._addr = addr
+        self._socket: None | socket.socket = None
+        pass
+
+    async def run(self, drop: ffi.Drop):
+        # bind socket to port 49111 and listen on itj
+        HOST = self._addr
+        PORT = 49111
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind((HOST, PORT))
+        s.listen()
+        self._socket = s
 
 
 class ExpectError(Action):

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -77,12 +77,11 @@ class ListenOnPort(Action):
         pass
 
     async def run(self, drop: ffi.Drop):
-        # bind socket to port 49111 and listen on itj
-        HOST = self._addr
-        PORT = 49111
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.bind((HOST, PORT))
+        s.bind((self._addr, 49111))
         s.listen()
+
+        # prevent socket from being closed
         self._socket = s
 
 

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -36,11 +36,29 @@ class LibResult(IntEnum):
     # Bad JSON input
     NORDDROP_RES_BAD_INPUT = (3,)
 
+    # Bad JSON for API
+    NORDDROP_RES_JSON_PARSE = (4,)
+
+    # Failed to create a transfer
+    NORDDROP_RES_TRANSFER_CREATE = (5,)
+
     # Instance not started
     NORDDROP_NOT_STARTED = (6,)
 
     # Address already in used
     NORDDROP_RES_ADDR_IN_USE = (7,)
+
+    # Failed to start instance
+    NORDDROP_RES_INSTANCE_START = (8,)
+
+    # Failed to stop instance
+    NORDDROP_RES_INSTANCE_STOP = (9,)
+
+    # Invalid private key provided
+    NORDDROP_RES_INVALID_PRIVKEY = (10,)
+
+    # Database error
+    NORDDROP_RES_DB_ERROR = (11,)
 
 
 class LogLevel(IntEnum):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -36,6 +36,12 @@ class LibResult(IntEnum):
     # Bad JSON input
     NORDDROP_RES_BAD_INPUT = (3,)
 
+    # Instance not started
+    NORDDROP_NOT_STARTED = (6,)
+
+    # Address already in used
+    NORDDROP_RES_ADDR_IN_USE = (7,)
+
 
 class LogLevel(IntEnum):
     Critical = 1

--- a/test/drop_test/scenario.py
+++ b/test/drop_test/scenario.py
@@ -32,12 +32,10 @@ class Scenario:
         id: str,
         desc: str,
         action_list: typing.Dict[str, ActionList],
-        dbpath: str = ":memory:",
     ):
         self._id = id
         self._desc = desc
         self._action_list = action_list
-        self._dbpath = dbpath
 
     def desc(self):
         return self._desc

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7831,7 +7831,6 @@ scenarios = [
                     # Peer is online for a few seconds and then starts libdrop instance, expect nothing
                     action.Sleep(4),
                     action.Start("172.20.0.15"),
-                    # TODO: this event never arrives
                     action.Wait(
                         event.Receive(
                             0,

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7822,7 +7822,7 @@ scenarios = [
                     action.Stop(),
                     # try again and expect no events and no activity
                     action.Start("172.20.0.5", "/tmp/data.base"),
-                    action.NoEvent(6),
+                    action.NoEvent(10),
                     action.Stop(),
                 ]
             ),


### PR DESCRIPTION
This PR swaps around `manager::resume` and WebSocket server start. This prevents from broken `norddrop_start()` from trying to communicate with the peer already, failing to accept incoming connections, and producing errors 