### PR TITLE
Fix: the docker network can reuse ip address between the containers failing some of the scenarios

### DIFF
--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7995,6 +7995,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
+                    action.WaitForAnotherPeer(),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(


### PR DESCRIPTION
Upon inspecting the containers I found that the MAC address is being reused across the containers (they are reassigned even between stopping and starting the container).
I decided to assign MAC addresses incrementally since that was causing the IP reuse in the first place (all the sane DHCP implementations won't share IPs between different MAC addresses, I guess).