### PR TITLE
Use WaitForAnotherPeer before issuing transfer requests

### DIFF
--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -5392,6 +5392,8 @@ scenarios = [
                             0, FILES["testfile-small"].id, Error.FILE_REJECTED
                         ),
                     ),
+                    # Canceling the transfer is actually emiting CLOSE frame which is not enqueued, meaning we need to give some time in order for the reject message to go back to the sender
+                    action.Sleep(4),
                     action.CancelTransferRequest([0]),
                     action.ExpectCancel([0], False),
                     action.NoEvent(),

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -677,12 +677,11 @@ scenarios = [
     ),
     Scenario(
         "scenario4-2",
-        "Send a request with one file, cancel the transfer from the sender side before downloading",
+        "Send a request with one file, cancel the transfer from the sender side, expect cancel message be synced",
         {
             "DROP_PEER_REN": ActionList(
                 [
                     action.Start("DROP_PEER_REN"),
-                    action.ConfigureNetwork(),
                     # Wait for another peer to appear
                     action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -696,7 +695,7 @@ scenarios = [
                             },
                         )
                     ),
-                    action.Sleep(1),
+                    action.Sleep(2),
                     action.CancelTransferRequest([0]),
                     action.Wait(event.FinishTransferCanceled(0, False)),
                     action.NoEvent(),
@@ -706,7 +705,6 @@ scenarios = [
             "DROP_PEER_STIMPY": ActionList(
                 [
                     action.Start("DROP_PEER_STIMPY"),
-                    action.ConfigureNetwork(),
                     action.Wait(
                         event.Receive(
                             0,

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3532,6 +3532,7 @@ scenarios = [
                             "/tmp/thisisaverylongfilenameusingonlylowercaselettersandnumbersanditcontainshugestringofnumbers01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234561234567891234567891234567890123456789012345678901234567890123456.txt"
                         ],
                     ),
+                    action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
                     action.NewTransfer(
                         "DROP_PEER_GEORGE",
                         [
@@ -8323,7 +8324,6 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # create a transfer so there would be transfer to be re-sent
                     action.Start("DROP_PEER_REN", "/tmp/data.base"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
@@ -8353,8 +8353,7 @@ scenarios = [
             ),
             "DROP_PEER_STIMPY": ActionList(
                 [
-                    # sleep some and enable libdrop instance
-                    action.Sleep(2),
+                    action.Sleep(4),
                     action.Start("DROP_PEER_STIMPY"),
                     action.NoEvent(),
                     action.Stop(),
@@ -8443,8 +8442,8 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1000ms"),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN", "/tmp/db/38.sqlite"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
                     action.Wait(
@@ -8954,10 +8953,11 @@ scenarios = [
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="10ms"),
                     action.Start("DROP_PEER_REN"),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
+                    action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
                     action.NewTransfer("DROP_PEER_GEORGE", ["/tmp/testfile-big"]),
                     action.WaitRacy(
                         [
@@ -9372,13 +9372,13 @@ scenarios = [
     ),
     Scenario(
         "scenario44-4",
-        "Initiate transfer to multiple peers that are online quickly and they will come and go online/offline multiple times",
+        "Initiate transfer to multiple peers that are online and they will come and go online/offline multiple times",
         {
             "DROP_PEER_REN": ActionList(
                 [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.ConfigureNetwork(latency="1ms"),
                     action.Start("DROP_PEER_REN"),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
@@ -9392,6 +9392,8 @@ scenarios = [
                             },
                         ),
                     ),
+                    # TODO: for such cases it would make sense to introduce "signals" for all of the peers to synchronize on
+                    action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
                     action.NewTransfer("DROP_PEER_GEORGE", ["/tmp/testfile-big"]),
                     action.Wait(
                         event.Queued(


### PR DESCRIPTION
New WaitForAnotherPeer() issues continuous connections towards the peer, this way we're pretty sure when the peer is online. Because peers come online at different times, we need to use it before every transfer issue to ensure the peer availability.

In hindsight - a sleep was OK but I want more determinism in the test runner