### PR TITLE
set_peer_state -> refresh_network

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+### v6.0.0
+### **Connection Clarity**
+---
+* New API `norddrop_network_refresh` to inform Libdrop that network configuration or peer
+availability has changed. This breaks the previous automated retry behavior where it automatically issued 
+requests and now waits for this API to be called to conserve the resources.
+
+---
+<br>
+
 ### v5.4.0
 ### **Unforeseen Moose**
 ---

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -36,4 +36,11 @@ pub const PING_INTERVAL: Duration = Duration::new(30, 0);
 pub const MAX_UPLOADS_IN_FLIGHT: usize = 4;
 pub const MAX_REQUESTS_PER_SEC: u32 = 50;
 pub const WS_SEND_TIMEOUT: Duration = Duration::new(20, 0);
-pub const ALIVE_CHECK_INTERVAL: Duration = Duration::new(60, 0);
+
+pub const RETRY_INTERVALS: [Duration; 5] = [
+    Duration::new(1, 0),
+    Duration::new(3, 0),
+    Duration::new(5, 0),
+    Duration::new(10, 0),
+    Duration::new(20, 0),
+];

--- a/drop-transfer/src/check.rs
+++ b/drop-transfer/src/check.rs
@@ -38,7 +38,6 @@ pub(crate) fn spawn(
                     break;
                 }
 
-                #[allow(clippy::let_underscore_must_use)]
                 let _ = refresh_trigger.changed().await;
             }
         };

--- a/drop-transfer/src/protocol/v1.rs
+++ b/drop-transfer/src/protocol/v1.rs
@@ -170,7 +170,7 @@ mod tests {
     fn test_json<T: Serialize + DeserializeOwned + Eq>(message: T, expected: &str) {
         let json_msg = serde_json::to_value(&message).expect("Failed to serialize");
         let json_exp: serde_json::Value =
-            serde_json::from_str(expected).expect("Failed to convert expected josn to value");
+            serde_json::from_str(expected).expect("Failed to convert expected json to value");
         assert_eq!(json_msg, json_exp);
 
         let deserialized: T = serde_json::from_str(expected).expect("Failed to serialize");

--- a/drop-transfer/src/protocol/v4.rs
+++ b/drop-transfer/src/protocol/v4.rs
@@ -66,7 +66,7 @@ mod tests {
     fn test_json<T: Serialize + DeserializeOwned + Eq>(message: T, expected: &str) {
         let json_msg = serde_json::to_value(&message).expect("Failed to serialize");
         let json_exp: serde_json::Value =
-            serde_json::from_str(expected).expect("Failed to convert expected josn to value");
+            serde_json::from_str(expected).expect("Failed to convert expected json to value");
         assert_eq!(json_msg, json_exp);
 
         let deserialized: T = serde_json::from_str(expected).expect("Failed to serialize");

--- a/drop-transfer/src/protocol/v5.rs
+++ b/drop-transfer/src/protocol/v5.rs
@@ -238,7 +238,7 @@ mod tests {
     fn test_json<T: Serialize + DeserializeOwned + Eq>(message: T, expected: &str) {
         let json_msg = serde_json::to_value(&message).expect("Failed to serialize");
         let json_exp: serde_json::Value =
-            serde_json::from_str(expected).expect("Failed to convert expected josn to value");
+            serde_json::from_str(expected).expect("Failed to convert expected json to value");
         assert_eq!(json_msg, json_exp);
 
         let deserialized: T = serde_json::from_str(expected).expect("Failed to serialize");

--- a/drop-transfer/src/ws/client/mod.rs
+++ b/drop-transfer/src/ws/client/mod.rs
@@ -93,7 +93,6 @@ pub(crate) fn spawn(
                     break;
                 }
 
-                #[allow(clippy::let_underscore_must_use)]
                 let _ = refresh_trigger.changed().await;
             }
         };

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -83,7 +83,7 @@ impl<'a, const PING: bool> handler::HandlerInit for HandlerInit<'a, PING> {
             .await
             .context("Failed to receive transfer request")?;
 
-        let msg = msg.to_str().ok().context("Expected JOSN message")?;
+        let msg = msg.to_str().ok().context("Expected JSON message")?;
 
         let req = serde_json::from_str(msg).context("Failed to deserialize transfer request")?;
 

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -87,7 +87,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             .await
             .context("Failed to receive transfer request")?;
 
-        let msg = msg.to_str().ok().context("Expected JOSN message")?;
+        let msg = msg.to_str().ok().context("Expected JSON message")?;
         debug!(self.logger, "Request received:\n\t{msg}");
 
         let req = serde_json::from_str(msg).context("Failed to deserialize transfer request")?;

--- a/drop-transfer/src/ws/server/v5.rs
+++ b/drop-transfer/src/ws/server/v5.rs
@@ -87,7 +87,10 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             .await
             .context("Failed to receive transfer request")?;
 
-        let msg = msg.to_str().ok().context("Expected JOSN message")?;
+        // print msg as ascii
+        debug!(self.logger, "************** msg:\n\t{msg:?}");
+
+        let msg = msg.to_str().ok().context("Expected JSON message")?;
         debug!(self.logger, "Request received:\n\t{msg}");
 
         let req = serde_json::from_str(msg).context("Failed to deserialize transfer request")?;

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/NordDrop.java
@@ -80,8 +80,8 @@ public class NordDrop {
     return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_removeTransferFile(swigCPtr, this, txid, fid));
   }
 
-  public NorddropResult setPeerState(String peer, int isOnline) {
-    return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_setPeerState(swigCPtr, this, peer, isOnline));
+  public NorddropResult networkRefresh() {
+    return NorddropResult.swigToEnum(libnorddropJNI.NordDrop_networkRefresh(swigCPtr, this));
   }
 
   public String getTransfersSince(long sinceTimestamp) {

--- a/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
+++ b/norddrop/ffi/bindings/android/java/com/nordsec/norddrop/libnorddropJNI.java
@@ -39,7 +39,7 @@ public class libnorddropJNI {
   public final static native int NordDrop_purgeTransfers(long jarg1, NordDrop jarg1_, String jarg2);
   public final static native int NordDrop_purgeTransfersUntil(long jarg1, NordDrop jarg1_, long jarg2);
   public final static native int NordDrop_removeTransferFile(long jarg1, NordDrop jarg1_, String jarg2, String jarg3);
-  public final static native int NordDrop_setPeerState(long jarg1, NordDrop jarg1_, String jarg2, int jarg3);
+  public final static native int NordDrop_networkRefresh(long jarg1, NordDrop jarg1_);
   public final static native String NordDrop_getTransfersSince(long jarg1, NordDrop jarg1_, long jarg2);
   public final static native String NordDrop_version();
 }

--- a/norddrop/ffi/bindings/android/wrap/java_wrap.c
+++ b/norddrop/ffi/bindings/android/wrap/java_wrap.c
@@ -1063,26 +1063,17 @@ SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1remov
 }
 
 
-SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1setPeerState(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_, jstring jarg2, jint jarg3) {
+SWIGEXPORT jint JNICALL Java_com_nordsec_norddrop_libnorddropJNI_NordDrop_1networkRefresh(JNIEnv *jenv, jclass jcls, jlong jarg1, jobject jarg1_) {
   jint jresult = 0 ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
   enum norddrop_result result;
   
   (void)jenv;
   (void)jcls;
   (void)jarg1_;
   arg1 = *(struct norddrop **)&jarg1; 
-  arg2 = 0;
-  if (jarg2) {
-    arg2 = (char *)(*jenv)->GetStringUTFChars(jenv, jarg2, 0);
-    if (!arg2) return 0;
-  }
-  arg3 = (int)jarg3; 
-  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  result = (enum norddrop_result)norddrop_network_refresh(arg1);
   jresult = (jint)result; 
-  if (arg2) (*jenv)->ReleaseStringUTFChars(jenv, jarg2, (const char *)arg2);
   return jresult;
 }
 

--- a/norddrop/ffi/bindings/linux/go/norddropgo.go
+++ b/norddrop/ffi/bindings/linux/go/norddropgo.go
@@ -54,70 +54,69 @@ typedef long long swig_type_22;
 typedef _gostring_ swig_type_23;
 typedef _gostring_ swig_type_24;
 typedef _gostring_ swig_type_25;
-typedef _gostring_ swig_type_26;
-typedef long long swig_type_27;
-typedef _gostring_ swig_type_28;
-extern void _wrap_Swig_free_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern uintptr_t _wrap_Swig_malloc_norddropgo_a604716e4848fd68(swig_intgo arg1);
-extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68(void);
-extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68(void);
-extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_1 arg2);
-extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68(void);
-extern void _wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_3 arg2);
-extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68(void);
-extern void _wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_5 arg2);
-extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68(void);
-extern void _wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(uintptr_t arg1, uintptr_t arg2);
-extern uintptr_t _wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern void _wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_7 arg2);
-extern swig_type_8 _wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern uintptr_t _wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68(void);
-extern void _wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(uintptr_t arg1);
+typedef long long swig_type_26;
+typedef _gostring_ swig_type_27;
+extern void _wrap_Swig_free_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern uintptr_t _wrap_Swig_malloc_norddropgo_6fe7bd86fa076afe(swig_intgo arg1);
+extern swig_intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPLOGERROR_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPLOGWARNING_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPLOGINFO_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPLOGDEBUG_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPLOGTRACE_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESOK_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESERROR_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESBADINPUT_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_6fe7bd86fa076afe(void);
+extern swig_intgo _wrap_NORDDROPRESDBERROR_norddropgo_6fe7bd86fa076afe(void);
+extern void _wrap_NorddropEventCb_Ctx_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropEventCb_Ctx_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropEventCb_Cb_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_1 arg2);
+extern swig_type_2 _wrap_NorddropEventCb_Cb_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropEventCb_norddropgo_6fe7bd86fa076afe(void);
+extern void _wrap_delete_NorddropEventCb_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropLoggerCb_Ctx_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropLoggerCb_Cb_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_3 arg2);
+extern swig_type_4 _wrap_NorddropLoggerCb_Cb_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe(void);
+extern void _wrap_delete_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropPubkeyCb_Ctx_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_5 arg2);
+extern swig_type_6 _wrap_NorddropPubkeyCb_Cb_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe(void);
+extern void _wrap_delete_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropFdCb_Ctx_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, uintptr_t arg2);
+extern uintptr_t _wrap_NorddropFdCb_Ctx_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern void _wrap_NorddropFdCb_Cb_set_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_7 arg2);
+extern swig_type_8 _wrap_NorddropFdCb_Cb_get_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern uintptr_t _wrap_new_NorddropFdCb_norddropgo_6fe7bd86fa076afe(void);
+extern void _wrap_delete_NorddropFdCb_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
 
 #include <string.h>
 
