### PR TITLE
Force recheck from the receiver side for active transfers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+### v5.1.0
+### **Silver Bullet**
+---
+* Suppress synchronization of transfers cancelled before the receiver got a chance to receive the transfer request.\
+This fixes the case when transfer cancelled on the sender side caused `TransferCancelled` being fired immedieatly after `TransferRequest`.\
+With this change the transfer would not be seen on the receiver side at all.
+* Implement a periodic transfer state check in case of stalled transfer for the receiver
+
+---
+<br>
+
 ### v5.0.1
 ### **Broken Records**
 ---

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -36,3 +36,4 @@ pub const CONNECTION_MAX_RETRY_INTERVAL: Duration = Duration::new(10, 0);
 pub const MAX_UPLOADS_IN_FLIGHT: usize = 4;
 pub const MAX_REQUESTS_PER_SEC: u32 = 50;
 pub const WS_SEND_TIMEOUT: Duration = Duration::new(20, 0);
+pub const ALIVE_CHECK_INTERVAL: Duration = Duration::new(60, 0);

--- a/drop-transfer/src/check.rs
+++ b/drop-transfer/src/check.rs
@@ -1,0 +1,118 @@
+use std::{net::SocketAddr, ops::ControlFlow, sync::Arc};
+
+use hyper::StatusCode;
+use slog::{debug, info, warn, Logger};
+use tokio_util::sync::CancellationToken;
+
+use crate::{auth, protocol, service::State, tasks::AliveGuard, IncomingTransfer, Transfer};
+
+pub(crate) fn spawn(
+    state: Arc<State>,
+    xfer: Arc<IncomingTransfer>,
+    logger: Logger,
+    guard: AliveGuard,
+    stop: CancellationToken,
+) {
+    let id = xfer.id();
+    let job = run(state, xfer, logger.clone());
+
+    tokio::spawn(async move {
+        let _guard = guard;
+
+        tokio::select! {
+            biased;
+
+            _ = stop.cancelled() => {
+                debug!(logger, "Check job stop for transfer: {id}");
+            },
+            _ = job => (),
+        }
+    });
+}
+
+async fn run(state: Arc<State>, xfer: Arc<IncomingTransfer>, logger: Logger) {
+    loop {
+        tokio::time::sleep(drop_config::ALIVE_CHECK_INTERVAL).await;
+
+        if !state.transfer_manager.is_incoming_alive(xfer.id()).await {
+            break;
+        }
+
+        if make_request(&state.auth, &xfer, &logger).await.is_break() {
+            break;
+        }
+    }
+
+    info!(logger, "Transfer {} is gone. Clearing", xfer.id());
+    if let Err(err) = state.transfer_manager.incoming_remove(xfer.id()).await {
+        warn!(logger, "Failed to clear incoming transfer: {err:?}");
+    }
+}
+
+async fn make_request(
+    auth: &auth::Context,
+    xfer: &IncomingTransfer,
+    logger: &Logger,
+) -> ControlFlow<()> {
+    let addr = SocketAddr::new(xfer.peer(), drop_config::PORT);
+    let client = hyper::Client::new();
+    let versions_to_try = [protocol::Version::V5];
+
+    for version in versions_to_try {
+        let url: hyper::Uri = format!("http://{addr}/drop/{version}/check/{}", xfer.id())
+            .parse()
+            .expect("URL should be valid");
+
+        debug!(logger, "Making HTTP request: {url}");
+
+        let mut response = client.get(url.clone()).await;
+
+        match &response {
+            Ok(resp) if resp.status() == StatusCode::UNAUTHORIZED => {
+                debug!(logger, "Creating 'authorization' header");
+
+                match auth.create_authorization_header(resp, xfer.peer()) {
+                    Ok((key, value)) => {
+                        debug!(logger, "Building 'authorization' request");
+
+                        let req = hyper::Request::get(url)
+                            .header(key, value)
+                            .body(hyper::Body::empty())
+                            .expect("Creating request should not fail");
+
+                        response = client.request(req).await;
+                    }
+                    Err(err) => warn!(logger, "Failed to extract authentication header: {err:?}"),
+                }
+            }
+            _ => (),
+        }
+
+        match response {
+            Ok(resp) => {
+                let status = resp.status();
+
+                if status == StatusCode::OK {
+                    break;
+                } else if status == StatusCode::GONE {
+                    return ControlFlow::Break(());
+                } else {
+                    debug!(
+                        logger,
+                        "Check returned {status}, trying again with lower version"
+                    );
+                }
+            }
+            Err(err) => {
+                debug!(
+                    logger,
+                    "Failed to check if transfer {} is alive: {err:?}",
+                    xfer.id()
+                );
+                break;
+            }
+        }
+    }
+
+    ControlFlow::Continue(())
+}

--- a/drop-transfer/src/lib.rs
+++ b/drop-transfer/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+mod check;
 mod error;
 pub mod event;
 pub mod file;

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -425,15 +425,21 @@ impl TransferManager {
         })
     }
 
-    pub async fn incoming_remove(&self, transfer_id: Uuid) -> crate::Result<()> {
+    /// Returns `true` if the cancel event should be suppressed
+    pub async fn incoming_remove(&self, transfer_id: Uuid) -> crate::Result<bool> {
         let mut lock = self.incoming.lock().await;
         if !lock.contains_key(&transfer_id) {
             return Err(crate::Error::BadTransfer);
         }
         self.storage.transfer_sync_clear(transfer_id).await;
-        lock.remove(&transfer_id);
 
-        Ok(())
+        let was_cancelled = if let Some(state) = lock.remove(&transfer_id) {
+            matches!(state.xfer_sync.local, sync::TransferState::Canceled)
+        } else {
+            true
+        };
+
+        Ok(was_cancelled)
     }
 
     pub async fn is_incoming_alive(&self, transfer_id: Uuid) -> bool {

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -84,7 +84,6 @@ impl Service {
             ws::server::spawn(
                 addr,
                 state.clone(),
-                auth,
                 logger.clone(),
                 stop.clone(),
                 guard.clone(),


### PR DESCRIPTION
I've implemented two things:
* server endpoint for checking transfer state
* client loop issuing request for this endpoint on the receiver side of things

I've also added a test case, which sadly takes a lot of time to execute