### PR TITLE
Fix: removing transfer from the db prevents the state syncing since the data is lost

### DIFF
--- a/drop-storage/migrations/003-retries/up.sql
+++ b/drop-storage/migrations/003-retries/up.sql
@@ -86,3 +86,7 @@ WHERE incoming_path_pending_states.path_id = ipss.path_id;
 
 ALTER TABLE incoming_path_started_states DROP COLUMN base_dir;
 
+
+-- transfers soft deletion
+ALTER TABLE transfers ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT FALSE CHECK (is_deleted IN (FALSE, TRUE));
+

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -960,6 +960,8 @@ pub(crate) async fn resume(
     guard: &AliveGuard,
     stop: &CancellationToken,
 ) {
+    state.storage.cleanup_garbage_transfers().await;
+
     *state.transfer_manager.incoming.lock().await =
         restore_incoming(&state.storage, &state.config, logger).await;
     *state.transfer_manager.outgoing.lock().await =


### PR DESCRIPTION
This one implements soft deletion for transfers.
The transfers are automatically hard deleted in the library initialization procedure once it's determined that the full state was synced with the peer