-extern uintptr_t _wrap_new_Norddrop_norddropgo_a604716e4848fd68(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_9 arg5);
-extern void _wrap_delete_Norddrop_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_Start_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_10 arg2, swig_type_11 arg3);
-extern swig_intgo _wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(uintptr_t arg1);
-extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_12 arg2);
-extern swig_intgo _wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3);
-extern swig_intgo _wrap_Norddrop_Download_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
-extern swig_type_18 _wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_19 arg2, swig_type_20 arg3);
-extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_21 arg2);
-extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_22 arg2);
-extern swig_intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_23 arg2, swig_type_24 arg3);
-extern swig_intgo _wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_25 arg2, swig_intgo arg3);
-extern swig_type_26 _wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(uintptr_t arg1, swig_type_27 arg2);
-extern swig_type_28 _wrap_Norddrop_Version_norddropgo_a604716e4848fd68(void);
+extern uintptr_t _wrap_new_Norddrop_norddropgo_6fe7bd86fa076afe(norddrop_event_cb arg1, swig_intgo arg2, norddrop_logger_cb arg3, norddrop_pubkey_cb arg4, swig_type_9 arg5);
+extern void _wrap_delete_Norddrop_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_Start_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_10 arg2, swig_type_11 arg3);
+extern swig_intgo _wrap_Norddrop_Stop_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern swig_intgo _wrap_Norddrop_CancelTransfer_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_12 arg2);
+extern swig_intgo _wrap_Norddrop_RejectFile_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_13 arg2, swig_type_14 arg3);
+extern swig_intgo _wrap_Norddrop_Download_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_15 arg2, swig_type_16 arg3, swig_type_17 arg4);
+extern swig_type_18 _wrap_Norddrop_NewTransfer_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_19 arg2, swig_type_20 arg3);
+extern swig_intgo _wrap_Norddrop_PurgeTransfers_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_21 arg2);
+extern swig_intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_22 arg2);
+extern swig_intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_23 arg2, swig_type_24 arg3);
+extern swig_intgo _wrap_Norddrop_NetworkRefresh_norddropgo_6fe7bd86fa076afe(uintptr_t arg1);
+extern swig_type_25 _wrap_Norddrop_GetTransfersSince_norddropgo_6fe7bd86fa076afe(uintptr_t arg1, swig_type_26 arg2);
+extern swig_type_27 _wrap_Norddrop_Version_norddropgo_6fe7bd86fa076afe(void);
 #undef intgo
 */
 import "C"
