### PR TITLE
Rust 1.72.1

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: 1.72.1
           default: true        
       - name: docker sdk
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,14 +6,14 @@ on:
     branches: [dev, main]
 jobs:
   lint-rust:
-    container: rust:1.64-bullseye
+    container: rust:1.72.1-bullseye
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: 1.72.1
           default: true
           components: clippy
       - name: Install nightly Rust toolchain

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,6 @@ jobs:
             --color always --lib --release
             --
             --allow unknown-lints
-            --deny clippy::let_underscore_must_use
             --deny clippy::unused_async
             --deny clippy::wildcard_imports
             --deny clippy::unwrap_used

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.64.0
+          toolchain: 1.72.1
           default: true
       - name: Run unit tests
         run: |

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -118,7 +118,9 @@ impl TransferManager {
                 match state.xfer_sync {
                     sync::TransferState::Canceled => {
                         debug!(self.logger, "Incoming transfer is locally cancelled");
-                        let _ = conn.send(ServerReq::Close);
+                        if let Err(e) = conn.send(ServerReq::Close) {
+                            error!(self.logger, "Failed to send close request: {}", e);
+                        }
                         drop(conn)
                     }
                     _ => {
@@ -137,7 +139,9 @@ impl TransferManager {
                     .is_none()
                 {
                     warn!(self.logger, "Transfer was closed already");
-                    let _ = conn.send(ServerReq::Close);
+                    if let Err(e) = conn.send(ServerReq::Close) {
+                        error!(self.logger, "Failed to send close request: {}", e);
+                    }
                     return Ok(false);
                 }
 
@@ -189,7 +193,9 @@ impl TransferManager {
         match state.xfer_sync {
             sync::TransferState::Canceled => {
                 debug!(self.logger, "Outgoing transfer is locally cancelled");
-                let _ = conn.send(ClientReq::Close);
+                if let Err(e) = conn.send(ClientReq::Close) {
+                    error!(self.logger, "Failed to send close request: {}", e);
+                }
                 drop(conn);
             }
             _ => {
@@ -299,9 +305,11 @@ impl TransferManager {
                 "Pushing outgoing rejection request: file_id {file_id}"
             );
 
-            let _ = conn.send(ClientReq::Reject {
+            if let Err(e) = conn.send(ClientReq::Reject {
                 file: file_id.clone(),
-            });
+            }) {
+                error!(self.logger, "Failed to send rejection request: {}", e);
+            }
         }
 
         Ok(FinishResult {
@@ -378,9 +386,11 @@ impl TransferManager {
                 "Pushing incoming rejection request: file_id {file_id}"
             );
 
-            let _ = conn.send(ServerReq::Reject {
+            if let Err(e) = conn.send(ServerReq::Reject {
                 file: file_id.clone(),
-            });
+            }) {
+                error!(self.logger, "Failed to send rejection request: {}", e);
+            }
         }
 
         Ok(FinishResult {
@@ -562,7 +572,9 @@ impl TransferManager {
 
         if let Some(conn) = state.conn.take() {
             debug!(self.logger, "Pushing outgoing close request");
-            let _ = conn.send(ServerReq::Close);
+            if let Err(e) = conn.send(ServerReq::Close) {
+                error!(self.logger, "Failed to send close request: {}", e);
+            }
         }
 
         for val in state.file_sync.values_mut() {
@@ -614,7 +626,9 @@ impl TransferManager {
 
                 if let Some(conn) = state.conn.take() {
                     debug!(self.logger, "Pushing incoming  close request");
-                    let _ = conn.send(ClientReq::Close);
+                    if let Err(e) = conn.send(ClientReq::Close) {
+                        error!(self.logger, "Failed to send close request: {}", e);
+                    }
                 }
 
                 Ok(CloseResult {
@@ -697,7 +711,9 @@ impl OutgoingState {
             });
 
         for req in iter {
-            let _ = conn.send(req);
+            if let Err(e) = conn.send(req) {
+                error!(logger, "Failed to send request: {}", e);
+            }
         }
     }
 
@@ -775,9 +791,11 @@ impl IncomingState {
 
             debug!(logger, "Pushing download request: file_id {file_id}");
 
-            let _ = conn.send(ServerReq::Download {
+            if let Err(e) = conn.send(ServerReq::Download {
                 task: Box::new(task),
-            });
+            }) {
+                error!(logger, "Failed to send download request: {}", e);
+            }
         }
 
         Ok(())
@@ -845,7 +863,9 @@ impl IncomingState {
             });
 
         for req in iter {
-            let _ = conn.send(req);
+            if let Err(e) = conn.send(req) {
+                error!(logger, "Failed to send request: {}", e);
+            }
         }
     }
 

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -6,6 +6,7 @@ use tokio_tungstenite::tungstenite::Message;
 use super::WebSocket;
 use crate::{ws, FileId, OutgoingTransfer};
 
+#[derive(Debug)]
 pub struct MsgToSend {
     pub msg: Message,
 }

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -155,7 +155,9 @@ async fn connect_to_peer(
         }
     };
 
-    let _ = state.transfer_manager.outgoing_disconnect(xfer.id()).await;
+    if let Err(e) = state.transfer_manager.outgoing_disconnect(xfer.id()).await {
+        error!(logger, "Failed to disconnect from transfer: {e:?}");
+    }
     control
 }
 

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -45,6 +45,7 @@ pub struct HandlerLoop<'a, const PING: bool> {
 struct Uploader {
     sink: Sender<MsgToSend>,
     file_subpath: FileSubPath,
+    logger: slog::Logger,
 }
 
 struct FileTask {
@@ -158,6 +159,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                             Uploader {
                                 sink: self.upload_tx.clone(),
                                 file_subpath: file_id.clone(),
+                                logger: self.logger.clone(),
                             },
                             self.xfer.clone(),
                             file_id,
@@ -176,6 +178,7 @@ impl<const PING: bool> HandlerLoop<'_, PING> {
                         Uploader {
                             sink: self.upload_tx.clone(),
                             file_subpath: file_id.clone(),
+                            logger: self.logger.clone(),
                         },
                         self.xfer.clone(),
                         file_id,
@@ -364,12 +367,15 @@ impl handler::Uploader for Uploader {
             msg,
         });
 
-        let _ = self
+        if let Err(e) = self
             .sink
             .send(MsgToSend {
                 msg: Message::from(&msg),
             })
-            .await;
+            .await
+        {
+            error!(self.logger, "Failed to send error message: {:?}", e);
+        }
     }
 
     fn offset(&self) -> u64 {

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -45,6 +45,7 @@ struct Uploader {
     sink: Sender<MsgToSend>,
     file_id: FileId,
     offset: u64,
+    logger: slog::Logger,
 }
 
 impl<'a> HandlerInit<'a> {
@@ -119,7 +120,7 @@ impl HandlerLoop<'_> {
         self.stop_task(&file_id, Status::FileFinished).await;
     }
 
-    async fn on_checksum(&mut self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
+    fn on_checksum(&mut self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
         let state = self.state.clone();
         let msg_tx = self.upload_tx.clone();
         let xfer = self.xfer.clone();
@@ -146,11 +147,14 @@ impl HandlerLoop<'_> {
 
             match make_report.await {
                 Ok(report) => {
-                    let _ = msg_tx
+                    if let Err(e) = msg_tx
                         .send(MsgToSend {
                             msg: Message::from(&v4::ClientMsg::ReportChsum(report)),
                         })
-                        .await;
+                        .await
+                    {
+                        error!(logger, "Failed to send checksum report: {:?}", e);
+                    }
                 }
                 Err(err) => {
                     error!(logger, "Failed to report checksum: {:?}", err);
@@ -172,11 +176,14 @@ impl HandlerLoop<'_> {
                         file: Some(file_id.clone()),
                         msg,
                     };
-                    let _ = msg_tx
+                    if let Err(e) = msg_tx
                         .send(MsgToSend {
                             msg: Message::from(&v4::ClientMsg::Error(msg)),
                         })
-                        .await;
+                        .await
+                    {
+                        error!(logger, "Failed to send error report: {:?}", e);
+                    }
                 }
             }
         };
@@ -202,6 +209,7 @@ impl HandlerLoop<'_> {
                     sink: self.upload_tx.clone(),
                     file_id: file_id.clone(),
                     offset,
+                    logger: self.logger.clone(),
                 };
                 let state = self.state.clone();
                 let alive = self.alive.clone();
@@ -347,7 +355,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             }) => self.on_done(file).await,
             v4::ServerMsg::Error(v4::Error { file, msg }) => self.on_error(file, msg).await,
             v4::ServerMsg::ReqChsum(v4::ReqChsum { file, limit }) => {
-                self.on_checksum(jobs, file, limit).await
+                self.on_checksum(jobs, file, limit)
             }
             v4::ServerMsg::Start(v4::Start { file, offset }) => {
                 self.on_start(socket, jobs, file, offset).await?
@@ -408,12 +416,15 @@ impl handler::Uploader for Uploader {
             msg,
         });
 
-        let _ = self
+        if let Err(e) = self
             .sink
             .send(MsgToSend {
                 msg: Message::from(&msg),
             })
-            .await;
+            .await
+        {
+            error!(self.logger, "Failed to send error report: {:?}", e);
+        }
     }
 
     fn offset(&self) -> u64 {

--- a/drop-transfer/src/ws/client/v5.rs
+++ b/drop-transfer/src/ws/client/v5.rs
@@ -45,6 +45,7 @@ struct Uploader {
     sink: Sender<MsgToSend>,
     file_id: FileId,
     offset: u64,
+    logger: slog::Logger,
 }
 
 impl<'a> HandlerInit<'a> {
@@ -151,7 +152,7 @@ impl HandlerLoop<'_> {
         self.stop_task(&file_id, Status::FileFinished).await;
     }
 
-    async fn on_checksum(&self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
+    fn on_checksum(&self, jobs: &mut JoinSet<()>, file_id: FileId, limit: u64) {
         let state = self.state.clone();
         let msg_tx = self.upload_tx.clone();
         let xfer = self.xfer.clone();
@@ -178,9 +179,12 @@ impl HandlerLoop<'_> {
 
             match make_report.await {
                 Ok(report) => {
-                    let _ = msg_tx
+                    if let Err(e) = msg_tx
                         .send(MsgToSend::from(&prot::ClientMsg::ReportChsum(report)))
-                        .await;
+                        .await
+                    {
+                        error!(logger, "Failed to send checksum report: {:?}", e);
+                    }
                 }
                 Err(err) => {
                     error!(logger, "Failed to report checksum: {:?}", err);
@@ -202,11 +206,14 @@ impl HandlerLoop<'_> {
                         file: Some(file_id.clone()),
                         msg,
                     };
-                    let _ = msg_tx
+                    if let Err(e) = msg_tx
                         .send(MsgToSend {
                             msg: Message::from(&prot::ClientMsg::Error(msg)),
                         })
-                        .await;
+                        .await
+                    {
+                        error!(logger, "Failed to send error message: {:?}", e);
+                    }
                 }
             }
         };
@@ -232,6 +239,7 @@ impl HandlerLoop<'_> {
                     sink: self.upload_tx.clone(),
                     file_id: file_id.clone(),
                     offset,
+                    logger: self.logger.clone(),
                 };
                 let state = self.state.clone();
                 let alive = self.alive.clone();
@@ -363,7 +371,7 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             }) => self.on_done(file).await,
             prot::ServerMsg::Error(prot::Error { file, msg }) => self.on_error(file, msg).await,
             prot::ServerMsg::ReqChsum(prot::ReqChsum { file, limit }) => {
-                self.on_checksum(jobs, file, limit).await
+                self.on_checksum(jobs, file, limit)
             }
             prot::ServerMsg::Start(prot::Start { file, offset }) => {
                 self.on_start(socket, jobs, file, offset).await?
@@ -423,12 +431,15 @@ impl handler::Uploader for Uploader {
             msg,
         });
 
-        let _ = self
+        if let Err(e) = self
             .sink
             .send(MsgToSend {
                 msg: Message::from(&msg),
             })
-            .await;
+            .await
+        {
+            error!(self.logger, "Failed to send error message: {:?}", e);
+        }
     }
 
     fn offset(&self) -> u64 {

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -52,6 +52,7 @@ struct Downloader {
     file_subpath: FileSubPath,
     msg_tx: Sender<MsgToSend>,
     tmp_loc: Option<Hidden<PathBuf>>,
+    logger: slog::Logger,
 }
 
 struct FileTask {
@@ -246,6 +247,7 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
             file_subpath: ctx.task.file.subpath().clone(),
             msg_tx: self.msg_tx.clone(),
             tmp_loc: None,
+            logger: self.logger.clone(),
         };
         let (job, events) = ctx.start(downloader, chunks_rx).await?;
 
@@ -408,7 +410,9 @@ impl Downloader {
 impl Drop for Downloader {
     fn drop(&mut self) {
         if let Some(path) = self.tmp_loc.as_ref() {
-            let _ = fs::remove_file(&path.0);
+            if let Err(e) = fs::remove_file(&path.0) {
+                error!(self.logger, "Failed to remove tmp file: {e}");
+            }
         }
     }
 }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -147,7 +147,9 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             Err(err) => {
                 error!(self.logger, "Failed to prepare checksum info: {err}");
 
-                let _ = self.on_error(ws, err).await;
+                if let Err(e) = self.on_error(ws, err).await {
+                    error!(self.logger, "Failed to send error message: {e}");
+                }
                 return None;
             }
         };

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -147,7 +147,9 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             Err(err) => {
                 error!(self.logger, "Failed to prepare checksum info: {err}");
 
-                let _ = self.on_error(ws, err).await;
+                if let Err(e) = self.on_error(ws, err).await {
+                    error!(self.logger, "Failed to send error message: {e}");
+                }
                 return None;
             }
         };

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -119,6 +119,7 @@ pub unsafe extern "C" fn norddrop_new_transfer(
 #[no_mangle]
 pub unsafe extern "C" fn norddrop_destroy(dev: *mut norddrop) {
     if !dev.is_null() {
+        #[allow(clippy::let_underscore_must_use)]
         let _ = Box::from_raw(dev);
     }
 }
@@ -773,6 +774,7 @@ impl slog::Drain for norddrop_logger_cb {
         let kv = record.kv();
 
         let mut serializer = KeyValueSerializer::new(record);
+        #[allow(clippy::let_underscore_must_use)]
         let _ = kv.serialize(record, &mut serializer);
 
         if let Ok(cstr) = CString::new(serializer.msg()) {


### PR DESCRIPTION
It's debatable if we should just use `#[allow]` everywhere for the unused variables, as we did before, but figured more logging can always help