### PR TITLE
Improve temporaries handling

### DIFF
--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -197,6 +197,19 @@ impl Service {
                 .await
             {
                 Ok(res) => {
+                    // Try to delete temporary files
+                    let tmp_bases = self
+                        .state
+                        .storage
+                        .fetch_base_dirs_for_file(transfer_id, file.as_ref())
+                        .await;
+
+                    super::ws::server::remove_temp_files(
+                        &self.logger,
+                        transfer_id,
+                        tmp_bases.into_iter().map(|base| (base, &file)),
+                    );
+
                     res.events.rejected(false).await;
                     return Ok(());
                 }

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -702,7 +702,16 @@ impl FileXferTask {
         };
 
         let dst = match self.place_file_into_dest(state, logger, tmp_loc).await {
-            Ok(dst) => dst,
+            Ok(dst) => {
+                info!(
+                    logger,
+                    "Sucesfully placed file for id {} into destination: {tmp_loc:?} -> {:?}",
+                    self.file.id(),
+                    Hidden(&dst)
+                );
+
+                dst
+            }
             Err(err) => {
                 error!(
                     logger,

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -479,18 +479,21 @@ impl RunContext<'_> {
             anyhow::Ok(())
         };
 
-        if let Err(err) = task.await {
+        let result = task.await;
+        info!(self.logger, "Connection loop finished");
+
+        jobs.shutdown().await;
+
+        if let Err(err) = result {
             info!(
                 self.logger,
                 "WS connection broke for {}: {err:?}",
                 xfer.id()
             );
         } else {
-            debug!(self.logger, "Sucesfully finalizing transfer loop");
+            info!(self.logger, "Sucesfully finalizing transfer loop");
             handler.finalize_success().await;
         }
-
-        jobs.shutdown().await;
     }
 
     async fn init_manager(

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -5,6 +5,7 @@ mod v4;
 mod v5;
 
 use std::{
+    borrow::Borrow,
     collections::HashMap,
     fs,
     io::{self, Write},
@@ -682,6 +683,9 @@ impl FileXferTask {
                 }
             }
 
+            // Close the file handle
+            drop(out_file);
+
             if bytes_received > self.file.size() {
                 return Err(crate::Error::UnexpectedData);
             }
@@ -690,15 +694,22 @@ impl FileXferTask {
             Ok(())
         };
 
-        if let Err(err) = consume_file_chunks.await {
-            if let Err(ioerr) = fs::remove_file(&tmp_loc.0) {
-                error!(
-                    logger,
-                    "Could not remove temporary file {tmp_loc:?} after failed download: {}", ioerr
-                );
-            }
+        match consume_file_chunks.await {
+            Err(err @ crate::Error::Canceled) => return Err(err), // Do not remove temp file
+            // when cancelled. We might
+            // resume
+            Err(err) => {
+                if let Err(ioerr) = fs::remove_file(&tmp_loc.0) {
+                    error!(
+                        logger,
+                        "Could not remove temporary file {tmp_loc:?} after failed download: {}",
+                        ioerr
+                    );
+                }
 
-            return Err(err);
+                return Err(err);
+            }
+            _ => (),
         };
 
         let dst = match self.place_file_into_dest(state, logger, tmp_loc).await {
@@ -979,4 +990,35 @@ impl<'a> FileStreamCtx<'a> {
 
         Ok((job, events))
     }
+}
+
+pub fn remove_temp_files<P, I>(
+    logger: &Logger,
+    transfer_id: uuid::Uuid,
+    iter: impl IntoIterator<Item = (P, I)>,
+) where
+    P: Into<PathBuf>,
+    I: Borrow<FileId>,
+{
+    for (base, file_id) in iter.into_iter() {
+        let file_id = file_id.borrow();
+        let location = base.into().join(temp_file_name(transfer_id, file_id));
+        let location = Hidden(location);
+
+        debug!(logger, "Removing temporary file: {location:?}");
+        match std::fs::remove_file(&*location) {
+            Ok(()) => (),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+            Err(err) => {
+                error!(
+                    logger,
+                    "Failed to delete temporary file, id: {file_id}, path {location:?}, {err:?}",
+                );
+            }
+        }
+    }
+}
+
+fn temp_file_name(transfer_id: uuid::Uuid, file_id: &FileId) -> String {
+    format!("{}-{file_id}.dropdl-part", transfer_id.as_simple(),)
 }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -462,24 +462,14 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             .storage
             .fetch_temp_locations(self.xfer.id())
             .await;
-        for file in files {
-            let file_id = FileId::from(file.file_id);
 
-            let loc = PathBuf::from(file.base_path).join(temp_file_name(self.xfer.id(), &file_id));
-            let loc = Hidden(loc);
-
-            debug!(self.logger, "Removing temporary file: {loc:?}");
-            match std::fs::remove_file(&*loc) {
-                Ok(()) => (),
-                Err(err) if err.kind() == io::ErrorKind::NotFound => (),
-                Err(err) => {
-                    error!(
-                        self.logger,
-                        "Failed to delete temporary file, id: {file_id}, path {loc:?}, {err:?}",
-                    );
-                }
-            }
-        }
+        super::remove_temp_files(
+            self.logger,
+            self.xfer.id(),
+            files
+                .into_iter()
+                .map(|tmp| (tmp.base_path, FileId::from(tmp.file_id))),
+        );
     }
 }
 
@@ -530,7 +520,7 @@ impl handler::Downloader for Downloader {
 
         let tmp_location: Hidden<PathBuf> = Hidden(
             task.base_dir
-                .join(temp_file_name(task.xfer.id(), task.file.id())),
+                .join(super::temp_file_name(task.xfer.id(), task.file.id())),
         );
 
         // Check if we can resume the temporary file
@@ -622,8 +612,4 @@ impl handler::Downloader for Downloader {
 
         Ok(())
     }
-}
-
-fn temp_file_name(transfer_id: uuid::Uuid, file_id: &FileId) -> String {
-    format!("{}-{file_id}.dropdl-part", transfer_id.as_simple(),)
 }

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -469,11 +469,15 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             let loc = Hidden(loc);
 
             debug!(self.logger, "Removing temporary file: {loc:?}");
-            if let Err(err) = std::fs::remove_file(&*loc) {
-                debug!(
-                    self.logger,
-                    "Failed to delete temporary file: {loc:?}, {err}"
-                );
+            match std::fs::remove_file(&*loc) {
+                Ok(()) => (),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+                Err(err) => {
+                    error!(
+                        self.logger,
+                        "Failed to delete temporary file, id: {file_id}, path {loc:?}, {err:?}",
+                    );
+                }
             }
         }
     }

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -240,20 +240,37 @@ impl HandlerLoop<'_> {
     async fn on_reject(&mut self, file_id: FileId) {
         info!(self.logger, "On reject file {file_id}");
 
-        match self
+        let result = self
             .state
             .transfer_manager
             .incoming_terminal_recv(self.xfer.id(), &file_id, FileTerminalState::Rejected)
-            .await
-        {
+            .await;
+
+        // Stop the task right now regardless of the result
+        self.stop_task(&file_id, Status::FileRejected).await;
+
+        match result {
             Err(err) => {
                 error!(self.logger, "Failed to handler file rejection: {err}");
             }
-            Ok(Some(res)) => res.events.rejected(true).await,
+            Ok(Some(res)) => {
+                // Try to delete temporary files
+                let tmp_bases = self
+                    .state
+                    .storage
+                    .fetch_base_dirs_for_file(self.xfer.id(), file_id.as_ref())
+                    .await;
+
+                super::remove_temp_files(
+                    self.logger,
+                    self.xfer.id(),
+                    tmp_bases.into_iter().map(|base| (base, &file_id)),
+                );
+
+                res.events.rejected(true).await;
+            }
             Ok(None) => (),
         }
-
-        self.stop_task(&file_id, Status::FileRejected).await;
     }
 
     async fn stop_task(&mut self, file_id: &FileId, status: Status) {
@@ -398,6 +415,20 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         socket.send(Message::from(&msg)).await?;
 
         self.stop_task(&file_id, Status::FileRejected).await;
+
+        // Try to delete temporary file
+        let tmp_bases = self
+            .state
+            .storage
+            .fetch_base_dirs_for_file(self.xfer.id(), file_id.as_ref())
+            .await;
+
+        super::remove_temp_files(
+            self.logger,
+            self.xfer.id(),
+            tmp_bases.into_iter().map(|base| (base, &file_id)),
+        );
+
         Ok(())
     }
 
@@ -481,24 +512,14 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             .storage
             .fetch_temp_locations(self.xfer.id())
             .await;
-        for file in files {
-            let file_id = FileId::from(file.file_id);
 
-            let loc = PathBuf::from(file.base_path).join(temp_file_name(self.xfer.id(), &file_id));
-            let loc = Hidden(loc);
-
-            debug!(self.logger, "Removing temporary file: {loc:?}");
-            match std::fs::remove_file(&*loc) {
-                Ok(()) => (),
-                Err(err) if err.kind() == io::ErrorKind::NotFound => (),
-                Err(err) => {
-                    error!(
-                        self.logger,
-                        "Failed to delete temporary file, id: {file_id}, path {loc:?}, {err:?}",
-                    );
-                }
-            }
-        }
+        super::remove_temp_files(
+            self.logger,
+            self.xfer.id(),
+            files
+                .into_iter()
+                .map(|tmp| (tmp.base_path, FileId::from(tmp.file_id))),
+        );
     }
 }
 
@@ -549,7 +570,7 @@ impl handler::Downloader for Downloader {
 
         let tmp_location: Hidden<PathBuf> = Hidden(
             task.base_dir
-                .join(temp_file_name(task.xfer.id(), task.file.id())),
+                .join(super::temp_file_name(task.xfer.id(), task.file.id())),
         );
 
         // Check if we can resume the temporary file
@@ -655,8 +676,4 @@ impl handler::Request for (prot::TransferRequest, IpAddr, Arc<DropConfig>) {
         IncomingTransfer::new_with_uuid(peer, files, id, &config)
             .context("Failed to crate transfer")
     }
-}
-
-fn temp_file_name(transfer_id: uuid::Uuid, file_id: &FileId) -> String {
-    format!("{}-{file_id}.dropdl-part", transfer_id.as_simple(),)
 }

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -488,11 +488,15 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
             let loc = Hidden(loc);
 
             debug!(self.logger, "Removing temporary file: {loc:?}");
-            if let Err(err) = std::fs::remove_file(&*loc) {
-                debug!(
-                    self.logger,
-                    "Failed to delete temporary file: {loc:?}, {err}"
-                );
+            match std::fs::remove_file(&*loc) {
+                Ok(()) => (),
+                Err(err) if err.kind() == io::ErrorKind::NotFound => (),
+                Err(err) => {
+                    error!(
+                        self.logger,
+                        "Failed to delete temporary file, id: {file_id}, path {loc:?}, {err:?}",
+                    );
+                }
             }
         }
     }

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -8686,4 +8686,218 @@ scenarios = [
             ),
         },
     ),