@@ -152,55 +151,55 @@ func swigCopyString(s string) string {
 
 func Swig_free(arg1 uintptr) {
 	_swig_i_0 := arg1
-	C._wrap_Swig_free_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_Swig_free_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 func Swig_malloc(arg1 int) (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_a604716e4848fd68(C.swig_intgo(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_Swig_malloc_norddropgo_6fe7bd86fa076afe(C.swig_intgo(_swig_i_0)))
 	return swig_r
 }
 
 type Enum_SS_norddrop_log_level int
 func _swig_getNORDDROPLOGCRITICAL() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGCRITICAL_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPLOGCRITICAL Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGCRITICAL()
 func _swig_getNORDDROPLOGERROR() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGERROR_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPLOGERROR Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGERROR()
 func _swig_getNORDDROPLOGWARNING() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGWARNING_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPLOGWARNING Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGWARNING()
 func _swig_getNORDDROPLOGINFO() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGINFO_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPLOGINFO Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGINFO()
 func _swig_getNORDDROPLOGDEBUG() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGDEBUG_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPLOGDEBUG Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGDEBUG()
 func _swig_getNORDDROPLOGTRACE() (_swig_ret Enum_SS_norddrop_log_level) {
 	var swig_r Enum_SS_norddrop_log_level
-	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_log_level)(C._wrap_NORDDROPLOGTRACE_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
@@ -208,84 +207,84 @@ var NORDDROPLOGTRACE Enum_SS_norddrop_log_level = _swig_getNORDDROPLOGTRACE()
 type Enum_SS_norddrop_result int
 func _swig_getNORDDROPRESOK() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESOK_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESOK Enum_SS_norddrop_result = _swig_getNORDDROPRESOK()
 func _swig_getNORDDROPRESERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESERROR_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESERROR Enum_SS_norddrop_result = _swig_getNORDDROPRESERROR()
 func _swig_getNORDDROPRESINVALIDSTRING() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDSTRING_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDSTRING Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDSTRING()
 func _swig_getNORDDROPRESBADINPUT() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESBADINPUT_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESBADINPUT Enum_SS_norddrop_result = _swig_getNORDDROPRESBADINPUT()
 func _swig_getNORDDROPRESJSONPARSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESJSONPARSE_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESJSONPARSE Enum_SS_norddrop_result = _swig_getNORDDROPRESJSONPARSE()
 func _swig_getNORDDROPRESTRANSFERCREATE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESTRANSFERCREATE_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESTRANSFERCREATE Enum_SS_norddrop_result = _swig_getNORDDROPRESTRANSFERCREATE()
 func _swig_getNORDDROPRESNOTSTARTED() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESNOTSTARTED_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESNOTSTARTED Enum_SS_norddrop_result = _swig_getNORDDROPRESNOTSTARTED()
 func _swig_getNORDDROPRESADDRINUSE() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESADDRINUSE_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESADDRINUSE Enum_SS_norddrop_result = _swig_getNORDDROPRESADDRINUSE()
 func _swig_getNORDDROPRESINSTANCESTART() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTART_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTART Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTART()
 func _swig_getNORDDROPRESINSTANCESTOP() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINSTANCESTOP_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESINSTANCESTOP Enum_SS_norddrop_result = _swig_getNORDDROPRESINSTANCESTOP()
 func _swig_getNORDDROPRESINVALIDPRIVKEY() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
 var NORDDROPRESINVALIDPRIVKEY Enum_SS_norddrop_result = _swig_getNORDDROPRESINVALIDPRIVKEY()
 func _swig_getNORDDROPRESDBERROR() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68())
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_NORDDROPRESDBERROR_norddropgo_6fe7bd86fa076afe())
 	return swig_r
 }
 
@@ -302,38 +301,38 @@ func (p SwigcptrNorddropEventCb) SwigIsNorddropEventCb() {
 func (arg1 SwigcptrNorddropEventCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropEventCb_Ctx_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropEventCb_Ctx_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropEventCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
+	C._wrap_NorddropEventCb_Cb_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_1(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropEventCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropEventCb_Cb_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropEventCb() (_swig_ret NorddropEventCb) {
 	var swig_r NorddropEventCb
-	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68()))
+	swig_r = (NorddropEventCb)(SwigcptrNorddropEventCb(C._wrap_new_NorddropEventCb_norddropgo_6fe7bd86fa076afe()))
 	return swig_r
 }
 
 func DeleteNorddropEventCb(arg1 NorddropEventCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropEventCb_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropEventCb interface {
@@ -357,38 +356,38 @@ func (p SwigcptrNorddropLoggerCb) SwigIsNorddropLoggerCb() {
 func (arg1 SwigcptrNorddropLoggerCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Ctx_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropLoggerCb_Ctx_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
+	C._wrap_NorddropLoggerCb_Cb_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_3(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropLoggerCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropLoggerCb_Cb_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropLoggerCb() (_swig_ret NorddropLoggerCb) {
 	var swig_r NorddropLoggerCb
-	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68()))
+	swig_r = (NorddropLoggerCb)(SwigcptrNorddropLoggerCb(C._wrap_new_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe()))
 	return swig_r
 }
 
 func DeleteNorddropLoggerCb(arg1 NorddropLoggerCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropLoggerCb interface {
@@ -412,38 +411,38 @@ func (p SwigcptrNorddropPubkeyCb) SwigIsNorddropPubkeyCb() {
 func (arg1 SwigcptrNorddropPubkeyCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Ctx_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropPubkeyCb_Ctx_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
+	C._wrap_NorddropPubkeyCb_Cb_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_5(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropPubkeyCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropPubkeyCb_Cb_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropPubkeyCb() (_swig_ret NorddropPubkeyCb) {
 	var swig_r NorddropPubkeyCb
-	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68()))
+	swig_r = (NorddropPubkeyCb)(SwigcptrNorddropPubkeyCb(C._wrap_new_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe()))
 	return swig_r
 }
 
 func DeleteNorddropPubkeyCb(arg1 NorddropPubkeyCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropPubkeyCb interface {
@@ -467,38 +466,38 @@ func (p SwigcptrNorddropFdCb) SwigIsNorddropFdCb() {
 func (arg1 SwigcptrNorddropFdCb) SetCtx(arg2 uintptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
+	C._wrap_NorddropFdCb_Ctx_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.uintptr_t(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropFdCb) GetCtx() (_swig_ret uintptr) {
 	var swig_r uintptr
 	_swig_i_0 := arg1
-	swig_r = (uintptr)(C._wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (uintptr)(C._wrap_NorddropFdCb_Ctx_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func (arg1 SwigcptrNorddropFdCb) SetCb(arg2 _swig_fnptr) {
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	C._wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_7(_swig_i_1))
+	C._wrap_NorddropFdCb_Cb_set_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_7(_swig_i_1))
 }
 
 func (arg1 SwigcptrNorddropFdCb) GetCb() (_swig_ret _swig_fnptr) {
 	var swig_r _swig_fnptr
 	_swig_i_0 := arg1
-	swig_r = (_swig_fnptr)(C._wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (_swig_fnptr)(C._wrap_NorddropFdCb_Cb_get_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
 func NewNorddropFdCb() (_swig_ret NorddropFdCb) {
 	var swig_r NorddropFdCb
-	swig_r = (NorddropFdCb)(SwigcptrNorddropFdCb(C._wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68()))
+	swig_r = (NorddropFdCb)(SwigcptrNorddropFdCb(C._wrap_new_NorddropFdCb_norddropgo_6fe7bd86fa076afe()))
 	return swig_r
 }
 
 func DeleteNorddropFdCb(arg1 NorddropFdCb) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_NorddropFdCb_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 type NorddropFdCb interface {
@@ -628,7 +627,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
         _swig_i_3 = cb
 }
 	_swig_i_4 := arg5
-	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_a604716e4848fd68(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_4)))))
+	swig_r = (Norddrop)(SwigcptrNorddrop(C._wrap_new_Norddrop_norddropgo_6fe7bd86fa076afe(C.norddrop_event_cb(_swig_i_0), C.swig_intgo(_swig_i_1), C.norddrop_logger_cb(_swig_i_2), C.norddrop_pubkey_cb(_swig_i_3), *(*C.swig_type_9)(unsafe.Pointer(&_swig_i_4)))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg5
 	}
@@ -645,7 +644,7 @@ func NewNorddrop(arg1 func(string), arg2 Enum_SS_norddrop_log_level, arg3 func(i
 
 func DeleteNorddrop(arg1 Norddrop) {
 	_swig_i_0 := arg1.Swigcptr()
-	C._wrap_delete_Norddrop_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0))
+	C._wrap_delete_Norddrop_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0))
 }
 
 func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result) {
@@ -653,7 +652,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Start_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_10)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_11)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -666,7 +665,7 @@ func (arg1 SwigcptrNorddrop) Start(arg2 string, arg3 string) (_swig_ret Enum_SS_
 func (arg1 SwigcptrNorddrop) Stop() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Stop_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -674,7 +673,7 @@ func (arg1 SwigcptrNorddrop) CancelTransfer(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_CancelTransfer_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_12)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -686,7 +685,7 @@ func (arg1 SwigcptrNorddrop) RejectFile(arg2 string, arg3 string) (_swig_ret Enu
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RejectFile_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_13)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_14)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -702,7 +701,7 @@ func (arg1 SwigcptrNorddrop) Download(arg2 string, arg3 string, arg4 string) (_s
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
 	_swig_i_3 := arg4
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_Download_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_15)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_16)(unsafe.Pointer(&_swig_i_2)), *(*C.swig_type_17)(unsafe.Pointer(&_swig_i_3))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -720,7 +719,7 @@ func (arg1 SwigcptrNorddrop) NewTransfer(arg2 string, arg3 string) (_swig_ret st
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_2)))
+	swig_r_p := C._wrap_Norddrop_NewTransfer_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_19)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_20)(unsafe.Pointer(&_swig_i_2)))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
@@ -737,7 +736,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfers(arg2 string) (_swig_ret Enum_SS_nord
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_1))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfers_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_21)(unsafe.Pointer(&_swig_i_1))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -748,7 +747,7 @@ func (arg1 SwigcptrNorddrop) PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1)))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_PurgeTransfersUntil_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_22(_swig_i_1)))
 	return swig_r
 }
 
