### PR TITLE
Introduce another file state or event for files being throttled

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ requests and now waits for this API to be called to conserve the resources.
 * Introduce server side authentication
 * Ensure `norddrop_stop()` blocks until all events are processed by the handler.
 * Normalize file paths upon receiving the transfer request immedieatly, thus eliminate misleading file names in the events.
+* Introduce `TransferThrottled` event for file uploads
 
 ---
 <br>

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -142,6 +142,12 @@ fn print_event(ev: &Event) {
             transfer_id,
             file_id,
         } => info!("[EVENT] FileDownloadPaused {transfer_id}: {file_id}"),
+
+        Event::FileUploadThrottled {
+            transfer_id,
+            file_id,
+            transfered,
+        } => info!("[EVENT] FileUploadThrottled {transfer_id}: {file_id}, progress: {transfered}"),
     }
 }
 

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -52,6 +52,12 @@ pub enum Event {
         by_peer: bool,
     },
 
+    FileUploadThrottled {
+        transfer_id: Uuid,
+        file_id: FileId,
+        transfered: u64,
+    },
+
     IncomingTransferCanceled(Arc<IncomingTransfer>, bool),
     OutgoingTransferCanceled(Arc<OutgoingTransfer>, bool),
 

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -32,7 +32,7 @@ pub(super) struct State {
     pub(crate) auth: Arc<auth::Context>,
     pub(crate) config: Arc<DropConfig>,
     pub(crate) storage: Arc<Storage>,
-    pub(crate) throttle: Semaphore,
+    pub(crate) throttle: Arc<Semaphore>,
     pub(crate) addr: IpAddr,
     #[cfg(unix)]
     pub fdresolv: Option<Arc<crate::file::FdResolver>>,
@@ -70,7 +70,7 @@ impl Service {
     ) -> Result<Self, Error> {
         let task = async {
             let state = Arc::new(State {
-                throttle: Semaphore::new(drop_config::MAX_UPLOADS_IN_FLIGHT), /* TODO: max uploads of 4 files per all libdrop is too restrictive, workout a better plan, like configurable through config */
+                throttle: Arc::new(Semaphore::new(drop_config::MAX_UPLOADS_IN_FLIGHT)), /* TODO: max uploads of 4 files per all libdrop is too restrictive, workout a better plan, like configurable through config */
                 transfer_manager: TransferManager::new(
                     storage.clone(),
                     FileEventTxFactory::new(event_tx.clone(), moose.clone()),

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -152,6 +152,7 @@ impl<'a> StorageDispatch<'a> {
             }
             crate::Event::RequestReceived(_) => (),
             crate::Event::RequestQueued(_) => (),
+            crate::Event::FileUploadThrottled { .. } => (),
         }
     }
 

--- a/drop-transfer/src/ws/client/throttle.rs
+++ b/drop-transfer/src/ws/client/throttle.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use slog::{error, info};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
+
+use crate::{service::State, ws::OutgoingFileEventTx};
+
+pub struct PermitInit(PermitInitRepr);
+
+enum PermitInitRepr {
+    Acquired(OwnedSemaphorePermit),
+    WillWait {
+        logger: slog::Logger,
+        throttle: Arc<Semaphore>,
+        events: Arc<OutgoingFileEventTx>,
+        transfered: u64,
+    },
+}
+
+pub(crate) async fn init(
+    logger: &slog::Logger,
+    state: &State,
+    events: &Arc<OutgoingFileEventTx>,
+    transfered: u64,
+) -> Option<PermitInit> {
+    let repr = match state.throttle.clone().try_acquire_owned() {
+        Err(TryAcquireError::NoPermits) => {
+            let file_id = events.file_id();
+            info!(logger, "Throttling file: {file_id}");
+            events.throttled(transfered).await;
+
+            PermitInitRepr::WillWait {
+                logger: logger.clone(),
+                throttle: state.throttle.clone(),
+                events: events.clone(),
+                transfered,
+            }
+        }
+        Err(TryAcquireError::Closed) => {
+            error!(logger, "Throttle semaphore is closed");
+            return None;
+        }
+        Ok(permit) => {
+            events.start(transfered).await;
+            PermitInitRepr::Acquired(permit)
+        }
+    };
+
+    Some(PermitInit(repr))
+}
+
+impl PermitInit {
+    pub async fn acquire(self) -> Option<OwnedSemaphorePermit> {
+        match self.0 {
+            PermitInitRepr::Acquired(permit) => Some(permit),
+            PermitInitRepr::WillWait {
+                logger,
+                throttle,
+                events,
+                transfered,
+            } => match throttle.acquire_owned().await {
+                Ok(permit) => {
+                    let file_id = events.file_id();
+                    info!(logger, "Throttle permited file: {file_id}");
+                    events.start(transfered).await;
+
+                    Some(permit)
+                }
+                Err(err) => {
+                    error!(logger, "Throttle semaphore failed: {err}");
+                    None
+                }
+            },
+        }
+    }
+}

--- a/drop-transfer/src/ws/client/throttle.rs
+++ b/drop-transfer/src/ws/client/throttle.rs
@@ -62,7 +62,7 @@ impl PermitInit {
                 Ok(permit) => {
                     let file_id = events.file_id();
                     info!(logger, "Throttle permited file: {file_id}");
-                    events.start(transfered).await;
+                    events.start_with_progress(transfered).await;
 
                     Some(permit)
                 }

--- a/drop-transfer/src/ws/events.rs
+++ b/drop-transfer/src/ws/events.rs
@@ -179,6 +179,10 @@ impl<T: Transfer> FileEventTx<T> {
             });
         }
     }
+
+    pub fn file_id(&self) -> &FileId {
+        &self.file_id
+    }
 }
 
 impl FileEventTx<IncomingTransfer> {
@@ -264,6 +268,15 @@ impl FileEventTx<OutgoingTransfer> {
             self.file_id.clone(),
             transfered,
         ))
+        .await
+    }
+
+    pub async fn throttled(&self, transfered: u64) {
+        self.emit(crate::Event::FileUploadThrottled {
+            transfer_id: self.xfer.id(),
+            file_id: self.file_id.clone(),
+            transfered,
+        })
         .await
     }
 

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -107,6 +107,12 @@ pub enum Event {
         file: String,
         timestamp: u64,
     },
