### PR TITLE
fix: still the receiver might get transfer request and transfer cancelled right after each other

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ### **Golden Bullet**
 ---
 * Use unbounded events queue in order to disable back pressure on the connection handlers in case the event callback blocks.
+* Improve the suppression of the `TransferRequest` and `TransferCancelled` event pair for cancelled transfers.
 
 ---
 <br>

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -312,8 +312,6 @@ impl RunContext<'_> {
         socket: &mut WebSocket,
         handler: &mut impl HandlerInit,
     ) -> crate::Result<Option<UnboundedReceiver<ClientReq>>> {
-        handler.start(socket, self.xfer).await?;
-
         let (tx, rx) = mpsc::unbounded_channel();
         match self
             .state
@@ -321,7 +319,7 @@ impl RunContext<'_> {
             .outgoing_connected(self.xfer.id(), tx)
             .await
         {
-            Ok(()) => (),
+            Ok(()) => handler.start(socket, self.xfer).await?,
             Err(crate::Error::BadTransfer) => return Ok(None),
             Err(err) => return Err(err),
         }

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -8426,4 +8426,41 @@ scenarios = [
             ),
         },
     ),
+    Scenario(
+        "scenario44",
+        "Check if the transfer request and cancelation are suppressed within a huge latency network",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.ConfigureNetwork(latency="1000ms"),
+                    action.Start("DROP_PEER_REN"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.Sleep(6),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.NoEvent(duration=8),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]


### PR DESCRIPTION
I've made a test case (failing before the fix) and a fix itself.
The full description of the fix is in the commit message.