### PR TITLE
Fix: sending identical named folders from different paths end up as a single folder with contents merged

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ---
 * Use unbounded events queue in order to disable back pressure on the connection handlers in case the event callback blocks.
 * Improve the suppression of the `TransferRequest` and `TransferCancelled` event pair for cancelled transfers.
+* Fix same named directories being merged on the sender side
 
 ---
 <br>

--- a/drop-transfer/src/file/gather.rs
+++ b/drop-transfer/src/file/gather.rs
@@ -1,0 +1,116 @@
+#[cfg(unix)]
+use std::os::unix::prelude::*;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
+
+use drop_config::DropConfig;
+
+use crate::FileToSend;
+
+pub enum GatherSrc {
+    Path(PathBuf),
+    #[cfg(unix)]
+    ContentUri {
+        uri: url::Url,
+        subpath: String,
+        fd: Option<RawFd>,
+    },
+}
+
+pub struct GatherCtx<'a> {
+    config: &'a DropConfig,
+    #[cfg(unix)]
+    fdresolv: Option<&'a super::FdResolver>,
+    files: Vec<FileToSend>,
+    used_names: HashSet<PathBuf>,
+}
+
+impl<'a> GatherCtx<'a> {
+    pub fn new(config: &'a DropConfig) -> Self {
+        Self {
+            config,
+            fdresolv: None,
+            files: Vec::new(),
+            used_names: HashSet::new(),
+        }
+    }
+
+    pub fn with_fd_resover(&mut self, fdresolv: &'a super::FdResolver) -> &mut Self {
+        self.fdresolv = Some(fdresolv);
+        self
+    }
+
+    pub fn take(&mut self) -> Vec<FileToSend> {
+        self.used_names.clear();
+        std::mem::take(&mut self.files)
+    }
+
+    fn fetch_free_name(&mut self, path: &Path) -> crate::Result<PathBuf> {
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| crate::Error::BadPath("Missing file name".into()))?;
+
+        let name = crate::utils::filepath_variants(Path::new(file_name))?
+            .find(|name| !self.used_names.contains(name))
+            .expect("The filename variants interator is unbounded");
+
+        self.used_names.insert(name.clone());
+        Ok(name)
+    }
+
+    pub fn gather_from_path(&mut self, path: impl AsRef<Path>) -> crate::Result<&mut Self> {
+        let path = path.as_ref();
+        let name = self.fetch_free_name(path)?;
+
+        let batch = super::FileToSend::from_path(path, &name, self.config)?;
+        self.files.extend(batch);
+        Ok(self)
+    }
+
+    #[cfg(unix)]
+    pub fn gather_from_content_uri(
+        &mut self,
+        path: impl AsRef<Path>,
+        uri: url::Url,
+        fd: Option<RawFd>,
+    ) -> crate::Result<&mut Self> {
+        use super::FileSubPath;
+
+        let path = path.as_ref();
+
+        let fd = if let Some(fd) = fd {
+            fd
+        } else {
+            let fdresolv = if let Some(fdresolv) = self.fdresolv.as_ref() {
+                fdresolv
+            } else {
+                return Err(crate::Error::BadTransferState(
+                    "Content URI provided but RD resolver callback is not set up".into(),
+                ));
+            };
+
+            if let Some(fd) = fdresolv(uri.as_str()) {
+                fd
+            } else {
+                return Err(crate::Error::BadTransferState(format!(
+                    "Failed to fetch FD for file: {uri}"
+                )));
+            }
+        };
+
+        let name = self.fetch_free_name(path)?;
+
+        let file = FileToSend::from_fd(
+            path,
+            FileSubPath::from_path(name)?,
+            uri,
+            fd,
+            self.files.len(),
+        )?;
+
+        self.files.push(file);
+        Ok(self)
+    }
+}

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -1,3 +1,4 @@
+mod gather;
 mod id;
 mod reader;
 
@@ -11,6 +12,7 @@ use std::{os::unix::prelude::*, sync::Arc};
 
 use drop_analytics::{FileInfo, TransferDirection};
 use drop_config::DropConfig;
+pub use gather::*;
 pub use id::{FileId, FileSubPath};
 use once_cell::sync::OnceCell;
 pub use reader::FileReader;
