### PR TITLE
Fix `FileDone` and `TransferCancelation` message reordering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 This fixes the case when transfer cancelled on the sender side caused `TransferCancelled` being fired immedieatly after `TransferRequest`.\
 With this change the transfer would not be seen on the receiver side at all.
 * Implement a periodic transfer state check in case of stalled transfer for the receiver
+* Fix occasional events reordering, for example file done swapped transfer cancelation, on the sender side 
 
 ---
 <br>

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -867,6 +867,9 @@ impl IncomingState {
 
                     Some(ServerReq::Fail {
                         file: file_id.clone(),
+                        msg: String::from(
+                            "File failed. The failed state was retrieved from the database.",
+                        ),
                     })
                 }
                 _ => None,

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -34,14 +34,20 @@ pub trait HandlerInit {
 
 #[async_trait::async_trait]
 pub trait HandlerLoop {
-    async fn issue_download(
+    async fn start_download(&mut self, ctx: super::FileStreamCtx<'_>) -> anyhow::Result<()>;
+    async fn issue_start(
         &mut self,
         ws: &mut WebSocket,
-        jobs: &mut JoinSet<()>,
-        task: super::FileXferTask,
+        file: FileId,
+        offset: u64,
     ) -> anyhow::Result<()>;
     async fn issue_reject(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
-    async fn issue_failure(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
+    async fn issue_failure(
+        &mut self,
+        ws: &mut WebSocket,
+        file: FileId,
+        msg: String,
+    ) -> anyhow::Result<()>;
     async fn issue_done(&mut self, ws: &mut WebSocket, file: FileId) -> anyhow::Result<()>;
 
     async fn on_close(&mut self);
@@ -68,8 +74,6 @@ pub trait Downloader {
     async fn init(&mut self, task: &super::FileXferTask) -> crate::Result<DownloadInit>;
     async fn open(&mut self, tmp_location: &Hidden<PathBuf>) -> crate::Result<fs::File>;
     async fn progress(&mut self, bytes: u64) -> crate::Result<()>;
-    async fn done(&mut self, bytes: u64) -> crate::Result<()>;
-    async fn error(&mut self, msg: String) -> crate::Result<()>;
     async fn validate(&mut self, location: &Hidden<PathBuf>) -> crate::Result<()>;
 }
 

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -37,7 +37,6 @@ pub struct HandlerInit<'a> {
 pub struct HandlerLoop<'a> {
     state: Arc<State>,
     logger: &'a slog::Logger,
-    alive: &'a AliveGuard,
     msg_tx: Sender<MsgToSend>,
     xfer: Arc<IncomingTransfer>,
     jobs: HashMap<FileId, FileTask>,
@@ -192,7 +191,6 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             jobs: HashMap::new(),
             logger,
             checksums,
-            alive,
         })
     }
 
@@ -345,15 +343,10 @@ impl HandlerLoop<'_> {
 
 #[async_trait::async_trait]
 impl handler::HandlerLoop for HandlerLoop<'_> {
-    async fn issue_download(
-        &mut self,
-        _: &mut WebSocket,
-        jobs: &mut JoinSet<()>,
-        task: super::FileXferTask,
-    ) -> anyhow::Result<()> {
+    async fn start_download(&mut self, ctx: super::FileStreamCtx<'_>) -> anyhow::Result<()> {
         let is_running = self
             .jobs
-            .get(task.file.id())
+            .get(ctx.task.file.id())
             .map_or(false, |state| !state.job.is_finished());
 
         if is_running {
@@ -362,7 +355,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
 
         let full_csum_cell = self
             .checksums
-            .get(task.file.id())
+            .get(ctx.task.file.id())
             .context("Missing file checksum cell")?
             .clone();
 
@@ -370,7 +363,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         let (csum_tx, csum_rx) = mpsc::channel(4);
 
         let downloader = Downloader {
-            file_id: task.file.id().clone(),
+            file_id: ctx.task.file.id().clone(),
             msg_tx: self.msg_tx.clone(),
             logger: self.logger.clone(),
             csum_rx,
@@ -378,17 +371,8 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             offset: 0,
         };
 
-        let file_id = task.file.id().clone();
-        let (job, events) = super::start_download(
-            jobs,
-            self.alive.clone(),
-            self.state.clone(),
-            task,
-            downloader,
-            chunks_rx,
-            self.logger.clone(),
-        )
-        .await?;
+        let file_id = ctx.task.file.id().clone();
+        let (job, events) = ctx.start(downloader, chunks_rx).await?;
 
         self.jobs.insert(
             file_id,
@@ -421,10 +405,11 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         &mut self,
         socket: &mut WebSocket,
         file_id: FileId,
+        msg: String,
     ) -> anyhow::Result<()> {
         let msg = prot::ServerMsg::Error(prot::Error {
             file: Some(file_id),
-            msg: String::from("File failed elsewhere"),
+            msg,
         });
         socket.send(Message::from(&msg)).await?;
 
@@ -437,6 +422,20 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         let msg = prot::ServerMsg::Done(prot::Done {
             file: file_id,
             bytes_transfered: file.size(),
+        });
+        socket.send(Message::from(&msg)).await?;
+        Ok(())
+    }
+
+    async fn issue_start(
+        &mut self,
+        socket: &mut WebSocket,
+        file_id: FileId,
+        offset: u64,
+    ) -> anyhow::Result<()> {
+        let msg = prot::ServerMsg::Start(prot::Start {
+            file: file_id.clone(),
+            offset,
         });
         socket.send(Message::from(&msg)).await?;
         Ok(())
@@ -604,12 +603,6 @@ impl handler::Downloader for Downloader {
             }
         };
 
-        let msg = prot::ServerMsg::Start(prot::Start {
-            file: self.file_id.clone(),
-            offset: self.offset,
-        });
-        self.send(Message::from(&msg)).await?;
-
         Ok(handler::DownloadInit::Stream {
             offset: self.offset,
             tmp_location,
@@ -630,22 +623,6 @@ impl handler::Downloader for Downloader {
         self.send(&prot::ServerMsg::Progress(prot::Progress {
             file: self.file_id.clone(),
             bytes_transfered: bytes,
-        }))
-        .await
-    }
-
-    async fn done(&mut self, bytes: u64) -> crate::Result<()> {
-        self.send(&prot::ServerMsg::Done(prot::Done {
-            file: self.file_id.clone(),
-            bytes_transfered: bytes,
-        }))
-        .await
-    }
-
-    async fn error(&mut self, msg: String) -> crate::Result<()> {
-        self.send(&prot::ServerMsg::Error(prot::Error {
-            file: Some(self.file_id.clone()),
-            msg,
         }))
         .await
     }


### PR DESCRIPTION
Is blocked by https://github.com/NordSecurity/libdrop/pull/199

The commit message describes it fully. 
I couldn't reproduce the issue. However, I do see a logic flaw which can lead to it.
There are plenty of test cases that should exercise this (file transferred, then transfer cancelation) and none of them fails spectacularly, suggesting that the issue is super rare to observe