### PR TITLE
Fix all the started DB states contained 0 bytes transmitted

### DIFF
--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -35,9 +35,9 @@ fn print_event(ev: &Event) {
 
             info!("[EVENT] RequestReceived {}: {:?}", xfid, files);
         }
-        Event::FileDownloadStarted(xfer, file, base_dir) => {
+        Event::FileDownloadStarted(xfer, file, base_dir, offset) => {
             info!(
-                "[EVENT] [{}] FileDownloadStarted {:?} transfer started, to {:?}",
+                "[EVENT] [{}] FileDownloadStarted {:?} transfer started, to {:?}, offset: {offset}",
                 xfer.id(),
                 file,
                 base_dir
@@ -66,8 +66,12 @@ fn print_event(ev: &Event) {
         Event::RequestQueued(xfer) => {
             info!("[EVENT] RequestQueued {}: {:?}", xfer.id(), xfer.files(),);
         }
-        Event::FileUploadStarted(xfer, file) => {
-            info!("[EVENT] FileUploadStarted {}: {:?}", xfer.id(), file,);
+        Event::FileUploadStarted(xfer, file, offset) => {
+            info!(
+                "[EVENT] FileUploadStarted {}: {:?}, offset {offset}",
+                xfer.id(),
+                file,
+            );
         }
         Event::FileDownloadProgress(xfer, file, progress) => {
             info!(
@@ -173,7 +177,7 @@ async fn listen(
                         .context("Cannot issue download call")?;
                 }
             }
-            Event::FileDownloadStarted(xfer, file, _) => {
+            Event::FileDownloadStarted(xfer, file, _, _) => {
                 active_file_downloads
                     .entry(xfer.id())
                     .or_insert_with(HashSet::new)

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -20,8 +20,8 @@ pub enum Event {
     RequestReceived(Arc<IncomingTransfer>),
     RequestQueued(Arc<OutgoingTransfer>),
 
-    FileUploadStarted(Arc<OutgoingTransfer>, FileId),
-    FileDownloadStarted(Arc<IncomingTransfer>, FileId, String),
+    FileUploadStarted(Arc<OutgoingTransfer>, FileId, u64),
+    FileDownloadStarted(Arc<IncomingTransfer>, FileId, String, u64),
 
     FileUploadProgress(Arc<OutgoingTransfer>, FileId, u64),
     FileDownloadProgress(Arc<IncomingTransfer>, FileId, u64),

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -20,14 +20,24 @@ impl<'a> StorageDispatch<'a> {
 
     pub async fn handle_event(&mut self, event: &crate::Event) {
         match event {
-            crate::Event::FileUploadStarted(transfer, file_id) => {
+            crate::Event::FileUploadStarted(transfer, file_id, bytes) => {
+                self.store_progres(transfer.id(), file_id, *bytes as _);
                 self.storage
-                    .insert_outgoing_path_started_state(transfer.id(), file_id.as_ref())
+                    .insert_outgoing_path_started_state(
+                        transfer.id(),
+                        file_id.as_ref(),
+                        *bytes as _,
+                    )
                     .await
             }
-            crate::Event::FileDownloadStarted(transfer, file_id, ..) => {
+            crate::Event::FileDownloadStarted(transfer, file_id, _, bytes) => {
+                self.store_progres(transfer.id(), file_id, *bytes as _);
                 self.storage
-                    .insert_incoming_path_started_state(transfer.id(), file_id.as_ref())
+                    .insert_incoming_path_started_state(
+                        transfer.id(),
+                        file_id.as_ref(),
+                        *bytes as _,
+                    )
                     .await
             }
             crate::Event::FileDownloadSuccess(transfer, download) => {

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -425,7 +425,7 @@ async fn start_upload(
         .outgoing_file_events(xfer.id(), &file_id)
         .await?;
 
-    events.start().await;
+    events.start(uploader.offset()).await;
 
     let upload_job = {
         async move {

--- a/drop-transfer/src/ws/events.rs
+++ b/drop-transfer/src/ws/events.rs
@@ -149,11 +149,12 @@ impl FileEventTx<IncomingTransfer> {
         .await
     }
 
-    pub async fn start(&self, base_dir: impl Into<String>) {
+    pub async fn start(&self, base_dir: impl Into<String>, offset: u64) {
         self.start_inner(crate::Event::FileDownloadStarted(
             self.xfer.clone(),
             self.file_id.clone(),
             base_dir.into(),
+            offset,
         ))
         .await
     }
@@ -206,10 +207,11 @@ impl FileEventTx<IncomingTransfer> {
 }
 
 impl FileEventTx<OutgoingTransfer> {
-    pub async fn start(&self) {
+    pub async fn start(&self, offset: u64) {
         self.start_inner(crate::Event::FileUploadStarted(
             self.xfer.clone(),
             self.file_id.clone(),
+            offset,
         ))
         .await
     }

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -625,6 +625,8 @@ impl FileXferTask {
                 offset,
                 tmp_location,
             } => {
+                events.start(self.base_dir.to_string_lossy(), offset).await;
+
                 let result = self
                     .stream_file(
                         StreamCtx {
@@ -831,8 +833,6 @@ async fn start_download(
         .transfer_manager
         .incoming_file_events(job.xfer.id(), job.file.id())
         .await?;
-
-    events.start(job.base_dir.to_string_lossy()).await;
 
     let job = {
         let events = events.clone();

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -125,13 +125,13 @@ impl From<drop_transfer::Event> for Event {
         match e {
             drop_transfer::Event::RequestReceived(tx) => Event::RequestReceived(tx.as_ref().into()),
             drop_transfer::Event::RequestQueued(tx) => Event::RequestQueued(tx.as_ref().into()),
-            drop_transfer::Event::FileUploadStarted(tx, fid) => {
+            drop_transfer::Event::FileUploadStarted(tx, fid, _) => {
                 Event::TransferStarted(StartEvent {
                     transfer: tx.id().to_string(),
                     file: fid.to_string(),
                 })
             }
-            drop_transfer::Event::FileDownloadStarted(tx, fid, _) => {
+            drop_transfer::Event::FileDownloadStarted(tx, fid, _, _) => {
                 Event::TransferStarted(StartEvent {
                     transfer: tx.id().to_string(),
                     file: fid.to_string(),

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -37,6 +37,7 @@ struct File {
 pub struct StartEvent {
     transfer: String,
     file: String,
+    transfered: u64,
 }
 
 #[derive(Serialize)]
@@ -125,16 +126,18 @@ impl From<drop_transfer::Event> for Event {
         match e {
             drop_transfer::Event::RequestReceived(tx) => Event::RequestReceived(tx.as_ref().into()),
             drop_transfer::Event::RequestQueued(tx) => Event::RequestQueued(tx.as_ref().into()),
-            drop_transfer::Event::FileUploadStarted(tx, fid, _) => {
+            drop_transfer::Event::FileUploadStarted(tx, fid, transfered) => {
                 Event::TransferStarted(StartEvent {
                     transfer: tx.id().to_string(),
                     file: fid.to_string(),
+                    transfered,
                 })
             }
-            drop_transfer::Event::FileDownloadStarted(tx, fid, _, _) => {
+            drop_transfer::Event::FileDownloadStarted(tx, fid, _, transfered) => {
                 Event::TransferStarted(StartEvent {
                     transfer: tx.id().to_string(),
                     file: fid.to_string(),
+                    transfered,
                 })
             }
             drop_transfer::Event::FileUploadProgress(tx, fid, progress) => {

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -515,7 +515,9 @@ class WaitForResume(Action):
         file_list = glob.glob(self._tmp_file_path)
         stat = os.stat(file_list[0])  # just take the first find
 
-        await drop._events.wait_for(event.Start(self._uuid_slot, self._file_id), False)
+        await drop._events.wait_for(
+            event.Start(self._uuid_slot, self._file_id, transferred=stat.st_size), False
+        )
         await drop._events.wait_for(
             event.Progress(self._uuid_slot, self._file_id, stat.st_size), False
         )

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -98,9 +98,12 @@ class Receive(Event):
 
 
 class Start(Event):
-    def __init__(self, uuid_slot: int, file: str):
+    def __init__(
+        self, uuid_slot: int, file: str, transferred: typing.Optional[int] = 0
+    ):
         self._uuid_slot = uuid_slot
         self._file = file
+        self._transferred = transferred
 
     def __eq__(self, rhs):
         if not isinstance(rhs, Start):
@@ -110,10 +113,14 @@ class Start(Event):
         if self._file != rhs._file:
             return False
 
+        if self._transferred is not None and rhs._transferred is not None:
+            if self._transferred != rhs._transferred:
+                return False
+
         return True
 
     def __str__(self):
-        return f"Start(transfer={print_uuid(self._uuid_slot)}, file={self._file})"
+        return f"Start(transfer={print_uuid(self._uuid_slot)}, file={self._file}, transfered={self._transferred})"
 
 
 class Progress(Event):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -606,8 +606,9 @@ def new_event(event_str: str) -> event.Event:
             trasnfer_slot = event.UUIDS.index(transfer)
 
         file: str = event_data["file"]
+        transfered: int = event_data["transfered"]
 
-        return event.Start(trasnfer_slot, file)
+        return event.Start(trasnfer_slot, file, transfered)
 
     elif event_type == "TransferProgress":
         transfer = event_data["transfer"]

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3447,18 +3447,6 @@ scenarios = [
                     ),
                     action.WaitRacy(
                         [
-                            event.Start(
-                                0,
-                                FILES[
-                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
-                                ].id,
-                            ),
-                            event.Start(
-                                1,
-                                FILES[
-                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
-                                ].id,
-                            ),
                             event.FinishFileFailed(
                                 0,
                                 FILES[
@@ -3531,18 +3519,6 @@ scenarios = [
                     ),
                     action.WaitRacy(
                         [
-                            event.Start(
-                                0,
-                                FILES[
-                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
-                                ].id,
-                            ),
-                            event.Start(
-                                1,
-                                FILES[
-                                    "thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
-                                ].id,
-                            ),
                             event.FinishFileFailed(
                                 0,
                                 FILES[
@@ -3866,7 +3842,9 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.FinishFileUploaded(0, FILES["testfile-big"].id)),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
@@ -4044,8 +4022,12 @@ scenarios = [
                             event.Start(0, FILES["nested/big/testfile-02"].id),
                             event.Paused(0, FILES["nested/big/testfile-01"].id),
                             event.Paused(0, FILES["nested/big/testfile-02"].id),
-                            event.Start(0, FILES["nested/big/testfile-01"].id),
-                            event.Start(0, FILES["nested/big/testfile-02"].id),
+                            event.Start(
+                                0, FILES["nested/big/testfile-01"].id, transferred=None
+                            ),
+                            event.Start(
+                                0, FILES["nested/big/testfile-02"].id, transferred=None
+                            ),
                             event.FinishFileUploaded(
                                 0, FILES["nested/big/testfile-01"].id
                             ),
@@ -4113,8 +4095,12 @@ scenarios = [
                     action.Start("172.20.0.15", dbpath="/tmp/db/21-3-stimpy.sqlite"),
                     action.WaitRacy(
                         [
-                            event.Start(0, FILES["nested/big/testfile-01"].id),
-                            event.Start(0, FILES["nested/big/testfile-02"].id),
+                            event.Start(
+                                0, FILES["nested/big/testfile-01"].id, transferred=None
+                            ),
+                            event.Start(
+                                0, FILES["nested/big/testfile-02"].id, transferred=None
+                            ),
                             event.FinishFileDownloaded(
                                 0,
                                 FILES["nested/big/testfile-01"].id,
@@ -5424,7 +5410,9 @@ scenarios = [
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-1-ren.sqlite"),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -5506,7 +5494,9 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(
                         event.FinishFileDownloaded(
                             0,
@@ -5600,7 +5590,9 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -5644,7 +5636,9 @@ scenarios = [
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     # start the receiver again
                     action.Start("172.20.0.15", dbpath="/tmp/db/29-2-stimpy.sqlite"),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileDownloaded(
@@ -5718,7 +5712,9 @@ scenarios = [
                     action.WaitForAnotherPeer(),
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-3-ren.sqlite"),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -5769,7 +5765,9 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(
                         event.FinishFileDownloaded(
                             0,
@@ -5834,7 +5832,9 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -5893,7 +5893,9 @@ scenarios = [
                     action.WaitForAnotherPeer(),
                     # start the receiver again
                     action.Start("172.20.0.15", dbpath="/tmp/db/29-4-stimpy.sqlite"),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileDownloaded(
@@ -5958,7 +5960,11 @@ scenarios = [
                     # start the sender again
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-5-ren.sqlite"),
                     action.Wait(
-                        event.Start(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
+                        event.Start(
+                            0,
+                            "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
+                            transferred=None,
+                        )
                     ),
                     action.Wait(
                         event.Progress(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
@@ -6003,7 +6009,11 @@ scenarios = [
                         event.Paused(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
                     ),
                     action.Wait(
-                        event.Start(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
+                        event.Start(
+                            0,
+                            "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
+                            transferred=None,
+                        )
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
@@ -6487,7 +6497,6 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileFailed(
                             0, FILES["testfile-big"].id, Error.BAD_TRANSFER_STATE


### PR DESCRIPTION
As in the title the `bytes_received` and `bytes_sent` field was not being set up in the DB. Even though it was not declared as `DEFAULT 0`