### PR TITLE
DB error triggered by android app on high latency network

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+### v5.0.1
+### **UNRELEASED**
+---
+* Mitigate trasnfer cancelation being out of sync on high latency network
+
+---
+<br>
+
 ### v5.0.0
 ### **Broken Records**
 ---

--- a/drop-transfer/src/ws/server/socket.rs
+++ b/drop-transfer/src/ws/server/socket.rs
@@ -48,12 +48,6 @@ impl WebSocket {
         Ok(msg)
     }
 
-    pub async fn close(self) -> crate::Result<()> {
-        self.stream.close().await?;
-
-        Ok(())
-    }
-
     pub async fn drain(&mut self) -> crate::Result<()> {
         while self.stream.next().await.transpose()?.is_some() {}
         Ok(())

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -419,12 +419,9 @@ class ExpectCancel(Action):
 # Shape egress traffic. Slowing down and adding latency helps introducing
 # determinism in the testing environment
 class ConfigureNetwork(Action):
-    def __init__(
-        self, rate: str = "10mbit", latency: str = "3000ms", delay: str = "0ms"
-    ):
+    def __init__(self, rate: str = "10mbit", latency: str = "0ms"):
         self._rate = rate
         self._latency = latency
-        self._delay = delay
 
     async def run(self, drop: ffi.Drop):
         def ex(cmd: str):
@@ -439,12 +436,12 @@ class ConfigureNetwork(Action):
 
         device = "eth0"
         ex(
-            f"tc qdisc add dev {device} root netem rate {self._rate} latency {self._latency} delay {self._delay}"
+            f"tc qdisc add dev {device} root netem rate {self._rate} delay {self._latency}"
         )
         ex(f"tc qdisc show dev {device}")
 
     def __str__(self):
-        return f"ConfigureNetwork({self._rate}, {self._latency}, {self._delay})"
+        return f"ConfigureNetwork({self._rate}, {self._latency})"
 
 
 class Stop(Action):

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -419,9 +419,12 @@ class ExpectCancel(Action):
 # Shape egress traffic. Slowing down and adding latency helps introducing
 # determinism in the testing environment
 class ConfigureNetwork(Action):
-    def __init__(self, rate: str = "10mbit", latency: str = "3000ms"):
+    def __init__(
+        self, rate: str = "10mbit", latency: str = "3000ms", delay: str = "0ms"
+    ):
         self._rate = rate
         self._latency = latency
+        self._delay = delay
 
     async def run(self, drop: ffi.Drop):
         def ex(cmd: str):
@@ -436,12 +439,12 @@ class ConfigureNetwork(Action):
 
         device = "eth0"
         ex(
-            f"tc qdisc add dev {device} root tbf rate {self._rate} burst 64k latency {self._latency}"
+            f"tc qdisc add dev {device} root netem rate {self._rate} latency {self._latency} delay {self._delay}"
         )
         ex(f"tc qdisc show dev {device}")
 
     def __str__(self):
-        return f"ConfigureNetwork({self._rate}, {self._latency})"
+        return f"ConfigureNetwork({self._rate}, {self._latency}, {self._delay})"
 
 
 class Stop(Action):

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7903,4 +7903,63 @@ scenarios = [
             ),
         },
     ),
+    Scenario(
+        "scenario38",
+        "Cancel the transfers from the receiver while the sender is offline and file were in flight, but the receiver did not catched the disconnection yet. Expect clean cancelation",
+        {
+            "ren": ActionList(
+                [
+                    action.ConfigureNetwork(delay="300ms"),
+                    action.Start("172.20.0.5", "/tmp/db/38.sqlite"),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
+                    action.SleepMs(100),
+                    action.Start("172.20.0.5", "/tmp/db/38.sqlite"),
+                    action.Wait(event.FinishTransferCanceled(0, True)),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "stimpy": ActionList(
+                [
+                    action.ConfigureNetwork(delay="300ms"),
+                    action.Start("172.20.0.15"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "172.20.0.5",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/38",
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.SleepMs(100),
+                    action.CancelTransferRequest(0),
+                    action.Wait(event.FinishTransferCanceled(0, False)),
+                    action.NoEvent(duration=5),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7909,7 +7909,7 @@ scenarios = [
         {
             "ren": ActionList(
                 [
-                    action.ConfigureNetwork(delay="300ms"),
+                    action.ConfigureNetwork(latency="300ms"),
                     action.Start("172.20.0.5", "/tmp/db/38.sqlite"),
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
                     action.Wait(
@@ -7934,7 +7934,7 @@ scenarios = [
             ),
             "stimpy": ActionList(
                 [
-                    action.ConfigureNetwork(delay="300ms"),
+                    action.ConfigureNetwork(latency="300ms"),
                     action.Start("172.20.0.15"),
                     action.Wait(
                         event.Receive(


### PR DESCRIPTION
The issue is that warp (WS server) does not guarantee message delivery on successful flushes - which is probably a bug on their side. This can cause a situation when the receiver thinks the close frame got delivered but in fact, it is not the case, leading to a mismatched transfer state.
Trying to receive from the socket after closing frame seems to catch the problem, though I don't think it catches it in 100% of cases.
Nonetheless, I managed to reproduce the issue with `scenario38` and managed to make it pass, so I don't know what else I could do to improve the implementation