+    Scenario(
+        "scenario46-1",
+        "Assert the temporary files are removed right after the rejection from the receiver",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_REN"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, True)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/45-1",
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    # wait for the initial progress indicating that we start from the beginning
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
+                    # make sure we have received something, so that we have non-empty tmp file
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id)),
+                    action.RejectTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileRejected(
+                            0,
+                            FILES["testfile-big"].id,
+                            False,
+                        )
+                    ),
+                    action.CompareTrees(Path("/tmp/received/45-1"), []),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario46-2",
+        "Assert the temporary files are removed right after the rejection from the sender",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_REN"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    # wait for the initial progress indicating that we start from the beginning
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
+                    # make sure we have received something, so that we have non-empty tmp file
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id)),
+                    action.RejectTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileRejected(0, FILES["testfile-big"].id, False)
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/45-1",
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.FinishFileRejected(
+                            0,
+                            FILES["testfile-big"].id,
+                            True,
+                        )
+                    ),
+                    action.CompareTrees(Path("/tmp/received/45-2"), []),
+                    action.CancelTransferRequest(0),
+                    action.ExpectCancel([0], False),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario46-3",
+        "Assert the temporary files are removed right after the rejection from the receiver and the sender is offline",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.WaitForAnotherPeer(),
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_REN"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    # wait for the initial progress indicating that we start from the beginning
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
+                    # make sure we have received something, so that we have non-empty tmp file
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id)),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.ConfigureNetwork(),
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id,
+                                    "testfile-big",
+                                    10485760,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/45-1",
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
+                    action.RejectTransferFile(0, FILES["testfile-big"].id),
+                    action.Wait(
+                        event.FinishFileRejected(
+                            0,
+                            FILES["testfile-big"].id,
+                            False,
+                        )
+                    ),
+                    action.CompareTrees(Path("/tmp/received/45-1"), []),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]


### PR DESCRIPTION
This PR contains the following changes:
* Ensure that all outstanding tasks are finished before removing temporaries while finalizing
* More logging added
* Try to remove temporaries right away when rejecting