### PR TITLE
FILE-501 peer online signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "uuid",
 ]
 
 [[package]]

--- a/drop-analytics/Cargo.toml
+++ b/drop-analytics/Cargo.toml
@@ -8,6 +8,7 @@ slog = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 moose = []

--- a/drop-analytics/src/file_impl.rs
+++ b/drop-analytics/src/file_impl.rs
@@ -84,7 +84,7 @@ impl FileImpl {
         // create unique temp path
         let temp_path = format!("{}.tmp.{}", self.event_path, uuid::Uuid::new_v4());
 
-        File::create(&temp_path)?.write_all(payload.as_bytes())?;
+        std::fs::write(&temp_path, payload.as_bytes())?;
         std::fs::rename(temp_path, &self.event_path)?;
 
         Ok(())

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -32,7 +32,6 @@ pub struct MooseConfig {
 pub const PORT: u16 = 49111;
 pub const TRANFER_IDLE_LIFETIME: Duration = Duration::new(60, 0);
 pub const PING_INTERVAL: Duration = Duration::new(30, 0);
-pub const CONNECTION_MAX_RETRY_INTERVAL: Duration = Duration::new(10, 0);
 pub const MAX_UPLOADS_IN_FLIGHT: usize = 4;
 pub const MAX_REQUESTS_PER_SEC: u32 = 50;
 pub const WS_SEND_TIMEOUT: Duration = Duration::new(20, 0);

--- a/drop-transfer/src/check.rs
+++ b/drop-transfer/src/check.rs
@@ -12,7 +12,7 @@ pub(crate) fn spawn(
     logger: Logger,
     guard: AliveGuard,
     stop: CancellationToken,
-) {
+) -> tokio::task::JoinHandle<()> {
     let id = xfer.id();
     let job = run(state, xfer, logger.clone());
 
@@ -27,7 +27,7 @@ pub(crate) fn spawn(
             },
             _ = job => (),
         }
-    });
+    })
 }
 
 async fn run(state: Arc<State>, xfer: Arc<IncomingTransfer>, logger: Logger) {

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -10,17 +10,13 @@ use drop_config::DropConfig;
 use drop_storage::{sync, types::OutgoingFileToRetry, Storage};
 use slog::{debug, error, info, warn, Logger};
 use tokio::sync::{mpsc::UnboundedSender, Mutex};
-use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
-    check,
     file::FileSubPath,
     service::State,
-    tasks::AliveGuard,
     transfer::{IncomingTransfer, OutgoingTransfer},
     ws::{
-        self,
         client::ClientReq,
         server::{FileXferTask, ServerReq},
         FileEventTx, FileEventTxFactory, IncomingFileEventTx, OutgoingFileEventTx,
@@ -970,41 +966,6 @@ impl OutgoingLocalFileState {
                 Ok(())
             }
             OutgoingLocalFileState::Terminal(state) => Err(crate::Error::FileStateMismatch(*state)),
-        }
-    }
-}
-
-pub(crate) async fn resume(
-    state: &Arc<State>,
-    logger: &Logger,
-    guard: &AliveGuard,
-    stop: &CancellationToken,
-) {
-    {
-        let xfers = state.transfer_manager.outgoing.lock().await;
-
-        for xstate in xfers.values() {
-            ws::client::spawn(
-                state.clone(),
-                xstate.xfer.clone(),
-                logger.clone(),
-                guard.clone(),
-                stop.clone(),
-            );
-        }
-    }
-
-    {
-        let xfers = state.transfer_manager.incoming.lock().await;
-
-        for xstate in xfers.values() {
-            check::spawn(
-                state.clone(),
-                xstate.xfer.clone(),
-                logger.clone(),
-                guard.clone(),
-                stop.clone(),
-            );
         }
     }
 }

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -89,39 +89,13 @@ impl Service {
 
             ws::server::spawn(state.clone(), logger.clone(), stop.clone(), guard.clone())?;
 
-            let mut service = Self {
+            Ok(Self {
                 state,
                 stop,
                 waiter,
                 logger,
                 tasks: Default::default(),
-            };
-
-            let outgoing_transfers = {
-                let xfers = service.state.transfer_manager.outgoing.lock().await;
-                xfers
-                    .values()
-                    .map(|xstate| xstate.xfer.clone())
-                    .collect::<Vec<_>>()
-            };
-
-            for xfer in outgoing_transfers {
-                service.trigger_peer_outgoing(xfer);
-            }
-
-            let incoming_transfers = {
-                let xfers = service.state.transfer_manager.incoming.lock().await;
-                xfers
-                    .values()
-                    .map(|xstate| xstate.xfer.clone())
-                    .collect::<Vec<_>>()
-            };
-
-            for xfer in incoming_transfers {
-                service.trigger_peer_incoming(xfer);
-            }
-
-            Ok(service)
+            })
         };
 
         let res = task.await;

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -189,38 +189,42 @@ impl Service {
 
     pub async fn set_peer_state(&mut self, addr: IpAddr, is_online: bool) {
         {
-            let outgoing_transfers_to_trigger = {
-                let xfers = self.state.transfer_manager.outgoing.lock().await;
+            if is_online {
+                let outgoing_transfers_to_trigger = {
+                    let xfers = self.state.transfer_manager.outgoing.lock().await;
 
-                xfers
-                    .values()
-                    .filter(|state| {
-                        let peer = state.xfer.peer();
-                        peer == addr && is_online
-                    })
-                    .map(|state| state.xfer.clone())
-                    .collect::<Vec<_>>()
-            };
+                    xfers
+                        .values()
+                        .filter(|state| {
+                            let peer = state.xfer.peer();
+                            peer == addr
+                        })
+                        .map(|state| state.xfer.clone())
+                        .collect::<Vec<_>>()
+                };
 
-            for xfer in outgoing_transfers_to_trigger {
-                self.trigger_peer_outgoing(xfer);
+                for xfer in outgoing_transfers_to_trigger {
+                    self.trigger_peer_outgoing(xfer);
+                }
             }
 
-            let incoming_transfers_to_trigger = {
-                let xfers = self.state.transfer_manager.incoming.lock().await;
+            if is_online {
+                let incoming_transfers_to_trigger = {
+                    let xfers = self.state.transfer_manager.incoming.lock().await;
 
-                xfers
-                    .values()
-                    .filter(|state| {
-                        let peer = state.xfer.peer();
-                        peer == addr && is_online
-                    })
-                    .map(|state| state.xfer.clone())
-                    .collect::<Vec<_>>()
-            };
+                    xfers
+                        .values()
+                        .filter(|state| {
+                            let peer = state.xfer.peer();
+                            peer == addr && is_online
+                        })
+                        .map(|state| state.xfer.clone())
+                        .collect::<Vec<_>>()
+                };
 
-            for xfer in incoming_transfers_to_trigger {
-                self.trigger_peer_incoming(xfer);
+                for xfer in incoming_transfers_to_trigger {
+                    self.trigger_peer_incoming(xfer);
+                }
             }
         }
     }

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -122,8 +122,6 @@ impl Service {
         if let Some(handle) = self.tasks.get(&id) {
             if !handle.is_finished() {
                 return;
-            } else {
-                self.tasks.remove(&id);
             }
         }
 
@@ -145,8 +143,6 @@ impl Service {
         if let Some(handle) = self.tasks.get(&id) {
             if !handle.is_finished() {
                 return;
-            } else {
-                self.tasks.remove(&id);
             }
         }
 
@@ -180,9 +176,7 @@ impl Service {
                 for xfer in outgoing_transfers_to_trigger {
                     self.trigger_peer_outgoing(xfer);
                 }
-            }
 
-            if is_online {
                 let incoming_transfers_to_trigger = {
                     let xfers = self.state.transfer_manager.incoming.lock().await;
 
@@ -190,7 +184,7 @@ impl Service {
                         .values()
                         .filter(|state| {
                             let peer = state.xfer.peer();
-                            peer == addr && is_online
+                            peer == addr
                         })
                         .map(|state| state.xfer.clone())
                         .collect::<Vec<_>>()

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fs,
     net::IpAddr,
     path::{Component, Path},
@@ -15,12 +16,12 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::{
-    auth,
+    auth, check,
     error::ResultExt,
     manager,
     tasks::AliveWaiter,
     ws::{self, FileEventTxFactory},
-    Error, Event, FileId, TransferManager,
+    Error, Event, FileId, Transfer, TransferManager,
 };
 
 pub(super) struct State {
@@ -36,14 +37,17 @@ pub(super) struct State {
     pub fdresolv: Option<Arc<crate::file::FdResolver>>,
 }
 
+type TaskRegistry = HashMap<uuid::Uuid, tokio::task::JoinHandle<()>>;
+
 pub struct Service {
     pub(super) state: Arc<State>,
     stop: CancellationToken,
     waiter: AliveWaiter,
     pub(super) logger: Logger,
+
+    tasks: TaskRegistry,
 }
 
-// todo: better name to reduce confusion
 impl Service {
     #[allow(clippy::too_many_arguments)]
     pub async fn start(
@@ -58,7 +62,7 @@ impl Service {
     ) -> Result<Self, Error> {
         let task = async {
             let state = Arc::new(State {
-                throttle: Semaphore::new(drop_config::MAX_UPLOADS_IN_FLIGHT),
+                throttle: Semaphore::new(drop_config::MAX_UPLOADS_IN_FLIGHT), /* TODO: max uploads of 4 files per all libdrop is too restrictive, workout a better plan, like configurable through config */
                 transfer_manager: TransferManager::new(
                     storage.clone(),
                     FileEventTxFactory::new(event_tx.clone(), moose.clone()),
@@ -85,14 +89,39 @@ impl Service {
 
             ws::server::spawn(state.clone(), logger.clone(), stop.clone(), guard.clone())?;
 
-            manager::resume(&state, &logger, &guard, &stop).await;
-
-            Ok(Self {
+            let mut service = Self {
                 state,
                 stop,
                 waiter,
                 logger,
-            })
+                tasks: Default::default(),
+            };
+
+            let outgoing_transfers = {
+                let xfers = service.state.transfer_manager.outgoing.lock().await;
+                xfers
+                    .values()
+                    .map(|xstate| xstate.xfer.clone())
+                    .collect::<Vec<_>>()
+            };
+
+            for xfer in outgoing_transfers {
+                service.trigger_peer_outgoing(xfer).await;
+            }
+
+            let incoming_transfers = {
+                let xfers = service.state.transfer_manager.incoming.lock().await;
+                xfers
+                    .values()
+                    .map(|xstate| xstate.xfer.clone())
+                    .collect::<Vec<_>>()
+            };
+
+            for xfer in incoming_transfers {
+                service.trigger_peer_incoming(xfer).await;
+            }
+
+            Ok(service)
         };
 
         let res = task.await;
@@ -109,6 +138,93 @@ impl Service {
 
     pub fn storage(&self) -> &Storage {
         &self.state.storage
+    }
+
+    async fn trigger_peer_incoming(&mut self, xfer: Arc<crate::IncomingTransfer>) {
+        debug!(self.logger, "trigger_peer_incoming() called: {:?}", xfer);
+
+        let _peer = xfer.peer();
+        let id = xfer.id();
+
+        if let Some(handle) = self.tasks.get(&id) {
+            if !handle.is_finished() {
+                return;
+            } else {
+                self.tasks.remove(&id);
+            }
+        }
+
+        let handle = check::spawn(
+            self.state.clone(),
+            xfer,
+            self.logger.clone(),
+            self.waiter.guard(),
+            self.stop.clone(),
+        );
+
+        self.tasks.insert(id, handle);
+    }
+
+    async fn trigger_peer_outgoing(&mut self, xfer: Arc<crate::OutgoingTransfer>) {
+        debug!(self.logger, "trigger_peer_outgoing() called: {:?}", xfer);
+
+        let id = xfer.id();
+        let _peer = xfer.peer();
+        if let Some(handle) = self.tasks.get(&id) {
+            if !handle.is_finished() {
+                return;
+            } else {
+                self.tasks.remove(&id);
+            }
+        }
+
+        let handle = ws::client::spawn(
+            self.state.clone(),
+            xfer,
+            self.logger.clone(),
+            self.waiter.guard(),
+            self.stop.clone(),
+        );
+
+        self.tasks.insert(id, handle);
+    }
+
+    pub async fn set_peer_state(&mut self, addr: &IpAddr, is_online: bool) {
+        {
+            let outgoing_transfers_to_trigger = {
+                let xfers = self.state.transfer_manager.outgoing.lock().await;
+
+                xfers
+                    .values()
+                    .filter(|state| {
+                        let peer = state.xfer.peer();
+                        peer == *addr && is_online
+                    })
+                    .map(|state| state.xfer.clone())
+                    .collect::<Vec<_>>()
+            };
+
+            for xfer in outgoing_transfers_to_trigger {
+                self.trigger_peer_outgoing(xfer).await;
+            }
+
+            let incoming_transfers_to_trigger = {
+                let xfers = self.state.transfer_manager.incoming.lock().await;
+
+                xfers
+                    .values()
+                    .filter(|state| {
+                        let peer = state.xfer.peer();
+                        peer == *addr && is_online
+                    })
+                    .map(|state| state.xfer.clone())
+                    .collect::<Vec<_>>()
+            };
+
+            for xfer in incoming_transfers_to_trigger {
+                self.trigger_peer_incoming(xfer).await;
+            }
+        }
     }
 
     pub async fn send_request(&mut self, xfer: crate::OutgoingTransfer) {
@@ -132,13 +248,7 @@ impl Service {
             .send(Event::RequestQueued(xfer.clone()))
             .expect("Could not send a RequestQueued event, channel closed");
 
-        ws::client::spawn(
-            self.state.clone(),
-            xfer,
-            self.logger.clone(),
-            self.waiter.guard(),
-            self.stop.clone(),
-        );
+        self.trigger_peer_outgoing(xfer).await;
     }
 
     pub async fn download(

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -5,12 +5,10 @@ mod v4;
 mod v5;
 
 use std::{
-    future::Future,
     io,
     net::{IpAddr, SocketAddr},
     ops::ControlFlow,
     sync::Arc,
-    time::Duration,
 };
 
 use anyhow::Context;
@@ -61,9 +59,8 @@ struct RunContext<'a> {
 }
 
 enum WsConnection {
-    Stopped,
-    Unrecoverable(crate::Error),
     Recoverable,
+    Unrecoverable(crate::Error),
     Connected(WsStream, protocol::Version),
 }
 
@@ -73,7 +70,7 @@ pub(crate) fn spawn(
     logger: Logger,
     guard: AliveGuard,
     stop: CancellationToken,
-) {
+) -> tokio::task::JoinHandle<()> {
     let id = xfer.id();
     let job = run(state, xfer, logger.clone(), guard.clone());
 
@@ -88,25 +85,20 @@ pub(crate) fn spawn(
             },
             _ = job => (),
         }
-    });
+    })
 }
 
 async fn run(state: Arc<State>, xfer: Arc<OutgoingTransfer>, logger: Logger, alive: AliveGuard) {
-    loop {
-        if connect_to_peer(&state, &xfer, &logger, &alive)
-            .await
-            .is_break()
-        {
-            break;
-        }
-    }
+    let status = connect_to_peer(&state, &xfer, &logger, &alive).await;
 
-    if let Err(err) = state.transfer_manager.outgoing_remove(xfer.id()).await {
-        warn!(
-            logger,
-            "Failed to clear sync state for {}: {err}",
-            xfer.id()
-        );
+    if status.is_break() {
+        if let Err(err) = state.transfer_manager.outgoing_remove(xfer.id()).await {
+            warn!(
+                logger,
+                "Failed to clear sync state for {}: {err}",
+                xfer.id()
+            );
+        }
     }
 }
 
@@ -119,7 +111,6 @@ async fn connect_to_peer(
     let (socket, ver) = match establish_ws_conn(state, xfer, logger).await {
         WsConnection::Connected(sock, ver) => (sock, ver),
         WsConnection::Recoverable => return ControlFlow::Continue(()),
-        WsConnection::Stopped => return ControlFlow::Break(()),
         WsConnection::Unrecoverable(err) => {
             error!(logger, "Could not connect to peer {}: {}", xfer.id(), err);
 
@@ -173,11 +164,15 @@ async fn establish_ws_conn(
     xfer: &OutgoingTransfer,
     logger: &Logger,
 ) -> WsConnection {
-    let break_check = || async { !state.transfer_manager.is_outgoing_alive(xfer.id()).await };
+    let remote = SocketAddr::new(xfer.peer(), drop_config::PORT);
+    let local = SocketAddr::new(state.addr, 0);
 
-    let mut socket = match tcp_connect(state.addr, xfer.peer(), break_check, logger).await {
-        Some(socket) => socket,
-        None => return WsConnection::Stopped,
+    let mut socket = match utils::connect(local, remote).await {
+        Ok(sock) => sock,
+        Err(err) => {
+            debug!(logger, "Failed to connect: {:?}", err,);
+            return WsConnection::Recoverable;
+        }
     };
 
     let mut versions_to_try = [
@@ -201,7 +196,9 @@ async fn establish_ws_conn(
         match make_request(&mut socket, xfer.peer(), ver, state.auth.as_ref(), logger).await {
             Ok(_) => break ver,
             Err(tungstenite::Error::Http(resp)) if resp.status().is_client_error() => {
-                if resp.status() == StatusCode::UNAUTHORIZED {
+                if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+                    return WsConnection::Recoverable;
+                } else if resp.status() == StatusCode::UNAUTHORIZED {
                     return WsConnection::Unrecoverable(crate::Error::AuthenticationFailed);
                 } else {
                     debug!(
@@ -269,43 +266,6 @@ async fn make_request(
     Err(err)
 }
 
-async fn tcp_connect<Fut: Future<Output = bool>>(
-    local_ip: IpAddr,
-    remote_ip: IpAddr,
-    break_check: impl Fn() -> Fut,
-    logger: &Logger,
-) -> Option<TcpStream> {
-    let remote = SocketAddr::new(remote_ip, drop_config::PORT);
-    let local = SocketAddr::new(local_ip, 0);
-
-    let mut sleep_time = Duration::from_millis(200);
-
-    loop {
-        if break_check().await {
-            break;
-        }
-
-        match utils::connect(local, remote).await {
-            Ok(sock) => return Some(sock),
-            Err(err) => {
-                debug!(
-                    logger,
-                    "Failed to connect: {:?}, sleeping for {} ms",
-                    err,
-                    sleep_time.as_millis(),
-                );
-
-                tokio::time::sleep(sleep_time).await;
-
-                // Exponential backoff but with upper limit
-                sleep_time = drop_config::CONNECTION_MAX_RETRY_INTERVAL.min(sleep_time * 2);
-            }
-        }
-    }
-
-    None
-}
-
 impl RunContext<'_> {
     async fn start(
         &mut self,
@@ -340,6 +300,9 @@ impl RunContext<'_> {
                     anyhow::Ok(())
                 };
                 if let Err(err) = task.await {
+                    // It means that the close() call returned an IO error for some reason. It
+                    // shouldn't happen probably, and even if it does, it's probably best to just
+                    // ignore it
                     error!(self.logger, "Failed to close socket on start: {err:?}");
                 } else {
                     info!(self.logger, "Socket closed on start");

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
@@ -80,6 +80,10 @@ public class NordDrop {
     return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_removeTransferFile(swigCPtr, this, txid, fid));
   }
 
+  public NorddropResult setPeerState(String peer, int isOnline) {
+    return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_setPeerState(swigCPtr, this, peer, isOnline));
+  }
+
   public String getTransfersSince(long sinceTimestamp) {
     return libnorddropJNI.NordDrop_getTransfersSince(swigCPtr, this, sinceTimestamp);
   }

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
@@ -39,6 +39,7 @@ public class libnorddropJNI {
   public final static native int NordDrop_purgeTransfers(long jarg1, NordDrop jarg1_, String jarg2);
   public final static native int NordDrop_purgeTransfersUntil(long jarg1, NordDrop jarg1_, long jarg2);
   public final static native int NordDrop_removeTransferFile(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);
+  public final static native int NordDrop_setPeerState(long jarg1, NordDrop jarg1_, String jarg2, int jarg3);
   public final static native String NordDrop_getTransfersSince(long jarg1, NordDrop jarg1_, long jarg2);
   public final static native String NordDrop_version();
 }

--- a/norddrop/ffi/bindings/android/wrap/java_wrap.c
+++ b/norddrop/ffi/bindings/android/wrap/java_wrap.c
@@ -1063,6 +1063,30 @@ SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1remov
 }
 
 
+SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1setPeerState(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jint jarg3) {
+  jint jresult = 0 ;
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  enum norddrop_result result;
+  
+  (void)jenv;
+  (void)jcls;
+  (void)jarg1_;
+  arg1 = *(struct norddrop **)&jarg1; 
+  arg2 = 0;
+  if (jarg2) {
+    arg2 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg2, 0);
+    if (!arg2) return 0;
+  }
+  arg3 = (int)jarg3; 
+  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  jresult = (jint)result; 
+  if (arg2) (*jenv)->ReleaseStringUTFChars(jenv, jarg2, (const char *)arg2);
+  return jresult;
+}
+
+
 SWIGEXPORT jstring JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1getTransfersSince(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jlong jarg2) {
   jstring jresult = 0 ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;

--- a/norddrop/ffi/bindings/linux/go/norddropgo.go
+++ b/norddrop/ffi/bindings/linux/go/norddropgo.go
@@ -54,68 +54,70 @@ typedef long long swig_type_22;
 typedef _gostring_ swig_type_23;
 typedef _gostring_ swig_type_24;
 typedef _gostring_ swig_type_25;
-typedef long long swig_type_26;
-typedef _gostring_ swig_type_27;
-extern void _wrap_Swig_free_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_norddropgo_4ce90ff5854b9132(swig_intgo arg1);
-extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_4ce90ff5854b9132(void);
-extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_4ce90ff5854b9132(void);
-extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropEventCb_Cb_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_1 arg2);
-extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_4ce90ff5854b9132(void);
-extern void _wrap_delete_NorddropEventCb_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_3 arg2);
-extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_4ce90ff5854b9132(void);
-extern void _wrap_delete_NorddropLoggerCb_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_5 arg2);
-extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132(void);
-extern void _wrap_delete_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropFdCb_Ctx_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropFdCb_Ctx_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern void _wrap_NorddropFdCb_Cb_set_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_7 arg2);
-extern swig_type_8 _wrap_NorddropFdCb_Cb_get_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropFdCb_norddropgo_4ce90ff5854b9132(void);
-extern void _wrap_delete_NorddropFdCb_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
+typedef _gostring_ swig_type_26;
+typedef long long swig_type_27;
+typedef _gostring_ swig_type_28;
+extern void _wrap_Swig_free_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_norddropgo_a604716e4848fd68(swig_intgo arg1);
+extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68(void);
+extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68(void);
+extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_1 arg2);
+extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68(void);
+extern void _wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_3 arg2);
+extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68(void);
+extern void _wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_5 arg2);
+extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68(void);
+extern void _wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern void _wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_7 arg2);
+extern swig_type_8 _wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68(void);
+extern void _wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
 
 #include <string.h>
 
-extern uintptr_t _wrap_new_Norddrop_norddropgo_4ce90ff5854b9132(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_9 arg5);
-extern void _wrap_delete_Norddrop_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_Start_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_10 arg2, swig_type_11 arg3);
-extern swig_intgo _wrap_Norddrop_Stop_norddropgo_4ce90ff5854b9132(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_12 arg2);
-extern swig_intgo _wrap_Norddrop_RejectFile_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3);
-extern swig_intgo _wrap_Norddrop_Download_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
-extern swig_type_18 _wrap_Norddrop_NewTransfer_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_19 arg2, swig_type_20 arg3);
-extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_21 arg2);
-extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_22 arg2);
-extern swig_intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_23 arg2, swig_type_24 arg3);
-extern swig_type_25 _wrap_Norddrop_GetTransfersSince_norddropgo_4ce90ff5854b9132(uintptr_t arg1, swig_type_26 arg2);
-extern swig_type_27 _wrap_Norddrop_Version_norddropgo_4ce90ff5854b9132(void);
+extern uintptr_t _wrap_new_Norddrop_norddropgo_a604716e4848fd68(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_9 arg5);
+extern void _wrap_delete_Norddrop_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_Start_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_10 arg2, swig_type_11 arg3);
+extern swig_intgo _wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_12 arg2);
+extern swig_intgo _wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3);
+extern swig_intgo _wrap_Norddrop_Download_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
+extern swig_type_18 _wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_19 arg2, swig_type_20 arg3);
+extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_21 arg2);
+extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_22 arg2);
+extern swig_intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_23 arg2, swig_type_24 arg3);
+extern swig_intgo _wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_25 arg2, swig_intgo arg3);
+extern swig_type_26 _wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_27 arg2);
+extern swig_type_28 _wrap_Norddrop_Version_norddropgo_a604716e4848fd68(void);
 #undef intgo
 */
 import "C"
