### PR TITLE
Fix: sender emits file finished each time it connects to the receiver

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ This fixes the case when transfer cancelled on the sender side caused `TransferC
 With this change the transfer would not be seen on the receiver side at all.
 * Implement a periodic transfer state check in case of stalled transfer for the receiver
 * Fix occasional events reordering, for example file done swapped transfer cancelation, on the sender side 
+* Fix repeated `FileDone` events on the sender, when reconnecting to the  receiver.
 
 ---
 <br>

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap},
     sync::Arc,
 };
 
@@ -33,7 +33,6 @@ pub struct HandlerLoop<'a> {
     alive: &'a AliveGuard,
     upload_tx: Sender<MsgToSend>,
     tasks: HashMap<FileId, FileTask>,
-    done: HashSet<FileId>,
     xfer: Arc<OutgoingTransfer>,
 }
 
@@ -91,7 +90,6 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             upload_tx,
             xfer,
             tasks: HashMap::new(),
-            done: HashSet::new(),
         }
     }
 
@@ -247,7 +245,6 @@ impl HandlerLoop<'_> {
                 }
             };
 
-            self.done.remove(&file_id);
             anyhow::Ok(())
         };
 

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -117,27 +117,20 @@ impl HandlerLoop<'_> {
     }
 
     async fn on_done(&mut self, file_id: FileId) {
-        if let Err(err) = self
+        match self
             .state
             .transfer_manager
             .outgoing_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Completed)
             .await
         {
-            warn!(self.logger, "Failed to accept file as done: {err}");
+            Err(err) => {
+                warn!(self.logger, "Failed to accept file as done: {err}");
+            }
+            Ok(Some(res)) => res.events.success().await,
+            Ok(None) => (),
         }
 
-        if let Some(task) = self.tasks.remove(&file_id) {
-            task.events.success().await;
-        } else if !self.done.contains(&file_id) {
-            let event = crate::Event::FileUploadSuccess(self.xfer.clone(), file_id.clone());
-            self.state
-                .event_tx
-                .send(event)
-                .await
-                .expect("Failed to emit event");
-        }
-
-        self.done.insert(file_id);
+        self.stop_task(&file_id, Status::FileFinished).await;
     }
 
     async fn on_checksum(&mut self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap},
     sync::Arc,
 };
 
@@ -33,7 +33,6 @@ pub struct HandlerLoop<'a> {
     alive: &'a AliveGuard,
     upload_tx: Sender<MsgToSend>,
     tasks: HashMap<FileId, FileTask>,
-    done: HashSet<FileId>,
     xfer: Arc<OutgoingTransfer>,
 }
 
@@ -91,7 +90,6 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             upload_tx,
             xfer,
             tasks: HashMap::new(),
-            done: HashSet::new(),
         }
     }
 
@@ -279,7 +277,6 @@ impl HandlerLoop<'_> {
                 }
             };
 
-            self.done.remove(&file_id);
             anyhow::Ok(())
         };
 

--- a/drop-transfer/src/ws/events.rs
+++ b/drop-transfer/src/ws/events.rs
@@ -235,7 +235,7 @@ impl FileEventTx<OutgoingTransfer> {
     }
 
     pub async fn success(&self) {
-        self.stop(
+        self.force_stop(
             crate::Event::FileUploadSuccess(self.xfer.clone(), self.file_id.clone()),
             Ok(()),
         )


### PR DESCRIPTION
I noticed that the `TransferManager::outgoing_terminal_recv()` already reports that the file is already terminated, just the code inside the clients was simply ignoring it. Hence the event was emitted even though the file was already terminated.

I managed to do a little™ refactor :smile: as well.

I think it best to review this PR commit by commit
