### PR TITLE
Suppress unseen cancelled transfers syncing

### DIFF
--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -178,6 +178,20 @@ impl TransferManager {
         }
     }
 
+    pub async fn is_outgoing_alive(&self, transfer_id: Uuid) -> bool {
+        let lock = self.outgoing.lock().await;
+        let state = match lock.get(&transfer_id) {
+            Some(state) => state,
+            None => return false,
+        };
+
+        !matches!(
+            (state.xfer_sync.local, state.xfer_sync.remote),
+            (sync::TransferState::Canceled, sync::TransferState::New)
+                | (sync::TransferState::Canceled, sync::TransferState::Canceled)
+        )
+    }
+
     pub async fn outgoing_connected(
         &self,
         transfer_id: Uuid,

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -44,7 +44,7 @@ pub trait HandlerLoop {
     async fn issue_failure(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
     async fn issue_done(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
 
-    async fn on_close(&mut self, by_peer: bool);
+    async fn on_close(&mut self);
     async fn on_text_msg(&mut self, ws: &mut WebSocket, text: &str) -> anyhow::Result<()>;
     async fn on_bin_msg(&mut self, ws: &mut WebSocket, bytes: Vec<u8>) -> anyhow::Result<()>;
 

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -341,16 +341,6 @@ impl HandlerLoop<'_> {
             }
         }
     }
-
-    async fn on_stop(&mut self) {
-        debug!(self.logger, "Stopping silently");
-
-        let tasks = self.jobs.drain().map(|(_, task)| async move {
-            task.events.stop_silent(Status::Canceled).await;
-        });
-
-        futures::future::join_all(tasks).await;
-    }
 }
 
 #[async_trait::async_trait]
@@ -452,21 +442,14 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn on_close(&mut self, by_peer: bool) {
-        debug!(self.logger, "ServerHandler::on_close(by_peer: {})", by_peer);
+    async fn on_close(&mut self) {
+        debug!(self.logger, "ServerHandler::on_close(), stopping silently",);
 
-        self.on_stop().await;
+        let tasks = self.jobs.drain().map(|(_, task)| async move {
+            task.events.stop_silent(Status::Canceled).await;
+        });
 
-        if by_peer {
-            self.state
-                .event_tx
-                .send(crate::Event::IncomingTransferCanceled(
-                    self.xfer.clone(),
-                    by_peer,
-                ))
-                .await
-                .expect("Could not send a file cancelled event, channel closed");
-        }
+        futures::future::join_all(tasks).await;
     }
 
     async fn on_text_msg(&mut self, _: &mut WebSocket, text: &str) -> anyhow::Result<()> {
@@ -493,7 +476,6 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 
     async fn finalize_success(mut self) {
         debug!(self.logger, "Finalizing");
-        self.on_stop().await;
 
         let files = self
             .state

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -692,6 +692,7 @@ scenarios = [
                             },
                         )
                     ),
+                    action.Sleep(1),
                     action.CancelTransferRequest(0),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
@@ -956,6 +957,7 @@ scenarios = [
                             },
                         )
                     ),
+                    action.SleepMs(200),
                     action.CancelTransferRequest(0),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
@@ -1000,28 +1002,31 @@ scenarios = [
             "ren": ActionList(
                 [
                     action.Start("172.20.0.5"),
-                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-big"]),
+                    action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
                             0,
                             {
                                 event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
                                 ),
                             },
                         )
                     ),
                     action.CancelTransferRequest(0),
                     action.Wait(event.FinishTransferCanceled(0, False)),
-                    action.NoEvent(),
+                    action.Sleep(4),
                     action.Stop(),
                 ]
             ),
             "stimpy": ActionList(
                 [
-                    action.Sleep(8),
+                    action.Sleep(1),
                     action.Start("172.20.0.15"),
-                    action.NoEvent(),
+                    action.NoEvent(4),
+                    action.AssertTransfers([], 0),
                     action.Stop(),
                 ]
             ),
@@ -5034,12 +5039,14 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-small"].id, False)
                     ),
+                    action.SleepMs(200),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
                     action.Wait(
                         event.FinishFileFailed(
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         ),
                     ),
+                    action.SleepMs(200),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                     action.Stop(),
@@ -6148,28 +6155,18 @@ scenarios = [
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
                     action.Stop(),
-                    action.Sleep(4),
+                    action.Sleep(2),
                     action.Start("172.20.0.5", dbpath="/tmp/db/29-8-ren.sqlite"),
                 ]
             ),
             "stimpy": ActionList(
                 [
-                    action.Sleep(4),
+                    action.Sleep(1),
                     action.Start("172.20.0.15"),
-                    action.Wait(
-                        event.Receive(
-                            0,
-                            "172.20.0.5",
-                            {
-                                event.File(
-                                    FILES["testfile-big"].id, "testfile-big", 10485760
-                                ),
-                            },
-                        )
-                    ),
-                    action.Wait(
-                        event.FinishTransferCanceled(0, True),
-                    ),
+                    action.Sleep(4),
+                    # No events, just updated database
+                    action.AssertTransfers([], 0),
+                    action.Stop(),
                 ]
             ),
         },
@@ -6793,6 +6790,7 @@ scenarios = [
         {
             "ren": ActionList(
                 [
+                    action.SleepMs(400),
                     action.Start("172.20.0.5", dbpath="/tmp/db/31-1-ren.sqlite"),
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -6849,6 +6847,7 @@ scenarios = [
                     }"""
                         ]
                     ),
+                    action.SleepMs(200),
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
@@ -7293,6 +7292,7 @@ scenarios = [
         {
             "ren": ActionList(
                 [
+                    action.SleepMs(400),
                     action.Start("172.20.0.5"),
                     action.NewTransfer("172.20.0.15", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7351,6 +7351,7 @@ scenarios = [
                     }"""
                         ]
                     ),
+                    action.SleepMs(200),
                     action.CancelTransferRequest(0),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),


### PR DESCRIPTION
This feature was requested by the Android team. They wanted to suppress showing the UI for transfers that are going to be canceled immediately 