@@ -150,55 +152,55 @@ func swigCopyString(s string) string {
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_4ce90ff5854b9132(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_a604716e4848fd68(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_norddrop_log_level int
 func _swig_getNORDDROPLOGCRITICAL() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPLOGCRITICAL Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGCRITICAL()
 func _swig_getNORDDROPLOGERROR() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPLOGERROR Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGERROR()
 func _swig_getNORDDROPLOGWARNING() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPLOGWARNING Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGWARNING()
 func _swig_getNORDDROPLOGINFO() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPLOGINFO Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGINFO()
 func _swig_getNORDDROPLOGDEBUG() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPLOGDEBUG Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGDEBUG()
 func _swig_getNORDDROPLOGTRACE() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
@@ -206,84 +208,84 @@ var NORDDROPLOGTRACE Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGTRACE()
 type Enum_SS_norddrop_result int
 func _swig_getNORDDROPRESOK() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESOK Enum_SS_norddrop_result = _swig_getNORDDROPRESOK()
 func _swig_getNORDDROPRESERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESERROR Enum_SS_norddrop_result = _swig_getNORDDROPRESERROR()
 func _swig_getNORDDROPRESINVALIDSTRING() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDSTRING Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDSTRING()
 func _swig_getNORDDROPRESBADINPUT() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESBADINPUT Enum_SS_norddrop_result = _swig_getNORDDROPRESBADINPUT()
 func _swig_getNORDDROPRESJSONPARSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESJSONPARSE Enum_SS_norddrop_result = _swig_getNORDDROPRESJSONPARSE()
 func _swig_getNORDDROPRESTRANSFERCREATE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESTRANSFERCREATE Enum_SS_norddrop_result = _swig_getNORDDROPRESTRANSFERCREATE()
 func _swig_getNORDDROPRESNOTSTARTED() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESNOTSTARTED Enum_SS_norddrop_result = _swig_getNORDDROPRESNOTSTARTED()
 func _swig_getNORDDROPRESADDRINUSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESADDRINUSE Enum_SS_norddrop_result = _swig_getNORDDROPRESADDRINUSE()
 func _swig_getNORDDROPRESINSTANCESTART() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTART Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTART()
 func _swig_getNORDDROPRESINSTANCESTOP() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTOP Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTOP()
 func _swig_getNORDDROPRESINVALIDPRIVKEY() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDPRIVKEY Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDPRIVKEY()
 func _swig_getNORDDROPRESDBERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_4ce90ff5854b9132())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68())
 	return swig_r
 }
 