@@ -757,7 +756,7 @@ func (arg1 SwigcptrNorddrop) RemoveTransferFile(arg2 string, arg3 string) (_swig
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
 	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_2))))
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_RemoveTransferFile_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), *(*C.swig_type_23)(unsafe.Pointer(&_swig_i_1)), *(*C.swig_type_24)(unsafe.Pointer(&_swig_i_2))))
 	if Swig_escape_always_false {
 		Swig_escape_val = arg2
 	}
@@ -767,15 +766,10 @@ func (arg1 SwigcptrNorddrop) RemoveTransferFile(arg2 string, arg3 string) (_swig
 	return swig_r
 }
 
-func (arg1 SwigcptrNorddrop) SetPeerState(arg2 string, arg3 int) (_swig_ret Enum_SS_norddrop_result) {
+func (arg1 SwigcptrNorddrop) NetworkRefresh() (_swig_ret Enum_SS_norddrop_result) {
 	var swig_r Enum_SS_norddrop_result
 	_swig_i_0 := arg1
-	_swig_i_1 := arg2
-	_swig_i_2 := arg3
-	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), *(*C.swig_type_25)(unsafe.Pointer(&_swig_i_1)), C.swig_intgo(_swig_i_2)))
-	if Swig_escape_always_false {
-		Swig_escape_val = arg2
-	}
+	swig_r = (Enum_SS_norddrop_result)(C._wrap_Norddrop_NetworkRefresh_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0)))
 	return swig_r
 }
 
@@ -783,7 +777,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 	var swig_r string
 	_swig_i_0 := arg1
 	_swig_i_1 := arg2
