### PR TITLE
Adjust test runner for docker compose 2.21. Print the docker compose …

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,4 +15,4 @@ jobs:
           default: true
       - name: run tests
         run: |
-          make -C test
+          docker compose version && make -C test


### PR DESCRIPTION
…version on CI

Recently docker cli got an update 2.21 in which they changed the cli output we're parsing. The update landed in Ubuntu 22.04 thus breaking the test framework.
This PR fixes the problem