@@ -300,38 +302,38 @@ func (p SwigcptrNorddropEventCb) SwigIsNorddropEventCb() {
 func (arg1 SwigcptrNorddropEventCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Ctx_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropEventCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Cb_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
+	C._wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropEventCb() (_swig_ret NorddropEventCb) {
 	var swig_r NorddropEventCb
-	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_4ce90ff5854b9132()))
+	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68()))
 	return swig_r
 }
 
 func DeleteNorddropEventCb(arg1 NorddropEventCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropEventCb_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropEventCb interface {
@@ -355,38 +357,38 @@ func (p SwigcptrNorddropLoggerCb) SwigIsNorddropLoggerCb() {
 func (arg1 SwigcptrNorddropLoggerCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropLoggerCb() (_swig_ret NorddropLoggerCb) {
 	var swig_r NorddropLoggerCb
-	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_4ce90ff5854b9132()))
+	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68()))
 	return swig_r
 }
 
 func DeleteNorddropLoggerCb(arg1 NorddropLoggerCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropLoggerCb_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropLoggerCb interface {
@@ -410,38 +412,38 @@ func (p SwigcptrNorddropPubkeyCb) SwigIsNorddropPubkeyCb() {
 func (arg1 SwigcptrNorddropPubkeyCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropPubkeyCb() (_swig_ret NorddropPubkeyCb) {
 	var swig_r NorddropPubkeyCb
-	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132()))
+	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68()))
 	return swig_r
 }
 
 func DeleteNorddropPubkeyCb(arg1 NorddropPubkeyCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropPubkeyCb interface {
@@ -465,38 +467,38 @@ func (p SwigcptrNorddropFdCb) SwigIsNorddropFdCb() {
 func (arg1 SwigcptrNorddropFdCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropFdCb_Ctx_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropFdCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropFdCb_Ctx_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropFdCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropFdCb_Cb_set_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_7(_swig_i_1))
+	C._wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_7(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropFdCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropFdCb_Cb_get_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropFdCb() (_swig_ret NorddropFdCb) {
 	var swig_r NorddropFdCb
-	swig_r = (NorddropFdCb)(SwigcptrNorddropFdCb(C._wrap_new_NorddropFdCb_norddropgo_4ce90ff5854b9132()))
+	swig_r = (NorddropFdCb)(SwigcptrNorddropFdCb(C._wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68()))
 	return swig_r
 }
 
 func DeleteNorddropFdCb(arg1 NorddropFdCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropFdCb_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropFdCb interface {
@@ -626,7 +628,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
         _swig_i_3 = cb
 }
 	_swig_i_4 := arg5
-	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_4ce90ff5854b9132(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_4)))))
+	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_a604716e4848fd68(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_4)))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg5
 	}
@@ -643,7 +645,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
 
 func DeleteNorddrop(arg1 Norddrop) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_Norddrop_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_Norddrop_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
 }
 
 func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result) {
@@ -651,7 +653,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -664,7 +666,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 func (arg1 SwigcptrNorddrop) Stop() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -672,7 +674,7 @@ func (arg1 SwigcptrNorddrop) CancelTransfer(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -684,7 +686,7 @@ func (arg1 SwigcptrNorddrop) RejectFile(arg2 string, arg3 string) (_swig_ret Enu
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RejectFile_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -700,7 +702,7 @@ func (arg1 SwigcptrNorddrop) Download(arg2 string, arg3 string, arg4 string) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -718,7 +720,7 @@ func (arg1 SwigcptrNorddrop) NewTransfer(arg2 string, arg3 string) (_swig_ret st
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_2)))
+	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_2)))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
@@ -735,7 +737,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfers(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -746,7 +748,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1)))
 	return swig_r
 }
 
@@ -755,7 +757,7 @@ func (arg1 SwigcptrNorddrop) RemoveTransferFile(arg2 string, arg3 string) (_swig
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RemoveTransferFile_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -765,11 +767,23 @@ func (arg1 SwigcptrNorddrop) RemoveTransferFile(arg2 string, arg3 string) (_swig
 	return swig_r
 }
 
+func (arg1 SwigcptrNorddrop) SetPeerState(arg2 string, arg3 int) (_swig_ret Enum_SS_norddrop_result) {
+	var swig_r Enum_SS_norddrop_result
+	_swig_i_0 := arg1
+	_swig_i_1 := arg2
+	_swig_i_2 := arg3
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_25)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2)))
+	if Swig_escape_always_false {
+		Swig_escape_val = arg2
+	}
+	return swig_r
+}
+
 func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_4ce90ff5854b9132(C.uintptr_t(_swig_i_0), C.swig_type_26(_swig_i_1))
+	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_27(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -778,7 +792,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 
 func NorddropVersion() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Norddrop_Version_norddropgo_4ce90ff5854b9132()
+	swig_r_p := C._wrap_Norddrop_Version_norddropgo_a604716e4848fd68()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -797,6 +811,7 @@ type Norddrop interface {
 	PurgeTransfers(arg2 string) (_swig_ret Enum_SS_norddrop_result)
 	PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_norddrop_result)
 	RemoveTransferFile(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result)
+	SetPeerState(arg2 string, arg3 int) (_swig_ret Enum_SS_norddrop_result)
 	GetTransfersSince(arg2 int64) (_swig_ret string)
 }
 

