### PR TITLE
Unify exception names

### DIFF
--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -669,7 +669,7 @@ fn open_database(
                             error as i32,
                             err.to_string(),
                             "Failed to open DB after cleanup".to_string(),
-                            "Database Error".to_string(),
+                            "DB Error".to_string(),
                         );
                         error!(
                             logger,


### PR DESCRIPTION
This was done to aid categorization of these events during aggregation