### PR TITLE
norddrop: Disable rlib builds

### DIFF
--- a/norddrop/Cargo.toml
+++ b/norddrop/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Lukas Pukenis"]
 edition = "2021"
 
 [lib]
-crate-type = ["staticlib", "cdylib", "lib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 uuid = { workspace = true }


### PR DESCRIPTION
Building rlibs breaks on Windows due to winresource setting the +whole-archive link modifier. This commit disables rlib builds for lack of a better solution.