-	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(C.uintptr_t(_swig_i_0), C.swig_type_27(_swig_i_1))
+	swig_r_p := C._wrap_Norddrop_GetTransfersSince_norddropgo_6fe7bd86fa076afe(C.uintptr_t(_swig_i_0), C.swig_type_26(_swig_i_1))
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -792,7 +786,7 @@ func (arg1 SwigcptrNorddrop) GetTransfersSince(arg2 int64) (_swig_ret string) {
 
 func NorddropVersion() (_swig_ret string) {
 	var swig_r string
-	swig_r_p := C._wrap_Norddrop_Version_norddropgo_a604716e4848fd68()
+	swig_r_p := C._wrap_Norddrop_Version_norddropgo_6fe7bd86fa076afe()
 	swig_r = *(*string)(unsafe.Pointer(&swig_r_p))
 	var swig_r_1 string
  swig_r_1 = swigCopyString(swig_r) 
@@ -811,7 +805,7 @@ type Norddrop interface {
 	PurgeTransfers(arg2 string) (_swig_ret Enum_SS_norddrop_result)
 	PurgeTransfersUntil(arg2 int64) (_swig_ret Enum_SS_norddrop_result)
 	RemoveTransferFile(arg2 string, arg3 string) (_swig_ret Enum_SS_norddrop_result)
-	SetPeerState(arg2 string, arg3 int) (_swig_ret Enum_SS_norddrop_result)
+	NetworkRefresh() (_swig_ret Enum_SS_norddrop_result)
 	GetTransfersSince(arg2 int64) (_swig_ret string)
 }
 

--- a/norddrop/ffi/bindings/linux/wrap/go_wrap.c
+++ b/norddrop/ffi/bindings/linux/wrap/go_wrap.c
@@ -242,7 +242,7 @@ SWIGINTERN void delete_norddrop(struct norddrop *self){
 extern "C" {
 #endif
 
-void _wrap_Swig_free_norddropgo_a604716e4848fd68(void *_swig_go_0) {
+void _wrap_Swig_free_norddropgo_6fe7bd86fa076afe(void *_swig_go_0) {
   void *arg1 = (void *) 0 ;
   
   arg1 = *(void **)&_swig_go_0; 
@@ -252,7 +252,7 @@ void _wrap_Swig_free_norddropgo_a604716e4848fd68(void *_swig_go_0) {
 }
 
 
-void *_wrap_Swig_malloc_norddropgo_a604716e4848fd68(intgo _swig_go_0) {
+void *_wrap_Swig_malloc_norddropgo_6fe7bd86fa076afe(intgo _swig_go_0) {
   int arg1 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -265,7 +265,7 @@ void *_wrap_Swig_malloc_norddropgo_a604716e4848fd68(intgo _swig_go_0) {
 }
 
 
-intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -277,7 +277,7 @@ intgo _wrap_NORDDROPLOGCRITICAL_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGERROR_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -289,7 +289,7 @@ intgo _wrap_NORDDROPLOGERROR_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGWARNING_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -301,7 +301,7 @@ intgo _wrap_NORDDROPLOGWARNING_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGINFO_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -313,7 +313,7 @@ intgo _wrap_NORDDROPLOGINFO_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGDEBUG_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -325,7 +325,7 @@ intgo _wrap_NORDDROPLOGDEBUG_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPLOGTRACE_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_log_level result;
   intgo _swig_go_result;
   
@@ -337,7 +337,7 @@ intgo _wrap_NORDDROPLOGTRACE_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESOK_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -349,7 +349,7 @@ intgo _wrap_NORDDROPRESOK_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESERROR_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -361,7 +361,7 @@ intgo _wrap_NORDDROPRESERROR_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -373,7 +373,7 @@ intgo _wrap_NORDDROPRESINVALIDSTRING_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESBADINPUT_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -385,7 +385,7 @@ intgo _wrap_NORDDROPRESBADINPUT_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -397,7 +397,7 @@ intgo _wrap_NORDDROPRESJSONPARSE_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -409,7 +409,7 @@ intgo _wrap_NORDDROPRESTRANSFERCREATE_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -421,7 +421,7 @@ intgo _wrap_NORDDROPRESNOTSTARTED_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -433,7 +433,7 @@ intgo _wrap_NORDDROPRESADDRINUSE_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -445,7 +445,7 @@ intgo _wrap_NORDDROPRESINSTANCESTART_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -457,7 +457,7 @@ intgo _wrap_NORDDROPRESINSTANCESTOP_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -469,7 +469,7 @@ intgo _wrap_NORDDROPRESINVALIDPRIVKEY_norddropgo_a604716e4848fd68() {
 }
 
 
-intgo _wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68() {
+intgo _wrap_NORDDROPRESDBERROR_norddropgo_6fe7bd86fa076afe() {
   enum norddrop_result result;
   intgo _swig_go_result;
   
@@ -481,7 +481,7 @@ intgo _wrap_NORDDROPRESDBERROR_norddropgo_a604716e4848fd68() {
 }
 
 
-void _wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropEventCb_Ctx_set_norddropgo_6fe7bd86fa076afe(struct norddrop_event_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -493,7 +493,7 @@ void _wrap_NorddropEventCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_e
 }
 
 
-void *_wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
+void *_wrap_NorddropEventCb_Ctx_get_norddropgo_6fe7bd86fa076afe(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -506,7 +506,7 @@ void *_wrap_NorddropEventCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_
 }
 
 
-void _wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropEventCb_Cb_set_norddropgo_6fe7bd86fa076afe(struct norddrop_event_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn arg2 = (norddrop_event_fn) 0 ;
   
@@ -518,7 +518,7 @@ void _wrap_NorddropEventCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_ev
 }
 
 
-void* _wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
+void* _wrap_NorddropEventCb_Cb_get_norddropgo_6fe7bd86fa076afe(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   norddrop_event_fn result;
   void* _swig_go_result;
@@ -531,7 +531,7 @@ void* _wrap_NorddropEventCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_e
 }
 
 
-struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68() {
+struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_6fe7bd86fa076afe() {
   struct norddrop_event_cb *result = 0 ;
   struct norddrop_event_cb *_swig_go_result;
   
@@ -542,7 +542,7 @@ struct norddrop_event_cb *_wrap_new_NorddropEventCb_norddropgo_a604716e4848fd68(
 }
 
 
-void _wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(struct norddrop_event_cb *_swig_go_0) {
+void _wrap_delete_NorddropEventCb_norddropgo_6fe7bd86fa076afe(struct norddrop_event_cb *_swig_go_0) {
   struct norddrop_event_cb *arg1 = (struct norddrop_event_cb *) 0 ;
   
   arg1 = *(struct norddrop_event_cb **)&_swig_go_0; 
@@ -552,7 +552,7 @@ void _wrap_delete_NorddropEventCb_norddropgo_a604716e4848fd68(struct norddrop_ev
 }
 
 
-void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_6fe7bd86fa076afe(struct norddrop_logger_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -564,7 +564,7 @@ void _wrap_NorddropLoggerCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_
 }
 
 
-void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
+void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_6fe7bd86fa076afe(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -577,7 +577,7 @@ void *_wrap_NorddropLoggerCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop
 }
 
 
-void _wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropLoggerCb_Cb_set_norddropgo_6fe7bd86fa076afe(struct norddrop_logger_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn arg2 = (norddrop_logger_fn) 0 ;
   
@@ -589,7 +589,7 @@ void _wrap_NorddropLoggerCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_l
 }
 
 
-void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
+void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_6fe7bd86fa076afe(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   norddrop_logger_fn result;
   void* _swig_go_result;
@@ -602,7 +602,7 @@ void* _wrap_NorddropLoggerCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_
 }
 
 
-struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd68() {
+struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe() {
   struct norddrop_logger_cb *result = 0 ;
   struct norddrop_logger_cb *_swig_go_result;
   
@@ -613,7 +613,7 @@ struct norddrop_logger_cb *_wrap_new_NorddropLoggerCb_norddropgo_a604716e4848fd6
 }
 
 
-void _wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(struct norddrop_logger_cb *_swig_go_0) {
+void _wrap_delete_NorddropLoggerCb_norddropgo_6fe7bd86fa076afe(struct norddrop_logger_cb *_swig_go_0) {
   struct norddrop_logger_cb *arg1 = (struct norddrop_logger_cb *) 0 ;
   
   arg1 = *(struct norddrop_logger_cb **)&_swig_go_0; 
@@ -623,7 +623,7 @@ void _wrap_delete_NorddropLoggerCb_norddropgo_a604716e4848fd68(struct norddrop_l
 }
 
 
-void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_6fe7bd86fa076afe(struct norddrop_pubkey_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -635,7 +635,7 @@ void _wrap_NorddropPubkeyCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_
 }
 
 
-void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
+void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_6fe7bd86fa076afe(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -648,7 +648,7 @@ void *_wrap_NorddropPubkeyCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop
 }
 
 
-void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_6fe7bd86fa076afe(struct norddrop_pubkey_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn arg2 = (norddrop_pubkey_fn) 0 ;
   
@@ -660,7 +660,7 @@ void _wrap_NorddropPubkeyCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_p
 }
 
 
-void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
+void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_6fe7bd86fa076afe(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   norddrop_pubkey_fn result;
   void* _swig_go_result;
@@ -673,7 +673,7 @@ void* _wrap_NorddropPubkeyCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_
 }
 
 
-struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd68() {
+struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe() {
   struct norddrop_pubkey_cb *result = 0 ;
   struct norddrop_pubkey_cb *_swig_go_result;
   
@@ -684,7 +684,7 @@ struct norddrop_pubkey_cb *_wrap_new_NorddropPubkeyCb_norddropgo_a604716e4848fd6
 }
 
 
-void _wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(struct norddrop_pubkey_cb *_swig_go_0) {
+void _wrap_delete_NorddropPubkeyCb_norddropgo_6fe7bd86fa076afe(struct norddrop_pubkey_cb *_swig_go_0) {
   struct norddrop_pubkey_cb *arg1 = (struct norddrop_pubkey_cb *) 0 ;
   
   arg1 = *(struct norddrop_pubkey_cb **)&_swig_go_0; 
@@ -694,7 +694,7 @@ void _wrap_delete_NorddropPubkeyCb_norddropgo_a604716e4848fd68(struct norddrop_p
 }
 
 
-void _wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0, void *_swig_go_1) {
+void _wrap_NorddropFdCb_Ctx_set_norddropgo_6fe7bd86fa076afe(struct norddrop_fd_cb *_swig_go_0, void *_swig_go_1) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   void *arg2 = (void *) 0 ;
   
@@ -706,7 +706,7 @@ void _wrap_NorddropFdCb_Ctx_set_norddropgo_a604716e4848fd68(struct norddrop_fd_c
 }
 
 
-void *_wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
+void *_wrap_NorddropFdCb_Ctx_get_norddropgo_6fe7bd86fa076afe(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   void *result = 0 ;
   void *_swig_go_result;
@@ -719,7 +719,7 @@ void *_wrap_NorddropFdCb_Ctx_get_norddropgo_a604716e4848fd68(struct norddrop_fd_
 }
 
 
-void _wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0, void* _swig_go_1) {
+void _wrap_NorddropFdCb_Cb_set_norddropgo_6fe7bd86fa076afe(struct norddrop_fd_cb *_swig_go_0, void* _swig_go_1) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   norddrop_fd_fn arg2 = (norddrop_fd_fn) 0 ;
   
@@ -731,7 +731,7 @@ void _wrap_NorddropFdCb_Cb_set_norddropgo_a604716e4848fd68(struct norddrop_fd_cb
 }
 
 
-void* _wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
+void* _wrap_NorddropFdCb_Cb_get_norddropgo_6fe7bd86fa076afe(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   norddrop_fd_fn result;
   void* _swig_go_result;
@@ -744,7 +744,7 @@ void* _wrap_NorddropFdCb_Cb_get_norddropgo_a604716e4848fd68(struct norddrop_fd_c
 }
 
 
-struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68() {
+struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_6fe7bd86fa076afe() {
   struct norddrop_fd_cb *result = 0 ;
   struct norddrop_fd_cb *_swig_go_result;
   
@@ -755,7 +755,7 @@ struct norddrop_fd_cb *_wrap_new_NorddropFdCb_norddropgo_a604716e4848fd68() {
 }
 
 
-void _wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(struct norddrop_fd_cb *_swig_go_0) {
+void _wrap_delete_NorddropFdCb_norddropgo_6fe7bd86fa076afe(struct norddrop_fd_cb *_swig_go_0) {
   struct norddrop_fd_cb *arg1 = (struct norddrop_fd_cb *) 0 ;
   
   arg1 = *(struct norddrop_fd_cb **)&_swig_go_0; 
@@ -765,7 +765,7 @@ void _wrap_delete_NorddropFdCb_norddropgo_a604716e4848fd68(struct norddrop_fd_cb
 }
 
 
-struct norddrop *_wrap_new_Norddrop_norddropgo_a604716e4848fd68(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
+struct norddrop *_wrap_new_Norddrop_norddropgo_6fe7bd86fa076afe(norddrop_event_cb _swig_go_0, intgo _swig_go_1, norddrop_logger_cb _swig_go_2, norddrop_pubkey_cb _swig_go_3, _gostring_ _swig_go_4) {
   norddrop_event_cb arg1 ;
   enum norddrop_log_level arg2 ;
   norddrop_logger_cb arg3 ;
@@ -797,7 +797,7 @@ struct norddrop *_wrap_new_Norddrop_norddropgo_a604716e4848fd68(norddrop_event_c
 }
 
 
-void _wrap_delete_Norddrop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0) {
+void _wrap_delete_Norddrop_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   
   arg1 = *(struct norddrop **)&_swig_go_0; 
@@ -807,7 +807,7 @@ void _wrap_delete_Norddrop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Start_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_Start_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -834,7 +834,7 @@ intgo _wrap_Norddrop_Start_norddropgo_a604716e4848fd68(struct norddrop *_swig_go
 }
 
 
-intgo _wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0) {
+intgo _wrap_Norddrop_Stop_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   enum norddrop_result result;
   intgo _swig_go_result;
@@ -847,7 +847,7 @@ intgo _wrap_Norddrop_Stop_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_
 }
 
 
-intgo _wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_CancelTransfer_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -867,7 +867,7 @@ intgo _wrap_Norddrop_CancelTransfer_norddropgo_a604716e4848fd68(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_RejectFile_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -894,7 +894,7 @@ intgo _wrap_Norddrop_RejectFile_norddropgo_a604716e4848fd68(struct norddrop *_sw
 }
 
 
-intgo _wrap_Norddrop_Download_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
+intgo _wrap_Norddrop_Download_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2, _gostring_ _swig_go_3) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -928,7 +928,7 @@ intgo _wrap_Norddrop_Download_norddropgo_a604716e4848fd68(struct norddrop *_swig
 }
 
 
-_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+_gostring_ _wrap_Norddrop_NewTransfer_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -956,7 +956,7 @@ _gostring_ _wrap_Norddrop_NewTransfer_norddropgo_a604716e4848fd68(struct norddro
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfers_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   enum norddrop_result result;
@@ -976,7 +976,7 @@ intgo _wrap_Norddrop_PurgeTransfers_norddropgo_a604716e4848fd68(struct norddrop 
 }
 
 
-intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, long long _swig_go_1) {
+intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   enum norddrop_result result;
@@ -991,7 +991,7 @@ intgo _wrap_Norddrop_PurgeTransfersUntil_norddropgo_a604716e4848fd68(struct nord
 }
 
 
-intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
+intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, _gostring_ _swig_go_2) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   char *arg2 = (char *) 0 ;
   char *arg3 = (char *) 0 ;
@@ -1018,29 +1018,20 @@ intgo _wrap_Norddrop_RemoveTransferFile_norddropgo_a604716e4848fd68(struct nordd
 }
 
 
-intgo _wrap_Norddrop_SetPeerState_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, _gostring_ _swig_go_1, intgo _swig_go_2) {
+intgo _wrap_Norddrop_NetworkRefresh_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
   enum norddrop_result result;
   intgo _swig_go_result;
   
   arg1 = *(struct norddrop **)&_swig_go_0; 
   
-  arg2 = (char *)malloc(_swig_go_1.n + 1);
-  memcpy(arg2, _swig_go_1.p, _swig_go_1.n);
-  arg2[_swig_go_1.n] = '\0';
-  
-  arg3 = (int)_swig_go_2; 
-  
-  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  result = (enum norddrop_result)norddrop_network_refresh(arg1);
   _swig_go_result = (intgo)result; 
-  free(arg2); 
   return _swig_go_result;
 }
 
 
-_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(struct norddrop *_swig_go_0, long long _swig_go_1) {
+_gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_6fe7bd86fa076afe(struct norddrop *_swig_go_0, long long _swig_go_1) {
   struct norddrop *arg1 = (struct norddrop *) 0 ;
   long long arg2 ;
   char *result = 0 ;
@@ -1056,7 +1047,7 @@ _gostring_ _wrap_Norddrop_GetTransfersSince_norddropgo_a604716e4848fd68(struct n
 }
 
 
-_gostring_ _wrap_Norddrop_Version_norddropgo_a604716e4848fd68() {
+_gostring_ _wrap_Norddrop_Version_norddropgo_6fe7bd86fa076afe() {
   char *result = 0 ;
   _gostring_ _swig_go_result;
   

--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -488,20 +488,18 @@ enum norddrop_result norddrop_new(struct norddrop **dev,
                                   const char *privkey);
 
 /**
- * Set connectivity state of a peer
+ * Refresh connections. Should be called when anything about the network
+ * changes that might affect connections. Also when peer availability has changed.
+ * This will kick-start the automated retries for all transfers.
  *
  * # Arguments
  *
  * * `dev` - A pointer to the instance.
- * * `peer` - peer address
- * * `is_online` - 0 if offline, 1 if online
  *
  * # Safety
  * The pointers provided should be valid
  */
-enum norddrop_result norddrop_set_peer_state(const struct norddrop *dev,
-                                             const char *peer,
-                                             int64_t is_online);
+enum norddrop_result norddrop_network_refresh(const struct norddrop *dev);
 
 void __norddrop_force_export(enum norddrop_result,
                              struct norddrop_event_cb,

--- a/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
+++ b/norddrop/ffi/bindings/windows/csharp/NordDrop.cs
@@ -127,8 +127,8 @@ public class Norddrop : global::System.IDisposable {
     return ret;
   }
 
-  public NorddropResult SetPeerState(string peer, int isOnline) {
-    NorddropResult ret = (NorddropResult)libnorddropPINVOKE.Norddrop_SetPeerState(swigCPtr, peer, isOnline);
+  public NorddropResult NetworkRefresh() {
+    NorddropResult ret = (NorddropResult)libnorddropPINVOKE.Norddrop_NetworkRefresh(swigCPtr);
     return ret;
   }
 
@@ -363,8 +363,8 @@ class libnorddropPINVOKE {
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_RemoveTransferFile___")]
   public static extern int Norddrop_RemoveTransferFile(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, string jarg3);
 
-  [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_SetPeerState___")]
-  public static extern int Norddrop_SetPeerState(global::System.Runtime.InteropServices.HandleRef jarg1, string jarg2, int jarg3);
+  [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_NetworkRefresh___")]
+  public static extern int Norddrop_NetworkRefresh(global::System.Runtime.InteropServices.HandleRef jarg1);
 
   [global::System.Runtime.InteropServices.DllImport("norddrop", EntryPoint="CSharp_NordSecfNordDrop_Norddrop_GetTransfersSince___")]
   public static extern string Norddrop_GetTransfersSince(global::System.Runtime.InteropServices.HandleRef jarg1, long jarg2);

--- a/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
+++ b/norddrop/ffi/bindings/windows/wrap/csharp_wrap.c
@@ -498,17 +498,13 @@ SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_RemoveTransferFile__
 }
 
 
-SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_SetPeerState___(void * jarg1, char * jarg2, int jarg3) {
+SWIGEXPORT int SWIGSTDCALL CSharp_NordSecfNordDrop_Norddrop_NetworkRefresh___(void * jarg1) {
   int jresult ;
   struct norddrop *arg1 = (struct norddrop *) 0 ;
-  char *arg2 = (char *) 0 ;
-  int arg3 ;
   enum norddrop_result result;
   
   arg1 = (struct norddrop *)jarg1; 
-  arg2 = (char *)jarg2; 
-  arg3 = (int)jarg3; 
-  result = (enum norddrop_result)norddrop_set_peer_state(arg1,(char const *)arg2,arg3);
+  result = (enum norddrop_result)norddrop_network_refresh(arg1);
   jresult = (int)result; 
   return jresult;
 }

--- a/norddrop/ffi/norddrop.i
+++ b/norddrop/ffi/norddrop.i
@@ -78,7 +78,7 @@ struct norddrop {};
 
     enum norddrop_result remove_transfer_file(const char* txid, const char* fid);
 
-    enum norddrop_result set_peer_state(const char* peer, int is_online);
+    enum norddrop_result network_refresh();
 
 
 

--- a/norddrop/src/device/mod.rs
+++ b/norddrop/src/device/mod.rs
@@ -360,26 +360,15 @@ impl NordDropFFI {
         Ok(xfid)
     }
 
-    pub(super) fn set_peer_state(&mut self, peer: &str, is_online: bool) -> Result<()> {
-        trace!(
-            self.logger,
-            "norddrop_set_peer_state() {:?} -> {:?}",
-            peer,
-            is_online
-        );
-
-        let peer: IpAddr = peer.parse().map_err(|err| {
-            error!(self.logger, "Failed to parse peer address: {err}");
-            ffi::types::NORDDROP_RES_BAD_INPUT
-        })?;
+    pub(super) fn network_refresh(&mut self) -> Result<()> {
+        trace!(self.logger, "norddrop_network_refresh()");
 
         let mut instance = self.instance.blocking_lock();
         let instance = instance
             .as_mut()
             .ok_or(ffi::types::NORDDROP_RES_NOT_STARTED)?;
 
-        self.rt
-            .block_on(instance.service.set_peer_state(peer, is_online));
+        instance.service.network_refresh();
 
         Ok(())
     }

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -119,7 +119,6 @@ pub unsafe extern "C" fn norddrop_new_transfer(
 #[no_mangle]
 pub unsafe extern "C" fn norddrop_destroy(dev: *mut norddrop) {
     if !dev.is_null() {
-        #[allow(clippy::let_underscore_must_use)]
         let _ = Box::from_raw(dev);
     }
 }
@@ -757,7 +756,6 @@ impl slog::Drain for norddrop_logger_cb {
 
         let mut serializer = KeyValueSerializer::new(record);
 
-        #[allow(clippy::let_underscore_must_use)]
         let _ = kv.serialize(record, &mut serializer);
 
         if let Ok(cstr) = CString::new(serializer.msg()) {

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -676,44 +676,26 @@ pub unsafe extern "C" fn norddrop_new(
     result.unwrap_or(norddrop_result::NORDDROP_RES_ERROR)
 }
 
-/// Set connectivity state of a peer
+/// Refresh connections. Should be called when anything about the network
+/// changes that might affect connections. Also when peer availability has
+/// changed. This will kick-start the automated retries for all transfers.
 ///
 /// # Arguments
 ///
 /// * `dev` - A pointer to the instance.
-/// * `peer` - peer address
-/// * `is_online` - 0 if offline, 1 if online
 ///
 /// # Safety
 /// The pointers provided should be valid
 #[no_mangle]
-pub unsafe extern "C" fn norddrop_set_peer_state(
-    dev: &norddrop,
-    peer: *const c_char,
-    is_online: i64,
-) -> norddrop_result {
+pub unsafe extern "C" fn norddrop_network_refresh(dev: &norddrop) -> norddrop_result {
     let result = panic::catch_unwind(move || {
         let mut dev = match dev.0.lock() {
             Ok(inst) => inst,
             Err(poisoned) => poisoned.into_inner(),
         };
 
-        let peer = {
-            if peer.is_null() {
-                return norddrop_result::NORDDROP_RES_INVALID_STRING;
-            }
-
-            ffi_try!(CStr::from_ptr(peer).to_str())
-        };
-
-        let is_online = match is_online {
-            0 => false,
-            1 => true,
-            _ => return norddrop_result::NORDDROP_RES_BAD_INPUT,
-        };
-
-        dev.set_peer_state(peer, is_online)
-            .norddrop_log_result(&dev.logger, "norddrop_set_peer_state")
+        dev.network_refresh()
+            .norddrop_log_result(&dev.logger, "norddrop_network_refresh")
     });
 
     result.unwrap_or(norddrop_result::NORDDROP_RES_ERROR)

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -103,13 +103,12 @@ class Action:
         raise NotImplementedError("run() on base Action class")
 
 
-class SetPeerState(Action):
-    def __init__(self, peer: str, state: PeerState):
-        self._peer = peer
-        self._state = state
+class NetworkRefresh(Action):
+    def __init__(self):
+        pass
 
     async def run(self, drop: ffi.Drop):
-        drop.set_peer_state(self._peer, self._state)
+        drop.network_refresh()
 
 
 class ListenOnPort(Action):
@@ -445,7 +444,7 @@ class WaitAndIgnoreExcept(Action):
                 )
 
     def __str__(self):
-        return f"WaitAndIgnoreExcept({self._events})"
+        return f"WaitAndIgnoreExcept({', '.join(str(e) for e in self._events)})"
 
 
 class WaitForOneOf(Action):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -317,11 +317,6 @@ class Drop:
         norddrop_lib.norddrop_new_transfer.restype = ctypes.c_char_p
         norddrop_lib.norddrop_get_transfers_since.restype = ctypes.c_char_p
 
-        norddrop_lib.norddrop_set_peer_state.argtypes = (
-            ctypes.c_void_p,
-            ctypes.c_char_p,
-            ctypes.c_int,
-        )
         norddrop_lib.norddrop_start.argtypes = (
             ctypes.c_void_p,
             ctypes.c_char_p,
@@ -491,18 +486,15 @@ class Drop:
 
         return transfers.decode("utf-8")
 
-    def set_peer_state(self, peer: str, state: PeerState):
-        addr = peer_resolver.resolve(peer)
-        err = self._lib.norddrop_set_peer_state(
+    def network_refresh(self):
+        err = self._lib.norddrop_network_refresh(
             self._instance,
-            ctypes.create_string_buffer(bytes(addr, "utf-8")),
-            state.value,
         )
 
         if err != 0:
             err_type = LibResult(err).name
             raise DropException(
-                f"set_peer_state has failed with code: {err}({err_type})", err
+                f"network_refresh has failed with code: {err}({err_type})", err
             )
 
     def purge_transfers_until(self, until_timestamp: int):


### PR DESCRIPTION
simplify code by having umbrella API for network change.

Along came:
- several retries upon the API call as it might be delayed
- fixed infinite check loop
- extra testcase

Adding retries simplified the logic where we don't need to store "refresh was called but the task was busy".

**TLDR:** Inherently this case makes the code behave as in current `main`, except instead of infinite retries it waits for the API to trigger it and gives out several tries.