### PR TITLE
Remove pending mentions from outgoing transfer

### DIFF
--- a/norddrop/ffi/bindings/norddrop.h
+++ b/norddrop/ffi/bindings/norddrop.h
@@ -374,10 +374,6 @@ enum norddrop_result norddrop_purge_transfers_until(const struct norddrop *dev,
  *              "created_at": 1686651025988,
  *              "states": [
  *                  {
- *                      "created_at": 1686651025991,
- *                      "state": "pending"
- *                  },
- *                  {
  *                      "created_at": 1686651025997,
  *                      "state": "started",
  *                      "bytes_sent": 0
@@ -405,7 +401,7 @@ enum norddrop_result norddrop_purge_transfers_until(const struct norddrop *dev,
  *             "by_peer": false
  *         }
  *     ],
- *     "type": "outgoing",
+ *     "type": "incoming",
  *     "paths": [
  *         {
  *             "transfer_id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",
@@ -489,8 +485,8 @@ enum norddrop_result norddrop_new(struct norddrop **dev,
 
 /**
  * Refresh connections. Should be called when anything about the network
- * changes that might affect connections. Also when peer availability has changed.
- * This will kick-start the automated retries for all transfers.
+ * changes that might affect connections. Also when peer availability has
+ * changed. This will kick-start the automated retries for all transfers.
  *
  * # Arguments
  *

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -484,10 +484,6 @@ pub extern "C" fn norddrop_purge_transfers_until(
 ///              "created_at": 1686651025988,
 ///              "states": [
 ///                  {
-///                      "created_at": 1686651025991,
-///                      "state": "pending"
-///                  },
-///                  {
 ///                      "created_at": 1686651025997,
 ///                      "state": "started",
 ///                      "bytes_sent": 0
@@ -515,7 +511,7 @@ pub extern "C" fn norddrop_purge_transfers_until(
 ///             "by_peer": false
 ///         }
 ///     ],
-///     "type": "outgoing",
+///     "type": "incoming",
 ///     "paths": [
 ///         {
 ///             "transfer_id": "b49fc2f8-ce2d-41ac-a081-96a4d760899e",


### PR DESCRIPTION
The example in API call was containing
`outgoing` state for the transfer which we don't have anymore