+    TransferThrottled {
+        transfer: String,
+        file: String,
+        transfered: u64,
+        timestamp: u64,
+    },
 }
 
 #[derive(Deserialize, Debug)]
@@ -262,6 +268,17 @@ impl From<(drop_transfer::Event, SystemTime)> for Event {
             } => Self::TransferPaused {
                 transfer: transfer_id.to_string(),
                 file: file_id.to_string(),
+                timestamp,
+            },
+
+            drop_transfer::Event::FileUploadThrottled {
+                transfer_id,
+                file_id,
+                transfered,
+            } => Self::TransferThrottled {
+                transfer: transfer_id.to_string(),
+                file: file_id.to_string(),
+                transfered,
                 timestamp,
             },
         }

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -470,7 +470,9 @@ class WaitRacy(Action):
 
     async def run(self, drop: ffi.Drop):
         await drop._events.wait_racy(
-            self._events, not any(isinstance(ev, event.Progress) for ev in self._events)
+            self._events,
+            not any(isinstance(ev, event.Progress) for ev in self._events),
+            not any(isinstance(ev, event.Throttled) for ev in self._events),
         )
 
     def __str__(self):

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -146,6 +146,32 @@ class Progress(Event):
         return f"Progress(transfer={print_uuid(self._uuid_slot)}, file={self._file}, transfered={self._transferred})"
 
 
+class Throttled(Event):
+    def __init__(
+        self, uuid_slot: int, file: str, transferred: typing.Optional[int] = 0
+    ):
+        self._uuid_slot = uuid_slot
+        self._file = file
+        self._transferred = transferred
+
+    def __eq__(self, rhs):
+        if not isinstance(rhs, Throttled):
+            return False
+        if self._uuid_slot != rhs._uuid_slot:
+            return False
+        if self._file != rhs._file:
+            return False
+
+        if self._transferred is not None and rhs._transferred is not None:
+            if self._transferred != rhs._transferred:
+                return False
+
+        return True
+
+    def __str__(self):
+        return f"Throttled(transfer={print_uuid(self._uuid_slot)}, file={self._file}, transfered={self._transferred})"
+
+
 class FinishTransferCanceled(Event):
     def __init__(self, uuid_slot: int, by_peer: bool):
         self._uuid_slot = uuid_slot


### PR DESCRIPTION
This PR implements emitting an additional event `TransferThrottled` before `TransferStarted` on throttled files