@@ -146,21 +148,20 @@ impl FileToRecv {
 }
 
 impl FileToSend {
-    pub fn from_path(path: impl Into<PathBuf>, config: &DropConfig) -> Result<Vec<Self>, Error> {
+    fn from_path(
+        path: impl Into<PathBuf>,
+        name: &Path,
+        config: &DropConfig,
+    ) -> Result<Vec<Self>, Error> {
         let path = path.into();
         let meta = fs::symlink_metadata(&path)?;
         let abspath = crate::utils::make_path_absolute(&path)?;
         let file_id = file_id_from_path(&abspath)?;
 
         let files = if meta.is_dir() {
-            Self::walk(&path, config)?
+            Self::walk(&path, name, config)?
         } else {
-            let file = Self::new(
-                FileSubPath::from_file_name(&path)?,
-                abspath,
-                meta.len(),
-                file_id,
-            );
+            let file = Self::new(FileSubPath::from_path(name)?, abspath, meta.len(), file_id);
             vec![file]
         };
 
@@ -180,16 +181,15 @@ impl FileToSend {
     }
 
     #[cfg(unix)]
-    pub fn from_fd(
-        path: impl AsRef<Path>,
+    fn from_fd(
+        path: &Path,
+        subpath: FileSubPath,
         content_uri: url::Url,
         fd: RawFd,
         unique_id: usize,
     ) -> Result<Self, Error> {
-        let subpath = FileSubPath::from_file_name(path.as_ref())?;
-
         let mut hash = sha2::Sha256::new();
-        hash.update(path.as_ref().as_os_str().as_bytes());
+        hash.update(path.as_os_str().as_bytes());
         hash.update(unique_id.to_ne_bytes());
         let file_id = FileId::from(hash);
 
@@ -243,11 +243,7 @@ impl FileToSend {
         }
     }
 
-    fn walk(path: &Path, config: &DropConfig) -> Result<Vec<Self>, Error> {
-        let parent = path
-            .parent()
-            .ok_or_else(|| crate::Error::BadPath("Missing parent directory".into()))?;
-
+    fn walk(path: &Path, subname: &Path, config: &DropConfig) -> Result<Vec<Self>, Error> {
         let mut files = Vec::new();
         let mut breadth = 0;
 
@@ -269,11 +265,12 @@ impl FileToSend {
                 return Err(Error::TransferLimitsExceeded);
             }
 
-            let subpath = entry
+            let relpath = entry
                 .path()
-                .strip_prefix(parent)
+                .strip_prefix(path)
                 .map_err(|err| crate::Error::BadPath(err.to_string()))?;
 
+            let subpath = PathBuf::from_iter([subname, relpath]);
             let subpath = FileSubPath::from_path(subpath)?;
 
             let path = entry.into_path();
@@ -345,6 +342,8 @@ fn infer_mime(mut reader: impl io::Read) -> io::Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     const TEST: &[u8] = b"abc";
     const EXPECTED: &[u8] = b"\xba\x78\x16\xbf\x8f\x01\xcf\xea\x41\x41\x40\xde\x5d\xae\x22\x23\xb0\x03\x61\xa3\x96\x17\x7a\x9c\xb4\x10\xff\x61\xf2\x00\x15\xad";
 
@@ -364,8 +363,12 @@ mod tests {
             let mut tmp = tempfile::NamedTempFile::new().expect("Failed to create tmp file");
             tmp.write_all(TEST).unwrap();
 
-            let file =
-                &super::FileToSend::from_path(tmp.path(), &DropConfig::default()).unwrap()[0];
+            let file = &super::FileToSend::from_path(
+                tmp.path(),
+                Path::new(tmp.path().file_name().unwrap()),
+                &DropConfig::default(),
+            )
+            .unwrap()[0];
             let size = file.size;
 
             assert_eq!(size, TEST.len() as u64);

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -515,10 +515,14 @@ impl NordDropFFI {
         &self,
         descriptors: &[TransferDescriptor],
     ) -> Result<Vec<FileToSend>> {
-        let mut files = Vec::new();
+        let mut gather = drop_transfer::file::GatherCtx::new(&self.config.drop);
 
-        #[allow(unused_variables)]
-        for (i, desc) in descriptors.iter().enumerate() {
+        #[cfg(unix)]
+        if let Some(fdresolv) = self.fdresolv.as_ref() {
+            gather.with_fd_resover(fdresolv.as_ref());
+        }
+
+        for desc in descriptors {
             if let Some(content_uri) = &desc.content_uri {
                 #[cfg(target_os = "windows")]
                 {
@@ -531,53 +535,29 @@ impl NordDropFFI {
 
                 #[cfg(not(target_os = "windows"))]
                 {
-                    let fd = if let Some(fd) = desc.fd {
-                        fd
-                    } else {
-                        let fdresolv = if let Some(fdresolv) = self.fdresolv.as_ref() {
-                            fdresolv
-                        } else {
+                    gather
+                        .gather_from_content_uri(&desc.path.0, content_uri.clone(), desc.fd)
+                        .map_err(|err| {
                             error!(
                                 self.logger,
-                                "Content URI provided but RD resolver callback is not set up"
-                            );
-                            return Err(ffi::types::NORDDROP_RES_TRANSFER_CREATE);
-                        };
-
-                        if let Some(fd) = fdresolv(content_uri.as_str()) {
-                            fd
-                        } else {
-                            error!(self.logger, "Failed to fetch FD for file: {content_uri}");
-                            return Err(ffi::types::NORDDROP_RES_TRANSFER_CREATE);
-                        }
-                    };
-
-                    let file = FileToSend::from_fd(&desc.path.0, content_uri.clone(), fd, i)
-                        .map_err(|e| {
-                            error!(
-                                self.logger,
-                                "Could not open file {desc:?} for transfer ({descriptors:?}): {e}",
+                                "Could not open file {desc:?} for transfer ({descriptors:?}): \
+                                 {err}",
                             );
                             ffi::types::NORDDROP_RES_TRANSFER_CREATE
                         })?;
-
-                    files.push(file);
                 }
             } else {
-                let batch =
-                    FileToSend::from_path(&desc.path.0, &self.config.drop).map_err(|e| {
-                        error!(
-                            self.logger,
-                            "Could not open file {desc:?} for transfer ({descriptors:?}): {e}",
-                        );
-                        ffi::types::NORDDROP_RES_TRANSFER_CREATE
-                    })?;
-
-                files.extend(batch);
+                gather.gather_from_path(&desc.path.0).map_err(|e| {
+                    error!(
+                        self.logger,
+                        "Could not open file {desc:?} for transfer ({descriptors:?}): {e}",
+                    );
+                    ffi::types::NORDDROP_RES_TRANSFER_CREATE
+                })?;
             }
         }
 
-        Ok(files)
+        Ok(gather.take())
     }
 }
 

--- a/test/drop_test/config.py
+++ b/test/drop_test/config.py
@@ -117,6 +117,12 @@ FILES = {
     "duplicate/testfile-big": TestFile(
         size=20 * 1024, id="Jr2sHMHPjPP5Y19bGJMf17GeT3B4Jrs1ozB1UnFcRzo"
     ),
+    "name/file-01": TestFile(
+        size=1 * 1024, id="weFjoDnlpN1C-pig-4GDPt1l38vuoStZpmUWedbSpYw"
+    ),
+    "different/name/file-02": TestFile(
+        size=1 * 1024, id="I_kCIoGtH-r0iHxtMQDgSLU84lNSHeGbemic7YGH_dU"
+    ),
 }
 
 DBFILES = {"26-1-corrupted.sqlite": b"this is a corrupted sqlite file"}

--- a/test/prepare_files.sh
+++ b/test/prepare_files.sh
@@ -7,6 +7,8 @@ mkdir -p /tmp/deep/path
 mkdir -p /tmp/deep/another-path
 mkdir -p /tmp/nested/big
 mkdir -p /tmp/duplicate
+mkdir -p /tmp/name
+mkdir -p /tmp/different/name
 
 # FILES dictionary
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
@@ -34,6 +36,8 @@ dd bs=1024K count=1 if=/dev/urandom of="/tmp/with-illegal-char-
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/duplicate/testfile-small"
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/duplicate/testfile.small.with.complicated.extension"
 dd bs=10240K count=2 if=/dev/urandom of="/tmp/duplicate/testfile-big"
+dd bs=1024K count=1 if=/dev/urandom of="/tmp/name/file-01"
+dd bs=1024K count=1 if=/dev/urandom of="/tmp/different/name/file-02"
 
 touch "/tmp/zero-sized-file"
 


### PR DESCRIPTION
This was reported as a bug. So here is the fix.
I've implemented the dedicated file-gathering methods so that it's easier to inspect and reuse those.
The logical change is recording file names in the hash set and checking if the name already exists. If it does then (1), (2),... suffix is added to the subpath's first component.

I'm not sure what to do with the file (not directories) names, it makes 23-1 failing. What do you think?