--- a/norddrop/ffi/bindings/linux/wrap/go_wrap.c
+++ b/norddrop/ffi/bindings/linux/wrap/go_wrap.c
@@ -242,7 +242,7 @@ SWIGINTERN void delete_norddrop(struct norddrop *self){
 extern "C" {
 #endif
 
-void _wrap_Swig_free_norddropgo_4ce90ff5854b9132(void *_swig_go_0) {
+void _wrap_Swig_free_norddropgo_a604716e4848fd68(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -252,7 +252,7 @@ void _wrap_Swig_free_norddropgo_4ce90ff5854b9132(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_norddropgo_4ce90ff5854b9132(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_norddropgo_a604716e4848fd68(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -265,7 +265,7 @@ void *_wrap_Swig_malloc_norddropgo_4ce90ff5854b9132(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -277,7 +277,7 @@ intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPLOGERROR_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -289,7 +289,7 @@ intgo _wrap_NORDDROPLOGERROR_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPLOGWARNING_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -301,7 +301,7 @@ intgo _wrap_NORDDROPLOGWARNING_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPLOGINFO_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -313,7 +313,7 @@ intgo _wrap_NORDDROPLOGINFO_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPLOGDEBUG_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -325,7 +325,7 @@ intgo _wrap_NORDDROPLOGDEBUG_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPLOGTRACE_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -337,7 +337,7 @@ intgo _wrap_NORDDROPLOGTRACE_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESOK_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -349,7 +349,7 @@ intgo _wrap_NORDDROPRESOK_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESERROR_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -361,7 +361,7 @@ intgo _wrap_NORDDROPRESERROR_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -373,7 +373,7 @@ intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESBADINPUT_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -385,7 +385,7 @@ intgo _wrap_NORDDROPRESBADINPUT_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -397,7 +397,7 @@ intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -409,7 +409,7 @@ intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -421,7 +421,7 @@ intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -433,7 +433,7 @@ intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -445,7 +445,7 @@ intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -457,7 +457,7 @@ intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -469,7 +469,7 @@ intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_4ce90ff5854b9132() {
 }
 
 
-intgo _wrap_NORDDROPRESDBERROR_norddropgo_4ce90ff5854b9132() {
+intgo _wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -481,7 +481,7 @@ intgo _wrap_NORDDROPRESDBERROR_norddropgo_4ce90ff5854b9132() {
 }
 
 
-void _wrap_NorddropEventCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -493,7 +493,7 @@ void _wrap_NorddropEventCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_e
 }
 
 
-void *_wrap_NorddropEventCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_event_cb *_swig_go_0) {
+void *_wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -506,7 +506,7 @@ void *_wrap_NorddropEventCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_
 }
 
 
-void _wrap_NorddropEventCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn arg2 = (norddrop_event_fn) 0 ;
   
@@ -518,7 +518,7 @@ void _wrap_NorddropEventCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_ev
 }
 
 
-void* _wrap_NorddropEventCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_event_cb *_swig_go_0) {
+void* _wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn result;
   void* _swig_go_result;
@@ -531,7 +531,7 @@ void* _wrap_NorddropEventCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_e
 }
 
 
-struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_4ce90ff5854b9132() {
+struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68() {
   struct norddrop_event_cb *result = 0 ;
   struct norddrop_event_cb *_swig_go_result;
   
@@ -542,7 +542,7 @@ struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_4ce90ff5854b9132(
 }
 
 
-void _wrap_delete_NorddropEventCb_norddropgo_4ce90ff5854b9132(struct norddrop_event_cb *_swig_go_0) {
+void _wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   
   arg1 = *(struct norddrop_event_cb **)&_swig_go_0; 
@@ -552,7 +552,7 @@ void _wrap_delete_NorddropEventCb_norddropgo_4ce90ff5854b9132(struct norddrop_ev
 }
 
 
-void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -564,7 +564,7 @@ void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_
 }
 
 
-void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_logger_cb *_swig_go_0) {
+void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -577,7 +577,7 @@ void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop
 }
 
 
-void _wrap_NorddropLoggerCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn arg2 = (norddrop_logger_fn) 0 ;
   
@@ -589,7 +589,7 @@ void _wrap_NorddropLoggerCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_l
 }
 
 
-void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_logger_cb *_swig_go_0) {
+void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn result;
   void* _swig_go_result;
@@ -602,7 +602,7 @@ void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_
 }
 
 
-struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_4ce90ff5854b9132() {
+struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68() {
   struct norddrop_logger_cb *result = 0 ;
   struct norddrop_logger_cb *_swig_go_result;
   
@@ -613,7 +613,7 @@ struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_4ce90ff5854b913
 }
 
 
-void _wrap_delete_NorddropLoggerCb_norddropgo_4ce90ff5854b9132(struct norddrop_logger_cb *_swig_go_0) {
+void _wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   
   arg1 = *(struct norddrop_logger_cb **)&_swig_go_0; 
@@ -623,7 +623,7 @@ void _wrap_delete_NorddropLoggerCb_norddropgo_4ce90ff5854b9132(struct norddrop_l
 }
 
 
-void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -635,7 +635,7 @@ void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_
 }
 
 
-void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_pubkey_cb *_swig_go_0) {
+void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -648,7 +648,7 @@ void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop
 }
 
 
-void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn arg2 = (norddrop_pubkey_fn) 0 ;
   
@@ -660,7 +660,7 @@ void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_p
 }
 
 
-void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_pubkey_cb *_swig_go_0) {
+void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn result;
   void* _swig_go_result;
@@ -673,7 +673,7 @@ void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_
 }
 
 
-struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132() {
+struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68() {
   struct norddrop_pubkey_cb *result = 0 ;
   struct norddrop_pubkey_cb *_swig_go_result;
   
@@ -684,7 +684,7 @@ struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_4ce90ff5854b913
 }
 
 
-void _wrap_delete_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132(struct norddrop_pubkey_cb *_swig_go_0) {
+void _wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   
   arg1 = *(struct norddrop_pubkey_cb **)&_swig_go_0; 
@@ -694,7 +694,7 @@ void _wrap_delete_NorddropPubkeyCb_norddropgo_4ce90ff5854b9132(struct norddrop_p
 }
 
 
-void _wrap_NorddropFdCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -706,7 +706,7 @@ void _wrap_NorddropFdCb_Ctx_set_norddropgo_4ce90ff5854b9132(struct norddrop_fd_c
 }
 
 
-void *_wrap_NorddropFdCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb *_swig_go_0) {
+void *_wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -719,7 +719,7 @@ void *_wrap_NorddropFdCb_Ctx_get_norddropgo_4ce90ff5854b9132(struct norddrop_fd_
 }
 
 
-void _wrap_NorddropFdCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   norddrop_fd_fn arg2 = (norddrop_fd_fn) 0 ;
   
@@ -731,7 +731,7 @@ void _wrap_NorddropFdCb_Cb_set_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb
 }
 
 
-void* _wrap_NorddropFdCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb *_swig_go_0) {
+void* _wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   norddrop_fd_fn result;
   void* _swig_go_result;
@@ -744,7 +744,7 @@ void* _wrap_NorddropFdCb_Cb_get_norddropgo_4ce90ff5854b9132(struct norddrop_fd_c
 }
 
 
-struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_4ce90ff5854b9132() {
+struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68() {
   struct norddrop_fd_cb *result = 0 ;
   struct norddrop_fd_cb *_swig_go_result;
   
@@ -755,7 +755,7 @@ struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_4ce90ff5854b9132() {
 }
 
 
-void _wrap_delete_NorddropFdCb_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb *_swig_go_0) {
+void _wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   
   arg1 = *(struct norddrop_fd_cb **)&_swig_go_0; 
@@ -765,7 +765,7 @@ void _wrap_delete_NorddropFdCb_norddropgo_4ce90ff5854b9132(struct norddrop_fd_cb
 }
 
 
-struct norddrop *_wrap_new_Norddrop_norddropgo_4ce90ff5854b9132(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
+struct norddrop *_wrap_new_Norddrop_norddropgo_a604716e4848fd68(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
   norddrop_event_cb arg1 ;
   enum norddrop_log_level arg2 ;
   norddrop_logger_cb arg3 ;
@@ -797,7 +797,7 @@ struct norddrop *_wrap_new_Norddrop_norddropgo_4ce90ff5854b9132(norddrop_event_c
 }
 
 
-void _wrap_delete_Norddrop_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0) {
+void _wrap_delete_Norddrop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   
   arg1 = *(struct norddrop **)&_swig_go_0; 
@@ -807,7 +807,7 @@ void _wrap_delete_Norddrop_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Start_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_Start_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -834,7 +834,7 @@ intgo _wrap_Norddrop_Start_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Stop_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0) {
+intgo _wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   enum norddrop_result result;
   intgo _swig_go_result;
@@ -847,7 +847,7 @@ intgo _wrap_Norddrop_Stop_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_
 }
 
 
-intgo _wrap_Norddrop_CancelTransfer_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -867,7 +867,7 @@ intgo _wrap_Norddrop_CancelTransfer_norddropgo_4ce90ff5854b9132(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_RejectFile_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -894,7 +894,7 @@ intgo _wrap_Norddrop_RejectFile_norddropgo_4ce90ff5854b9132(struct norddrop *_sw
 }
 
 
-intgo _wrap_Norddrop_Download_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Norddrop_Download_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -928,7 +928,7 @@ intgo _wrap_Norddrop_Download_norddropgo_4ce90ff5854b9132(struct norddrop *_swig
 }
 
 
-_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -956,7 +956,7 @@ _gostring_ _wrap_Norddrop_NewTransfer_norddropgo_4ce90ff5854b9132(struct norddro
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfers_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -976,7 +976,7 @@ intgo _wrap_Norddrop_PurgeTransfers_norddropgo_4ce90ff5854b9132(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, long long _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   enum norddrop_result result;
@@ -991,7 +991,7 @@ intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_4ce90ff5854b9132(struct nord
 }
 
 
-intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1018,7 +1018,29 @@ intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_4ce90ff5854b9132(struct nordd
 }
 
 
-_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_4ce90ff5854b9132(struct norddrop *_swig_go_0, long long _swig_go_1) {
+intgo _wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2) {
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  enum norddrop_result result;
+  intgo _swig_go_result;
+  
+  arg1 = *(struct norddrop **)&_swig_go_0; 
+  
+  arg2 = (char *)malloc(_swig_go_1.n + 1);
+  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
+  arg2[_swig_go_1.n] = '\0';
+  
+  arg3 = (int)_swig_go_2; 
+  
+  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  _swig_go_result = (intgo)result; 
+  free(arg2); 
+  return _swig_go_result;
+}
+
+
+_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   char *result = 0 ;
@@ -1034,7 +1056,7 @@ _gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_4ce90ff5854b9132(struct n
 }
 
 
-_gostring_ _wrap_Norddrop_Version_norddropgo_4ce90ff5854b9132() {
+_gostring_ _wrap_Norddrop_Version_norddropgo_a604716e4848fd68() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -487,6 +487,22 @@ enum norddrop_result norddrop_new(struct norddrop **dev,
                                   struct norddrop_pubkey_cb pubkey_cb,
                                   const char *privkey);
 
+/**
+ * Set connectivity state of a peer
+ *
+ * # Arguments
+ *
+ * * `dev` - A pointer to the instance.
+ * * `peer` - peer address
+ * * `is_online` - 0 if offline, 1 if online
+ *
+ * # Safety
+ * The pointers provided should be valid
+ */
+enum norddrop_result norddrop_set_peer_state(const struct norddrop *dev,
+                                             const char *peer,
+                                             int64_t is_online);
+
 void __norddrop_force_export(enum norddrop_result,
                              struct norddrop_event_cb,
                              struct norddrop_logger_cb,

--- a/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
+++ b/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
@@ -127,6 +127,11 @@ public class Norddrop : global::System.IDisposable {
     return ret;
   }
 
+  public NorddropResult SetPeerState(string peer, int isOnline) {
+    NorddropResult ret = (NorddropResult)libnorddropPINVOKE.Norddrop_SetPeerState(swigCPtr, peer, isOnline);
+    return ret;
+  }
+
   public string GetTransfersSince(long sinceTimestamp) {
     string ret = libnorddropPINVOKE.Norddrop_GetTransfersSince(swigCPtr, sinceTimestamp);
     return ret;
@@ -357,6 +362,9 @@ class libnorddropPINVOKE {
 
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_RemoveTransferFile___")]
   public static extern int Norddrop_RemoveTransferFile(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
+
+  [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_SetPeerState___")]
+  public static extern int Norddrop_SetPeerState(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
 
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_GetTransfersSince___")]
   public static extern string Norddrop_GetTransfersSince(global::System.Runtime.InteropServices.HandleRef jarg1, long jarg2);

--- a/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
+++ b/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
@@ -498,6 +498,22 @@ SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_RemoveTransferFile__
 }
 
 
+SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_SetPeerState___(void * jarg1, char * jarg2, int jarg3) {
+  int jresult ;
+  struct norddrop *arg1 = (struct norddrop *) 0 ;
+  char *arg2 = (char *) 0 ;
+  int arg3 ;
+  enum norddrop_result result;
+  
+  arg1 = (struct norddrop *)jarg1; 
+  arg2 = (char *)jarg2; 
+  arg3 = (int)jarg3; 
+  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  jresult = (int)result; 
+  return jresult;
+}
+
+
 SWIGEXPORT char * SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_GetTransfersSince___(void * jarg1, long long jarg2) {
   char * jresult ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;

--- a/norddrop/ffi/norddrop.i
+++ b/norddrop/ffi/norddrop.i
@@ -78,6 +78,10 @@ struct norddrop {};
 
     enum norddrop_result remove_transfer_file(const char* txid, const char* fid);
 
+    enum norddrop_result set_peer_state(const char* peer, int is_online);
+
+
+
     %newobject get_transfers_since;
     char *get_transfers_since(long long since_timestamp);
 

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -354,7 +354,7 @@ impl NordDropFFI {
             .as_mut()
             .ok_or(ffi::types::NORDDROP_RES_NOT_STARTED)?;
 
-        self.rt.block_on(instance.set_peer_state(&peer, is_online));
+        self.rt.block_on(instance.set_peer_state(peer, is_online));
 
         Ok(())
     }

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -336,6 +336,29 @@ impl NordDropFFI {
         Ok(xfid)
     }
 
+    pub(super) fn set_peer_state(&mut self, peer: &str, is_online: bool) -> Result<()> {
+        trace!(
+            self.logger,
+            "norddrop_set_peer_state() {:?} -> {:?}",
+            peer,
+            is_online
+        );
+
+        let peer: IpAddr = peer.parse().map_err(|err| {
+            error!(self.logger, "Failed to parse peer address: {err}");
+            ffi::types::NORDDROP_RES_BAD_INPUT
+        })?;
+
+        let mut instance = self.instance.blocking_lock();
+        let instance = instance
+            .as_mut()
+            .ok_or(ffi::types::NORDDROP_RES_NOT_STARTED)?;
+
+        self.rt.block_on(instance.set_peer_state(&peer, is_online));
+
+        Ok(())
+    }
+
     pub(super) fn download(
         &mut self,
         xfid: uuid::Uuid,

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -675,6 +675,49 @@ pub unsafe extern "C" fn norddrop_new(
     result.unwrap_or(norddrop_result::NORDDROP_RES_ERROR)
 }
 
+/// Set connectivity state of a peer
+///
+/// # Arguments
+///
+/// * `dev` - A pointer to the instance.
+/// * `peer` - peer address
+/// * `is_online` - 0 if offline, 1 if online
+///
+/// # Safety
+/// The pointers provided should be valid
+#[no_mangle]
+pub unsafe extern "C" fn norddrop_set_peer_state(
+    dev: &norddrop,
+    peer: *const c_char,
+    is_online: i64,
+) -> norddrop_result {
+    let result = panic::catch_unwind(move || {
+        let mut dev = match dev.0.lock() {
+            Ok(inst) => inst,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let peer = {
+            if peer.is_null() {
+                return norddrop_result::NORDDROP_RES_INVALID_STRING;
+            }
+
+            ffi_try!(CStr::from_ptr(peer).to_str())
+        };
+
+        let is_online = match is_online {
+            0 => false,
+            1 => true,
+            _ => return norddrop_result::NORDDROP_RES_BAD_INPUT,
+        };
+
+        dev.set_peer_state(peer, is_online)
+            .norddrop_log_result(&dev.logger, "norddrop_set_peer_state")
+    });
+
+    result.unwrap_or(norddrop_result::NORDDROP_RES_ERROR)
+}
+
 struct KeyValueSerializer<'a> {
     rec: &'a slog::Record<'a>,
     kv: HashMap<slog::Key, String>,

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -308,11 +308,23 @@ class CheckFileDoesNotExist(Action):
 # as it is the most common setup, a sleep on the sender side is usually added.
 # This function is just a nicer sleep for those cases to increase readability
 class WaitForAnotherPeer(Action):
-    def __init__(self):
-        pass
-
+    def __init__(self, peer: str):
+        self._peer = peer
+        
     async def run(self, drop: ffi.Drop):
-        await asyncio.sleep(2)
+        ip = peer_resolver.resolve(self._peer)
+        
+        # try to open cnnection to port 49111 on peer until we succeed
+        while True:
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.connect((ip, 49111))
+                s.close()
+                break
+            except:
+                await asyncio.sleep(0.1)
+                pass
+        # await asyncio.sleep(2)
 
     def __str__(self):
         return f"WaitForAnotherPeer"

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -227,13 +227,12 @@ class CancelTransferRequest(Action):
 
     async def run(self, drop: ffi.Drop):
         with UUIDS_LOCK:
-            for slot in self._uuid_slots:                
+            for slot in self._uuid_slots:
                 drop.cancel_transfer_request(UUIDS[slot])
 
     def __str__(self):
-        uuid_strings = ', '.join(map(print_uuid, self._uuid_slots))
+        uuid_strings = ", ".join(map(print_uuid, self._uuid_slots))
         return f"CancelTransferRequest({uuid_strings})"
-
 
 
 class CancelTransferFile(Action):

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -19,6 +19,7 @@ from .logger import logger
 from .event import Event, print_uuid, get_uuid, UUIDS, UUIDS_LOCK
 from .peer_resolver import peer_resolver
 
+from .ffi import PeerState
 import sys
 
 
@@ -71,6 +72,15 @@ class Action:
 
     async def run(self, drop: ffi.Drop):
         raise NotImplementedError("run() on base Action class")
+
+
+class SetPeerState(Action):
+    def __init__(self, peer: str, state: PeerState):
+        self._peer = peer
+        self._state = state
+
+    async def run(self, drop: ffi.Drop):
+        drop.set_peer_state(self._peer, self._state)
 
 
 class ListenOnPort(Action):
@@ -292,6 +302,9 @@ class CheckFileDoesNotExist(Action):
         return f"CheckFileDoesNotExist({self._files})"
 
 
+# Peer might be already online but libdrop might not be started
+# as it is the most common setup, a sleep on the sender side is usually added.
+# This function is just a nicer sleep for those cases to increase readability
 class WaitForAnotherPeer(Action):
     def __init__(self):
         pass
@@ -304,8 +317,8 @@ class WaitForAnotherPeer(Action):
 
 
 class Sleep(Action):
-    def __init__(self, seconds: int):
-        self._seconds: int = seconds
+    def __init__(self, seconds: float):
+        self._seconds: float = seconds
 
     async def run(self, drop: ffi.Drop):
         await asyncio.sleep(self._seconds)
@@ -336,6 +349,49 @@ class Wait(Action):
 
     def __str__(self):
         return f"Wait({str(self._event)})"
+
+
+# TODO: there's a bit messy collection of Wait's in here. It would be
+# nice to refactor those waits into a single Wait class and also into boolean
+# actions that can be combined with AND and OR. This way we could `wait(AND(AtLeastOne(Progress), Finish)))` and similar
+
+
+# this tests for specified events while ignoring others. In case the events we renot
+# received it will produce an exception
+class WaitAndIgnoreExcept(Action):
+    def __init__(self, events: typing.List[Event]):
+        self._events: typing.List[Event] = events
+        self._found: typing.List[Event] = []
+
+    async def run(self, drop: ffi.Drop):
+        fuse = 0
+        limit = 100
+
+        while True:
+            e = await drop._events.wait_for_any_event(100, ignore_progress=True)
+
+            if e in self._events:
+                if e in self._found:
+                    raise Exception(f"Event {e} was received twice")
+
+                self._found.append(e)
+
+                if len(self._found) == len(self._events):
+                    break
+                else:
+                    continue
+
+            if e not in self._events:
+                pass
+
+            fuse += 1
+            if fuse > limit:
+                raise Exception(
+                    f"Expected {self._events} (while ignoring others) but got nothing"
+                )
+
+    def __str__(self):
+        return f"WaitAndIgnoreExcept({self._events})"
 
 
 class WaitForOneOf(Action):

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -222,15 +222,18 @@ class Download(Action):
 
 
 class CancelTransferRequest(Action):
-    def __init__(self, uuid_slot: int):
-        self._uuid_slot = uuid_slot
+    def __init__(self, uuid_slots: typing.List[int]):
+        self._uuid_slots = uuid_slots
 
     async def run(self, drop: ffi.Drop):
         with UUIDS_LOCK:
-            drop.cancel_transfer_request(UUIDS[self._uuid_slot])
+            for slot in self._uuid_slots:                
+                drop.cancel_transfer_request(UUIDS[slot])
 
     def __str__(self):
-        return f"CancelTransferRequest({print_uuid(self._uuid_slot)})"
+        uuid_strings = ', '.join(map(print_uuid, self._uuid_slots))
+        return f"CancelTransferRequest({uuid_strings})"
+
 
 
 class CancelTransferFile(Action):

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -308,23 +308,31 @@ class CheckFileDoesNotExist(Action):
 # as it is the most common setup, a sleep on the sender side is usually added.
 # This function is just a nicer sleep for those cases to increase readability
 class WaitForAnotherPeer(Action):
-    def __init__(self, peer: str):
+    def __init__(self, peer: str, state: PeerState = PeerState.Online):
         self._peer = peer
-        
+        self._state = state
+
     async def run(self, drop: ffi.Drop):
         ip = peer_resolver.resolve(self._peer)
-        
-        # try to open cnnection to port 49111 on peer until we succeed
-        while True:
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.connect((ip, 49111))
-                s.close()
-                break
-            except:
-                await asyncio.sleep(0.1)
-                pass
-        # await asyncio.sleep(2)
+
+        if self._state == PeerState.Online:
+            while True:
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    s.connect((ip, 49111))
+                    s.close()
+                    break
+                except:
+                    await asyncio.sleep(0.1)
+        else:
+            while True:
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    s.connect((ip, 49111))
+                    s.close()
+                    await asyncio.sleep(0.1)
+                except:
+                    break
 
     def __str__(self):
         return f"WaitForAnotherPeer"

--- a/test/drop_test/colors.py
+++ b/test/drop_test/colors.py
@@ -1,0 +1,10 @@
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -3,7 +3,9 @@ import ctypes
 import json
 import typing
 import logging
-from enum import IntEnum
+from enum import IntEnum  # todo why two enums
+from enum import Enum
+
 from threading import Lock
 
 from . import event
@@ -11,8 +13,20 @@ from .logger import logger
 from .config import RUNNERS
 from .peer_resolver import peer_resolver
 
+import datetime
 
 DEBUG_PRINT_EVENT = True
+from .colors import bcolors
+
+
+class PeerState(Enum):
+    Offline = 0
+    Online = 1
+
+
+def tprint(*args, **kwargs):
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    print(f"[{timestamp}]", *args, **kwargs)
 
 
 class DropException(Exception):
@@ -102,7 +116,7 @@ class EventQueue:
 
     def callback(self, ctx, s: str):
         if DEBUG_PRINT_EVENT:
-            print("--- event: ", s, flush=True)
+            tprint(bcolors.HEADER + "--- event: ", s, bcolors.ENDC, flush=True)
 
         with self._lock:
             self._events.append(new_event(s))
@@ -180,8 +194,12 @@ class EventQueue:
                     found = False
                     for te in target_events:
                         if te == e:
-                            found = True
                             success.append(te)
+                            found = True
+                            tprint(
+                                f"*racy event({len(success)}/{len(target_events)}), found {e}",
+                                flush=True,
+                            )
                             break
 
                     if not found:
@@ -205,10 +223,8 @@ class KeysCtx:
         self.this = RUNNERS[hostname]
 
     def callback(self, ctx, ip, pubkey):
-        print(f"KeysCtx.callback({ctx}, {ip}, {pubkey})")
         ip = ip.decode("utf-8")
         peer = peer_resolver.reverse_lookup(ip)
-        print(f"KeysCtx.callback({ctx}, {ip}, {pubkey}) -> {peer}")
         if peer is None:
             return 1
 
@@ -301,6 +317,11 @@ class Drop:
         norddrop_lib.norddrop_new_transfer.restype = ctypes.c_char_p
         norddrop_lib.norddrop_get_transfers_since.restype = ctypes.c_char_p
 
+        norddrop_lib.norddrop_set_peer_state.argtypes = (
+            ctypes.c_void_p,
+            ctypes.c_char_p,
+            ctypes.c_int,
+        )
         norddrop_lib.norddrop_start.argtypes = (
             ctypes.c_void_p,
             ctypes.c_char_p,
@@ -469,6 +490,20 @@ class Drop:
             raise DropException(f"get_transfers_since has failed)")
 
         return transfers.decode("utf-8")
+
+    def set_peer_state(self, peer: str, state: PeerState):
+        addr = peer_resolver.resolve(peer)
+        err = self._lib.norddrop_set_peer_state(
+            self._instance,
+            ctypes.create_string_buffer(bytes(addr, "utf-8")),
+            state.value,
+        )
+
+        if err != 0:
+            err_type = LibResult(err).name
+            raise DropException(
+                f"set_peer_state has failed with code: {err}({err_type})", err
+            )
 
     def purge_transfers_until(self, until_timestamp: int):
         err = self._lib.norddrop_purge_transfers_until(
@@ -677,4 +712,4 @@ def new_event(event_str: str) -> event.Event:
 
 def log_callback(ctx, level, msg):
     msg = msg.decode("utf-8")
-    logger.log(LOG_LEVEL_MAP.get(level), f"callback: {level}: {msg}")
+    logger.log(LOG_LEVEL_MAP.get(level), f"{msg}")

--- a/test/drop_test/logger.py
+++ b/test/drop_test/logger.py
@@ -1,10 +1,16 @@
 import logging
+from .colors import bcolors
 
-logger = logging.getLogger("global")
+logger = logging.getLogger("drop")
 
 handler = logging.StreamHandler()
 handler.setFormatter(
-    logging.Formatter("%(asctime)s:%(name)s:%(levelname)s:%(message)s")
+    logging.Formatter(
+        bcolors.BOLD
+        + "%(asctime)s:"
+        + bcolors.ENDC
+        + "%(name)s:%(levelname)s:%(message)s"
+    )
 )
 logger.setLevel(logging.DEBUG)
 logger.addHandler(handler)

--- a/test/drop_test/peer_resolver.py
+++ b/test/drop_test/peer_resolver.py
@@ -7,7 +7,7 @@ import time
 class PEERResolver:
     def __init__(self):
         self._peer_mappings = {}
-
+        self._cache = {}
         # peers do not know initially how their peers are named, and because
         # everyone lives in the same network we need to dynamically allocate
         # hostnames. This mapping maps those peers to their hostnames based on
@@ -44,6 +44,9 @@ class PEERResolver:
         hostname = self._peer_mappings[peer]
         ipv6 = "6" in peer
 
+        if peer in self._cache:
+            return self._cache[peer]
+
         for _ in range(5):
             print(f"Resolving hostname {hostname} ...", flush=True)
             try:
@@ -53,6 +56,7 @@ class PEERResolver:
                     ip = socket.getaddrinfo(hostname, 49111, socket.AF_INET)
 
                 host_ip = ip[0][4][0]
+                self._cache[peer] = host_ip
 
                 print(f"hostname {hostname} resolved to {host_ip}", flush=True)
                 return host_ip

--- a/test/drop_test/scenario.py
+++ b/test/drop_test/scenario.py
@@ -4,6 +4,7 @@ from . import action, ffi
 from .logger import logger
 
 from . import action
+from .ffi import bcolors
 
 
 class ActionList:
@@ -13,14 +14,16 @@ class ActionList:
     async def run(self, drop: ffi.Drop):
         logger.info("Processing action list...")
         for k, v in enumerate(self._actions):
-            logger.info(f"Running action {k+1}/{len(self._actions)}: {v}")
+            logger.info(
+                f"{bcolors.HEADER}Running action {k+1}/{len(self._actions)}: {v}{bcolors.ENDC}"
+            )
             start = time.time()
 
             await v.run(drop)
 
             elapsed = (time.time() - start) * 1000.0
             logger.info(
-                f"Action {k+1}/{len(self._actions)} completed in {elapsed} ms: {v}"
+                f"{bcolors.HEADER}Action {k+1}/{len(self._actions)} completed in {elapsed} ms: {v}{bcolors.ENDC}"
             )
 
         logger.info("Done processing actions")

--- a/test/drop_test/scenario.py
+++ b/test/drop_test/scenario.py
@@ -35,10 +35,15 @@ class Scenario:
         id: str,
         desc: str,
         action_list: typing.Dict[str, ActionList],
+        tags: typing.List[str] = [],
     ):
         self._id = id
         self._desc = desc
         self._action_list = action_list
+        self._tags = tags
+
+    def tags(self):
+        return self._tags
 
     def desc(self):
         return self._desc

--- a/test/runner.py
+++ b/test/runner.py
@@ -169,7 +169,7 @@ def run():
                 networks.append(create_network(client, netname, i + 1))
 
                 scenario_results[scenario.id()] = []
-                                
+
                 for runner in scenario.runners():
                     COMMON_VOLUMES = {}
                     parent_dir = os.path.dirname(os.getcwd())

--- a/test/runner.py
+++ b/test/runner.py
@@ -169,6 +169,7 @@ def run():
                 networks.append(create_network(client, netname, i + 1))
 
                 scenario_results[scenario.id()] = []
+                                
                 for runner in scenario.runners():
                     COMMON_VOLUMES = {}
                     parent_dir = os.path.dirname(os.getcwd())
@@ -180,7 +181,8 @@ def run():
                     hostname = f"{runner}-{scenario.id()}"
                     print(f"Starting {hostname}...")
                     LIB_PATH = os.environ["LIB_PATH"]
-                    cmd = f"sh -c './run.py --runner={runner} --scenario={scenario.id()} --lib={LIB_PATH}'"
+                    # TODO: would be great to notify each container that all of their peers are online and DNS resolving now works instead of sleeping
+                    cmd = f"sh -c 'sleep 5 && ./run.py --runner={runner} --scenario={scenario.id()} --lib={LIB_PATH}'"
 
                     env = [
                         "RUST_BACKTRACE=1",

--- a/test/runner.py
+++ b/test/runner.py
@@ -88,8 +88,27 @@ class ContainerHolder:
 def run():
     print("*** Test suite launched", flush=True)
 
+    all_tags = []
+    for scenario in all_scenarios:
+        all_tags += scenario.tags()
+
+    all_tags = list(set(all_tags))
+    print(f"* Available tags: {all_tags}")
+
     scenarios = []
-    if "SCENARIO" in os.environ:
+    if "SCENARIO" in os.environ and "TAGS" in os.environ:
+        print("TAGS and SCENARIO cannot appear at once")
+        exit(3)
+
+    if "TAGS" in os.environ:
+        tags = [x.strip() for x in os.environ["TAGS"].split(",")]
+
+        print(f"Will execute scenarios with tags: {tags}")
+        for s in all_scenarios:
+            if all([tag in s.tags() for tag in tags]):
+                scenarios.append(s)
+
+    elif "SCENARIO" in os.environ:
         name = os.environ["SCENARIO"]
         pattern = re.compile(name)
 
@@ -193,14 +212,18 @@ def run():
         curr_time = time.strftime("%H:%M:%S", time.localtime())
 
         done_containers = 0
+        failed_container_count = 0
         for scenario in scenarios:
             if scenario.id() in scenario_results:
                 for container in scenario_results[scenario.id()]:
                     if container.done():
                         done_containers += 1
+                        success, reason = container.success()
+                        if not success:
+                            failed_container_count += 1
 
         print(
-            f"*** Test suite progress: {curr_time}: {done_containers}/{total_containers} containers finished",
+            f"*** Test suite progress: {curr_time}: {done_containers}/{total_containers} containers finished, {failed_container_count} failed",
             flush=True,
         )
 
@@ -224,11 +247,6 @@ def run():
             if not success:
                 failed_scenarios.append(scenario)
                 break
-
-    print(
-        f"*** Test suite results: {total_scenarios_count} scenarios, {len(failed_scenarios)} failed. Succeeded ({round((1.0-(len(failed_scenarios)/total_scenarios_count)) * 100, 2)}%), on average one scenario took {math.ceil(total_time/total_scenarios_count)} seconds",
-        flush=True,
-    )
 
     if len(failed_scenarios) == 0:
         print("Success! All tests passed!", flush=True)
@@ -257,6 +275,11 @@ def run():
                     f"*** Scenario {scenario.id()}, failed containers: {failed_container_names}",
                     flush=True,
                 )
+        print(
+            f"*** Test suite results: {total_scenarios_count} scenarios, {len(failed_scenarios)} failed. Succeeded ({round((1.0-(len(failed_scenarios)/total_scenarios_count)) * 100, 2)}%), on average one scenario took {math.ceil(total_time/total_scenarios_count)} seconds",
+            flush=True,
+        )
+
         exit(1)
 
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -2192,6 +2192,7 @@ scenarios = [
                         "DROP_PEER_STIMPY",
                         "/tmp/testfile-big",
                     ),
+                    action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
                     action.NewTransferWithFD(
                         "DROP_PEER_GEORGE",
                         "/tmp/testfile-big",
@@ -2337,6 +2338,7 @@ scenarios = [
                     action.NewTransferWithFD(
                         "DROP_PEER_STIMPY", "/tmp/testfile-small", cached=True
                     ),
+                    action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
                     action.NewTransferWithFD(
                         "DROP_PEER_GEORGE", "/tmp/testfile-small", cached=True
                     ),
@@ -5483,7 +5485,7 @@ scenarios = [
             "DROP_PEER_REN6": ActionList(
                 [
                     action.Start("DROP_PEER_REN6"),
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY6"),
                     action.NewTransfer("DROP_PEER_STIMPY6", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -6825,7 +6827,7 @@ scenarios = [
                                     HTTPStatus.NOT_FOUND,
                                 )
                             ]
-                            * 500,
+                            * 1500,
                         ),
                     ),
                     action.MakeHttpGetRequest(
@@ -6843,7 +6845,7 @@ scenarios = [
             "DROP_PEER_STIMPY": ActionList(
                 [
                     action.Start("DROP_PEER_STIMPY"),
-                    action.Sleep(15),
+                    action.Sleep(30),
                     action.Stop(),
                 ]
             ),
@@ -7939,7 +7941,6 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY", ["../../tmp/testfile-small"]
@@ -8004,7 +8005,6 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.Repeated(
                         [

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -6547,6 +6547,10 @@ scenarios = [
                             },
                         )
                     ),
+                    # give it some time to arrive
+                    # TODO: it would be better if we would have an explicit event for this
+                    # or slightly worse - coordinate testrunners from two peers via central container about stuff which happened
+                    action.Sleep(3),
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-10-ren.sqlite"),
@@ -6580,7 +6584,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.Sleep(1),
+                    action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
                     action.Download(
                         0,
                         FILES["testfile-small"].id,
@@ -6627,6 +6631,10 @@ scenarios = [
                             },
                         )
                     ),
+                    # give it some time to arrive
+                    # TODO: it would be better if we would have an explicit event for this
+                    # or slightly worse - coordinate testrunners from two peers via central container about stuff which happened
+                    action.Sleep(3),
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-11-ren.sqlite"),
@@ -6655,7 +6663,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.Sleep(1),
+                    action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-small"].id, False)
@@ -6686,6 +6694,10 @@ scenarios = [
                             },
                         )
                     ),
+                    # give it some time to arrive
+                    # TODO: it would be better if we would have an explicit event for this
+                    # or slightly worse - coordinate testrunners from two peers via central container about stuff which happened
+                    action.Sleep(3),
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-12-ren.sqlite"),
@@ -6712,7 +6724,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.Sleep(1),
+                    action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
                     action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -149,7 +149,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.AssertTransfers(
                         [
@@ -397,8 +397,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.AssertTransfers(
                         [
@@ -610,8 +609,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -642,7 +640,7 @@ scenarios = [
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
                     action.Stop(),
@@ -699,7 +697,7 @@ scenarios = [
                         )
                     ),
                     action.Sleep(1),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
                     action.Stop(),
@@ -780,7 +778,7 @@ scenarios = [
                         "/tmp/received",
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(
                         event.FinishTransferCanceled(0, False),
                     ),
@@ -832,7 +830,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(
                         event.FinishTransferCanceled(0, False),
                     ),
@@ -933,7 +931,7 @@ scenarios = [
                             ),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(
                         event.FinishTransferCanceled(
                             0,
@@ -968,7 +966,7 @@ scenarios = [
                         )
                     ),
                     action.SleepMs(200),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
                     action.Stop(),
@@ -1026,7 +1024,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.Sleep(4),
                     action.Stop(),
@@ -1326,7 +1324,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -1408,7 +1406,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -1529,8 +1527,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small(1)", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -1700,8 +1697,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -1828,16 +1824,7 @@ scenarios = [
                         ]
                     ),
                     # fmt: on
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
-                    action.CancelTransferRequest(2),
-                    action.CancelTransferRequest(3),
-                    action.CancelTransferRequest(4),
-                    action.CancelTransferRequest(5),
-                    action.CancelTransferRequest(6),
-                    action.CancelTransferRequest(7),
-                    action.CancelTransferRequest(8),
-                    action.CancelTransferRequest(9),
+                    action.CancelTransferRequest([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]),
                     action.ExpectCancel([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2289,7 +2276,7 @@ scenarios = [
                             action.File("/tmp/received/stimpy/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2331,7 +2318,7 @@ scenarios = [
                             action.File("/tmp/received/george/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2439,7 +2426,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2483,7 +2470,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2564,7 +2551,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2631,7 +2618,7 @@ scenarios = [
                             "/tmp/symtest-dir/testfile-small",
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2723,7 +2710,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2807,7 +2794,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -2892,7 +2879,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -3100,8 +3087,7 @@ scenarios = [
                             action.File("/tmp/received/path(1)/file2.ext2", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -3221,7 +3207,7 @@ scenarios = [
                             action.File("/tmp/received/15-3/name(1)/file-02", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -3360,7 +3346,7 @@ scenarios = [
                             Error.BAD_TRANSFER_STATE,
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.AssertTransfers(
                         [
@@ -3681,8 +3667,7 @@ scenarios = [
                             ),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -3753,8 +3738,7 @@ scenarios = [
                             ),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -3835,7 +3819,7 @@ scenarios = [
                             action.File("/tmp/received/with-illegal-char-_-", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4034,7 +4018,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4123,7 +4107,7 @@ scenarios = [
                             action.File("/tmp/received/21-1/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4216,7 +4200,7 @@ scenarios = [
                             action.File("/tmp/received/21-2/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4377,7 +4361,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4449,7 +4433,7 @@ scenarios = [
                             action.File("/tmp/received/22/zero-sized-file", 0),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4560,7 +4544,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4631,7 +4615,7 @@ scenarios = [
                             13,
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4700,7 +4684,7 @@ scenarios = [
                         event.FinishFileFailed(0, FILES["testfile-big"].id, Error.IO, 2)
                     ),
                     action.CompareTrees(Path("/tmp/received/25"), []),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -4899,7 +4883,7 @@ scenarios = [
                             action.File("/tmp/received/26-2/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                 ]
             ),
@@ -4955,7 +4939,7 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-small"].id, True)
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5013,7 +4997,7 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-small"].id, False)
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5072,7 +5056,7 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-big"].id, True)
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5131,7 +5115,7 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-big"].id, False)
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5197,7 +5181,7 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5263,7 +5247,7 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5335,7 +5319,7 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         ),
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5405,7 +5389,7 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         ),
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5483,7 +5467,7 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_FINISHED
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -5595,7 +5579,7 @@ scenarios = [
                             action.File("/tmp/received/28/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.AssertTransfers(
                         [
@@ -5773,7 +5757,7 @@ scenarios = [
                             action.File("/tmp/received/29-1/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.AssertTransfers(
@@ -5923,7 +5907,7 @@ scenarios = [
                             action.File("/tmp/received/29-2/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -6052,7 +6036,7 @@ scenarios = [
                             action.File("/tmp/received/29-3/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -6188,7 +6172,7 @@ scenarios = [
                             action.File("/tmp/received/29-4/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -6307,7 +6291,7 @@ scenarios = [
                             action.File("/tmp/received/29-5/testfile-big", 10485760),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -6434,7 +6418,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
                     action.Sleep(2),
@@ -6524,7 +6508,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
                     action.Start(
@@ -6608,7 +6592,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                 ]
@@ -6720,7 +6704,7 @@ scenarios = [
                         )
                     ),
                     action.Sleep(1),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                 ]
@@ -6796,7 +6780,7 @@ scenarios = [
                             0, FILES["testfile-big"].id, Error.BAD_TRANSFER_STATE
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                 ]
@@ -6904,7 +6888,7 @@ scenarios = [
                     }"""
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7071,7 +7055,7 @@ scenarios = [
                     }"""
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7141,7 +7125,7 @@ scenarios = [
                         ]
                     ),
                     action.SleepMs(200),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7230,7 +7214,7 @@ scenarios = [
                     }"""
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7367,7 +7351,7 @@ scenarios = [
                     }"""
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7493,7 +7477,7 @@ scenarios = [
                     }"""
                         ]
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7641,7 +7625,7 @@ scenarios = [
                         ]
                     ),
                     action.SleepMs(200),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7809,7 +7793,7 @@ scenarios = [
                             "/tmp/received/31-8/path/file2.ext2",
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
                 ]
@@ -7919,8 +7903,7 @@ scenarios = [
                             action.File("/tmp/received/32/testfile-small(1)", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),                
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -7951,7 +7934,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.AssertTransfers(
                         [
@@ -8164,7 +8147,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
                 ]
@@ -8252,7 +8235,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Sleep(8),  # give time for the signal to be sent
                     action.Stop(),
@@ -8386,7 +8369,7 @@ scenarios = [
                             FILES["testfile-big"].id,
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
                 ]
@@ -8483,7 +8466,7 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.SleepMs(400),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(duration=10),
                     action.Stop(),
@@ -8717,12 +8700,15 @@ scenarios = [
                         "/tmp/db/41-ren.sqlite", "/tmp/db/41-ren-copy.sqlite"
                     ),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/41-ren.sqlite"),
-                    action.Sleep(4),  # synchronize with other peer about the transfer
-                    action.CancelTransferRequest(0),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
+                    
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
+                    
                     # Start again but this time with a copy of the database. The transfer should be again retried but the other peer should respond with already cancelled
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/41-ren-copy.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.ExpectCancel([0], True),
                     action.Stop(),
                 ]
@@ -8799,7 +8785,7 @@ scenarios = [
                         )
                     ),
                     action.Sleep(1),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Sleep(2),
                     action.Stop(),
@@ -8830,7 +8816,7 @@ scenarios = [
                         )
                     ),
                     action.SleepMs(500),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Sleep(2),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
@@ -8985,8 +8971,7 @@ scenarios = [
                             ),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(6),
                     action.Stop(),
@@ -9116,8 +9101,7 @@ scenarios = [
                         ],
                     ),
                     # TODO if ExpectCancel is taking an array, it makes sense for CancelTransferRequest to take in an array as well
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(6),
                     action.Stop(),
@@ -9249,8 +9233,7 @@ scenarios = [
                             ),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(6),
                     action.Stop(),
@@ -9420,8 +9403,7 @@ scenarios = [
                             ),
                         ]
                     ),
-                    action.CancelTransferRequest(0),
-                    action.CancelTransferRequest(1),
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(6),
                     action.Stop(),
@@ -9558,7 +9540,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Sleep(6),
                     action.Stop(),
@@ -9646,7 +9628,7 @@ scenarios = [
                             action.File("/tmp/received/testfile-small", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest(0),
+                    action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),
                     action.Stop(),

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -5659,6 +5659,7 @@ scenarios = [
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     # start the sender again
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-1-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.Start(0, FILES["testfile-big"].id, transferred=None)
                     ),
@@ -5968,6 +5969,7 @@ scenarios = [
                     action.WaitForAnotherPeer(),
                     # start the sender again
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-3-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.Start(0, FILES["testfile-big"].id, transferred=None)
                     ),
@@ -6223,6 +6225,7 @@ scenarios = [
                     action.WaitForAnotherPeer(),
                     # start the sender again
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-5-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.Start(
                             0,
@@ -6320,6 +6323,7 @@ scenarios = [
                     ),
                     action.Stop(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-6-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Sleep(6),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.NoEvent(),
@@ -6423,6 +6427,7 @@ scenarios = [
                     action.Stop(),
                     action.Sleep(2),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-8-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                 ]
             ),
             "DROP_PEER_STIMPY": ActionList(
@@ -6469,6 +6474,7 @@ scenarios = [
                     action.ExpectCancel([0], True),
                     action.Stop(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-9-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.NoEvent(),
                 ]
             ),
@@ -6544,6 +6550,7 @@ scenarios = [
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-10-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
                     action.Wait(
                         event.FinishFileUploaded(
@@ -6623,6 +6630,7 @@ scenarios = [
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-11-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-small"].id, True)
                     ),
@@ -6681,6 +6689,7 @@ scenarios = [
                     action.Stop(),
                     action.Sleep(3),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-12-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.ExpectCancel([0], True),
                     action.NoEvent(),
                 ]
@@ -6743,6 +6752,7 @@ scenarios = [
                     action.DeleteFileFromFS("/tmp/testfile-big"),
                     # restart
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-13-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.FinishFileFailed(
                             0, FILES["testfile-big"].id, Error.IO, os_err=2
@@ -7903,7 +7913,7 @@ scenarios = [
                             action.File("/tmp/received/32/testfile-small(1)", 1048576),
                         ],
                     ),
-                    action.CancelTransferRequest([0, 1]),                
+                    action.CancelTransferRequest([0, 1]),
                     action.ExpectCancel([0, 1], False),
                     action.NoEvent(),
                     action.Stop(),
@@ -8183,7 +8193,7 @@ scenarios = [
                         [
                             action.Sleep(0.01),
                             action.SetPeerState("DROP_PEER_STIMPY", PeerState.Offline),
-                            action.SetPeerState("DROP_PEER_GEORGE", PeerState.Online),
+                            action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                         ],
                         500,
                     ),
@@ -8440,6 +8450,7 @@ scenarios = [
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     action.SleepMs(400),
                     action.Start("DROP_PEER_REN", "/tmp/db/38.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(event.FinishTransferCanceled(0, True)),
                     action.NoEvent(),
                     action.Stop(),
@@ -8701,11 +8712,9 @@ scenarios = [
                     ),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/41-ren.sqlite"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
-                    
                     action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.Stop(),
-                    
                     # Start again but this time with a copy of the database. The transfer should be again retried but the other peer should respond with already cancelled
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/41-ren-copy.sqlite"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
@@ -8764,6 +8773,7 @@ scenarios = [
                     action.Stop(),
                     action.Sleep(1),
                     action.Start("DROP_PEER_REN", "/tmp/db/42-1-ren.sqlite"),
+                    action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.ExpectCancel([0], True),
                     action.Stop(),
                 ]

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -1025,6 +1025,7 @@ scenarios = [
                 ]
             ),
         },
+        tags=["offline", "cancel"],
     ),
     Scenario(
         "scenario5",

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -22,7 +22,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -228,7 +228,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -488,7 +488,7 @@ scenarios = [
                 [
                     action.ConfigureNetwork(latency="100ms"),
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -627,7 +627,7 @@ scenarios = [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -684,7 +684,7 @@ scenarios = [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -737,7 +737,7 @@ scenarios = [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -798,7 +798,7 @@ scenarios = [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -849,7 +849,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/nested/big"]),
                     action.Wait(
                         event.Queued(
@@ -953,7 +953,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -1127,7 +1127,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/deep"]),
                     action.Wait(
                         event.Queued(
@@ -1340,7 +1340,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferWithFD(
                         "DROP_PEER_STIMPY",
                         "/tmp/testfile-small",
@@ -1422,7 +1422,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -1543,7 +1543,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         ["/tmp/testfile.small.with.complicated.extension"],
@@ -1713,7 +1713,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # fmt: off
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
                     action.Wait(event.Queued(0, { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
@@ -1838,7 +1838,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.Repeated(
                         [
@@ -2004,7 +2004,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.Repeated(
                         [
@@ -2187,7 +2187,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferWithFD(
                         "DROP_PEER_STIMPY",
                         "/tmp/testfile-big",
@@ -2333,7 +2333,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferWithFD(
                         "DROP_PEER_STIMPY", "/tmp/testfile-small", cached=True
                     ),
@@ -2486,7 +2486,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -2566,7 +2566,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -2633,7 +2633,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -2725,7 +2725,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferFails(
                         "DROP_PEER_STIMPY", "/tmp/testfile-small-xd"
                     ),
@@ -2809,7 +2809,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -2894,7 +2894,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/deep/path"]),
                     action.Wait(
                         event.Queued(
@@ -3101,7 +3101,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY", ["/tmp/name", "/tmp/different/name"]
@@ -3223,7 +3223,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -3423,7 +3423,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferFails("DROP_PEER_STIMPY", "/tmp/empty-dir"),
                     action.NoEvent(),
                 ]
@@ -3444,7 +3444,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -3517,7 +3517,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         [
@@ -3757,7 +3757,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     # Wait for another peer to appear
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY", ["/tmp/with-illegal-char-\x0A-"]
                     ),
@@ -3834,7 +3834,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         [
@@ -4034,7 +4034,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(latency="0.5s"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -4124,7 +4124,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(latency="0.5s"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -4138,7 +4138,7 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(
@@ -4217,7 +4217,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(latency="0.5s"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/nested"]),
                     action.Wait(
                         event.Queued(
@@ -4248,7 +4248,7 @@ scenarios = [
                             event.Paused(0, FILES["nested/big/testfile-02"].id),
                         ]
                     ),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.WaitRacy(
                         [
@@ -4377,7 +4377,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/zero-sized-file"]),
                     action.Wait(
                         event.Queued(
@@ -4448,7 +4448,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         ["/tmp/testfile-small", "/tmp/duplicate/testfile-small"],
@@ -4559,7 +4559,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -4631,7 +4631,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -4734,7 +4734,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.DropPrivileges(),
                     action.Start(
                         "DROP_PEER_REN",
@@ -4897,7 +4897,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -4955,7 +4955,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5014,7 +5014,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -5073,7 +5073,7 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_REN"),
                     action.ConfigureNetwork(),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -5131,7 +5131,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5197,7 +5197,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5263,7 +5263,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5335,7 +5335,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5405,7 +5405,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5483,7 +5483,7 @@ scenarios = [
             "DROP_PEER_REN6": ActionList(
                 [
                     action.Start("DROP_PEER_REN6"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY6", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -5636,7 +5636,7 @@ scenarios = [
                 [
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-1-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -5823,7 +5823,7 @@ scenarios = [
                 [
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(
@@ -5839,7 +5839,7 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # TODO: could be nice to actually signal the peer via docker that peer is online, this would reduce flakyness
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
@@ -5925,7 +5925,7 @@ scenarios = [
                 [
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-3-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         [
@@ -5966,7 +5966,7 @@ scenarios = [
                     action.Wait(event.Progress(0, FILES["testfile-big"].id)),
                     action.Stop(),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # start the sender again
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-3-ren.sqlite"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
@@ -6053,10 +6053,10 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY",
                         [
@@ -6092,7 +6092,7 @@ scenarios = [
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
-                    action.Sleep(4),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.Wait(
                         event.Start(0, FILES["testfile-big"].id, transferred=None)
@@ -6191,7 +6191,7 @@ scenarios = [
                 [
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-5-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransferWithFD("DROP_PEER_STIMPY", "/tmp/testfile-big"),
                     action.Wait(
                         event.Queued(
@@ -6222,7 +6222,7 @@ scenarios = [
                     action.Wait(
                         event.Paused(0, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw")
                     ),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # start the sender again
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-5-ren.sqlite"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
@@ -6324,7 +6324,7 @@ scenarios = [
                     action.Stop(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-6-ren.sqlite"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
-                    action.Sleep(6),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.NoEvent(),
                 ]
@@ -6372,7 +6372,7 @@ scenarios = [
                     action.Wait(
                         event.FinishFileRejected(0, FILES["testfile-big"].id, False)
                     ),
-                    action.Sleep(4),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.SetPeerState("DROP_PEER_STIMPY", PeerState.Online),
                     action.NoEvent(),
                     action.Stop(),
@@ -6450,7 +6450,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-9-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -6533,7 +6533,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-10-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -6613,7 +6613,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-11-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -6672,7 +6672,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-12-ren.sqlite"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -6726,7 +6726,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/29-13-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -6803,7 +6803,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ExpectAnyError(
                         action.Parallel(
                             [
@@ -6843,7 +6843,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/31-1-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -6961,7 +6961,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/31-2-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7079,7 +7079,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/31-1-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7190,7 +7190,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/31-1-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7301,7 +7301,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7439,7 +7439,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7577,7 +7577,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -7711,7 +7711,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/deep/path"]),
@@ -7818,7 +7818,7 @@ scenarios = [
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.WaitRacy(
@@ -7927,7 +7927,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer(
                         "DROP_PEER_STIMPY", ["../../tmp/testfile-small"]
@@ -7992,7 +7992,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.Repeated(
                         [
@@ -8024,7 +8024,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -8072,7 +8072,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="10ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -8171,7 +8171,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="100ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -8260,7 +8260,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -8311,7 +8311,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # create a transfer so there would be transfer to be re-sent
                     action.Start("DROP_PEER_REN", "/tmp/data.base"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -8357,7 +8357,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", "/tmp/data.base"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
@@ -8431,7 +8431,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1000ms"),
                     action.Start("DROP_PEER_REN", "/tmp/db/38.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -8491,7 +8491,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -8569,7 +8569,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -8689,7 +8689,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", dbpath="/tmp/db/41-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -8754,7 +8754,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", "/tmp/db/42-1-ren.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
@@ -8810,7 +8810,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
@@ -8871,7 +8871,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
@@ -8942,7 +8942,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="10ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -9194,7 +9194,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -9364,7 +9364,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -9534,7 +9534,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1000ms"),
                     action.Start("DROP_PEER_REN"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -9571,7 +9571,7 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer(),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.ExpectError(
                         action.Start("DROP_PEER_REN"), ReturnCodes.INSTANCE_START


### PR DESCRIPTION
Introduce `norddrop_set_peer_state(peer, state)` API
---
- removed logic for infinite loop with exponential, capped sleep
- transfer is initiated when:
  * libdrop starts
  * A new transfer is made
  * norddrop_set_peers_state() with `online` flag is passed

- Each testcase became very sensitive to timing as without automated retry if the transfer is initiated from A->B, B is online but libdrop has not yet started it will then return `CONN REFUSED` immediately and without retry logic it will fail. For this, the solution was to add `WaitForAnotherPeer()` in each testcase. An alternative could be to add `norddrop_set_peers_state()` but I didn't see a reason for that.
- `offline` state is actually ignored but I think it's nice to ask for it from the apps as they have that state ready, however not a hard opinion on this, we can rework it into `set_peers_online(json_array_of_peers)`. Opinions are welcome :)
- all offline testcases(those where one of the peers stop libdrop) now contains explicit `norddrop_set_peers_state()` call to inform that peer is online
- tags were introduced in scenarios for easy running via `TAGS=offline,reject make -C test`
- Simplified DDoS protection logic as previously if it was tripped it would remove the transfer. As we moved the connection to a manual API call, it's easy to trip on it accidentally and remove the transfer thus I reworked DDoS protection to be recoverable error.
- Added rapidly disconnecting peer scenarios(35-*, 44-2, 44-3).
