### PR TITLE
Try not to make use of the remote transfer state, kept in the database

### DIFF
--- a/drop-storage/migrations/004-sync-cleanup/up.sql
+++ b/drop-storage/migrations/004-sync-cleanup/up.sql
@@ -1,0 +1,4 @@
+-- Add migration script here
+
+ALTER TABLE sync_transfer DROP COLUMN remote_state;
+

--- a/drop-storage/src/lib.rs
+++ b/drop-storage/src/lib.rs
@@ -123,25 +123,10 @@ impl Storage {
         }
     }
 
-    pub async fn update_transfer_sync_states(
-        &self,
-        transfer_id: Uuid,
-        remote: Option<sync::TransferState>,
-        local: Option<sync::TransferState>,
-    ) {
+    pub async fn update_transfer_sync_states(&self, transfer_id: Uuid, local: sync::TransferState) {
         let task = async {
-            let mut conn = self.conn.lock().await;
-            let conn = conn.transaction()?;
-
-            if let Some(remote) = remote {
-                sync::transfer_set_remote_state(&conn, transfer_id, remote)?;
-            }
-            if let Some(local) = local {
-                sync::transfer_set_local_state(&conn, transfer_id, local)?;
-            }
-
-            conn.commit()?;
-
+            let conn = self.conn.lock().await;
+            sync::transfer_set_local_state(&conn, transfer_id, local)?;
             Ok::<(), Error>(())
         };
 

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -146,11 +146,7 @@ impl TransferManager {
                 }
 
                 self.storage
-                    .update_transfer_sync_states(
-                        xfer.id(),
-                        Some(sync::TransferState::Active),
-                        Some(sync::TransferState::Active),
-                    )
+                    .update_transfer_sync_states(xfer.id(), sync::TransferState::Active)
                     .await;
 
                 vacc.insert(IncomingState {
@@ -188,11 +184,7 @@ impl TransferManager {
 
         if let sync::TransferState::New = state.xfer_sync {
             self.storage
-                .update_transfer_sync_states(
-                    transfer_id,
-                    Some(sync::TransferState::Active),
-                    Some(sync::TransferState::Active),
-                )
+                .update_transfer_sync_states(transfer_id, sync::TransferState::Active)
                 .await;
 
             state.xfer_sync = sync::TransferState::Active;
@@ -558,11 +550,7 @@ impl TransferManager {
         state.ensure_not_cancelled()?;
 
         self.storage
-            .update_transfer_sync_states(
-                transfer_id,
-                None,
-                Some(drop_storage::sync::TransferState::Canceled),
-            )
+            .update_transfer_sync_states(transfer_id, drop_storage::sync::TransferState::Canceled)
             .await;
         state.xfer_sync = sync::TransferState::Canceled;
 
@@ -612,8 +600,7 @@ impl TransferManager {
                 self.storage
                     .update_transfer_sync_states(
                         transfer_id,
-                        None,
-                        Some(drop_storage::sync::TransferState::Canceled),
+                        drop_storage::sync::TransferState::Canceled,
                     )
                     .await;
                 state.xfer_sync = sync::TransferState::Canceled;


### PR DESCRIPTION
This removes the `remote` transfer state from the database.
This stems from the discussion with @LukasPukenis that it should be safe to delete this information from the database