### PR TITLE
Recude flakyness of analytics tests

### DIFF
--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4818,210 +4818,6 @@ scenarios = [
         },
     ),
     Scenario(
-        "analytics-6-1",
-        "Test if the instance can recover on database corruption",
-        {
-            "DROP_PEER_REN": ActionList(
-                [
-                    action.Start(
-                        "DROP_PEER_REN",
-                        dbpath="/tmp/db/26-1-corrupted.sqlite",
-                    ),
-                    action.Wait(event.RuntimeError(Error.DB_LOST)),
-                    action.NoEvent(),
-                    action.Stop(),
-                    action.AssertMooseEvents(
-                        [
-                            """{
-                            "type": "exception",
-                            "code": 11,
-                            "note": "Initial DB open failed, recreating",
-                            "message": "Failed to open DB file",
-                            "name": "DB Error"
-                        }""",
-                            """{
-                            "type": "init",
-                            "result": 0,
-                            "lib_version": "*",
-                            "app_version": "test-framework",
-                            "prod": false,
-                            "init_duration": ">0"
-                        }""",
-                        ]
-                    ),
-                ]
-            ),
-        },
-        tags=["moose"],
-    ),
-    Scenario(
-        "analytics-6-2",
-        "Provide database with insufficient permissions, expect file share and in-memory database to work, with failures being reported to moose",
-        {
-            "DROP_PEER_REN": ActionList(
-                [
-                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
-                    action.DropPrivileges(),
-                    action.Start(
-                        "DROP_PEER_REN",
-                        dbpath="/root/no-access-db.sqlite",
-                    ),
-                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
-                    action.Wait(
-                        event.Queued(
-                            0,
-                            {
-                                event.File(
-                                    FILES["testfile-small"].id,
-                                    "testfile-small",
-                                    1048576,
-                                ),
-                            },
-                        )
-                    ),
-                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
-                    action.Wait(
-                        event.FinishFileUploaded(
-                            0,
-                            FILES["testfile-small"].id,
-                        )
-                    ),
-                    action.ExpectCancel([0], True),
-                    action.NoEvent(),
-                    action.AssertTransfers(
-                        [
-                            """{
-                        "id": "*",
-                        "created_at": "*",
-                        "states": [
-                            {
-                                "created_at": "*",
-                                "state": "cancel",
-                                "by_peer": true
-                            }
-                        ],
-                        "type": "outgoing",
-                        "paths": [
-                            {
-                                "relative_path": "testfile-small",
-                                "base_path": "/tmp",
-                                "bytes": 1048576,
-                                "states": [
-                                    {
-                                        "created_at": "*",
-                                        "state": "started",
-                                        "bytes_sent": 0
-                                    },
-                                    {
-                                        "created_at": "*",
-                                        "state": "completed"
-                                    }
-                                ]
-                            }
-                        ]
-                    }""",
-                        ]
-                    ),
-                    action.Stop(),
-                    action.AssertMooseEvents(
-                        [
-                            """{
-                            "type": "exception",
-                            "code": 11,
-                            "note": "Initial DB open failed, recreating",
-                            "message": "Failed to open DB file",
-                            "name": "DB Error"
-                        }""",
-                            """{
-                            "type": "exception",
-                            "code": 11,
-                            "note": "Permission denied (os error 13)",
-                            "message": "Failed to remove old DB file",
-                            "name": "DB Error"
-                        }""",
-                            """{
-                            "type": "init",
-                            "result": 0,
-                            "lib_version": "*",
-                            "app_version": "test-framework",
-                            "prod": false,
-                            "init_duration": ">0"
-                        }""",
-                            """{
-                            "type": "transfer_intent",
-                            "transfer_id": "*",
-                            "path_ids": \""""
-                            + FILES["testfile-small"].id
-                            + """\",
-                            "extensions": "none",
-                            "mime_types": "unknown",
-                            "file_count": 1,
-                            "file_sizes": "1024",
-                            "transfer_size": 1024
-                        }""",
-                            """{
-                            "type": "transfer_state",
-                            "protocol_version": ">=5",
-                            "result": 0
-                        }""",
-                            """{
-                            "type": "file",
-                            "result": 0,
-                            "phase": "finished",
-                            "transfer_id": "*",
-                            "transfer_time": ">0",
-                            "transferred": ">=0",
-                            "path_id": \""""
-                            + FILES["testfile-small"].id
-                            + """\",
-                            "direction": "upload"
-                        }""",
-                        ]
-                    ),
-                ]
-            ),
-            "DROP_PEER_STIMPY": ActionList(
-                [
-                    action.Start("DROP_PEER_STIMPY"),
-                    action.Wait(
-                        event.Receive(
-                            0,
-                            "DROP_PEER_REN",
-                            {
-                                event.File(
-                                    FILES["testfile-small"].id,
-                                    "testfile-small",
-                                    1048576,
-                                ),
-                            },
-                        )
-                    ),
-                    action.Download(
-                        0,
-                        FILES["testfile-small"].id,
-                        "/tmp/received/26-2",
-                    ),
-                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
-                    action.Wait(
-                        event.FinishFileDownloaded(
-                            0,
-                            FILES["testfile-small"].id,
-                            "/tmp/received/26-2/testfile-small",
-                        )
-                    ),
-                    action.CheckDownloadedFiles(
-                        [
-                            action.File("/tmp/received/26-2/testfile-small", 1048576),
-                        ],
-                    ),
-                    action.CancelTransferRequest([0]),
-                    action.ExpectCancel([0], False),
-                ]
-            ),
-        },
-        tags=["moose"],
-    ),
-    Scenario(
         "scenario27-1",
         "Reject file on sending side. Expect event on both peers",
         {
@@ -10190,7 +9986,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10272,6 +10068,7 @@ scenarios = [
                 ]
             ),
         },
+        tags=["moose"],
     ),
     Scenario(
         "analytics-2",
@@ -10342,7 +10139,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10352,9 +10149,7 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": ">0",
                             "transferred": 0,
-                            "path_id": \""""
-                            + FILES["tiny-jpeg.jpg"].id
-                            + """\",
+                            "path_id": "*",
                             "direction": "upload"
                         }""",
                             """{
@@ -10364,9 +10159,7 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": ">0",
                             "transferred": 0,
-                            "path_id": \""""
-                            + FILES["tiny-gif.gif"].id
-                            + """\",
+                            "path_id": "*",
                             "direction": "upload"
                         }""",
                         ]
@@ -10445,9 +10238,7 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": ">0",
                             "transferred": 0,
-                            "path_id": \""""
-                            + FILES["tiny-jpeg.jpg"].id
-                            + """\",
+                            "path_id": "*",
                             "direction": "download"
                         }""",
                             """{
@@ -10457,9 +10248,7 @@ scenarios = [
                             "transfer_id": "*",
                             "transfer_time": ">0",
                             "transferred": 0,
-                            "path_id": \""""
-                            + FILES["tiny-gif.gif"].id
-                            + """\",
+                            "path_id": "*",
                             "direction": "download"
                         }""",
                         ]
@@ -10467,6 +10256,7 @@ scenarios = [
                 ]
             ),
         },
+        tags=["moose"],
     ),
     Scenario(
         "analytics-3",
@@ -10523,7 +10313,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10608,6 +10398,7 @@ scenarios = [
                 ]
             ),
         },
+        tags=["moose"],
     ),
     Scenario(
         "analytics-4",
@@ -10664,7 +10455,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10681,7 +10472,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10799,6 +10590,7 @@ scenarios = [
                 ]
             ),
         },
+        tags=["moose"],
     ),
     Scenario(
         "analytics-5",
@@ -10856,7 +10648,7 @@ scenarios = [
                         }""",
                             """{
                             "type": "transfer_state",
-                            "protocol_version": ">=5",
+                            "protocol_version": 6,
                             "result": 0
                         }""",
                             """{
@@ -10934,6 +10726,211 @@ scenarios = [
                 ]
             ),
         },
+        tags=["moose"],
+    ),
+    Scenario(
+        "analytics-6-1",
+        "Test if the instance can recover on database corruption",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.Start(
+                        "DROP_PEER_REN",
+                        dbpath="/tmp/db/26-1-corrupted.sqlite",
+                    ),
+                    action.Wait(event.RuntimeError(Error.DB_LOST)),
+                    action.NoEvent(),
+                    action.Stop(),
+                    action.AssertMooseEvents(
+                        [
+                            """{
+                            "type": "exception",
+                            "code": 11,
+                            "note": "Initial DB open failed, recreating",
+                            "message": "Failed to open DB file",
+                            "name": "DB Error"
+                        }""",
+                            """{
+                            "type": "init",
+                            "result": 0,
+                            "lib_version": "*",
+                            "app_version": "test-framework",
+                            "prod": false,
+                            "init_duration": ">0"
+                        }""",
+                        ]
+                    ),
+                ]
+            ),
+        },
+        tags=["moose"],
+    ),
+    Scenario(
+        "analytics-6-2",
+        "Provide database with insufficient permissions, expect file share and in-memory database to work, with failures being reported to moose",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.DropPrivileges(),
+                    action.Start(
+                        "DROP_PEER_REN",
+                        dbpath="/root/no-access-db.sqlite",
+                    ),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            0,
+                            FILES["testfile-small"].id,
+                        )
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.AssertTransfers(
+                        [
+                            """{
+                        "id": "*",
+                        "created_at": "*",
+                        "states": [
+                            {
+                                "created_at": "*",
+                                "state": "cancel",
+                                "by_peer": true
+                            }
+                        ],
+                        "type": "outgoing",
+                        "paths": [
+                            {
+                                "relative_path": "testfile-small",
+                                "base_path": "/tmp",
+                                "bytes": 1048576,
+                                "states": [
+                                    {
+                                        "created_at": "*",
+                                        "state": "started",
+                                        "bytes_sent": 0
+                                    },
+                                    {
+                                        "created_at": "*",
+                                        "state": "completed"
+                                    }
+                                ]
+                            }
+                        ]
+                    }""",
+                        ]
+                    ),
+                    action.Stop(),
+                    action.AssertMooseEvents(
+                        [
+                            """{
+                            "type": "exception",
+                            "code": 11,
+                            "note": "Initial DB open failed, recreating",
+                            "message": "Failed to open DB file",
+                            "name": "DB Error"
+                        }""",
+                            """{
+                            "type": "exception",
+                            "code": 11,
+                            "note": "Permission denied (os error 13)",
+                            "message": "Failed to remove old DB file",
+                            "name": "DB Error"
+                        }""",
+                            """{
+                            "type": "init",
+                            "result": 0,
+                            "lib_version": "*",
+                            "app_version": "test-framework",
+                            "prod": false,
+                            "init_duration": ">0"
+                        }""",
+                            """{
+                            "type": "transfer_intent",
+                            "transfer_id": "*",
+                            "path_ids": \""""
+                            + FILES["testfile-small"].id
+                            + """\",
+                            "extensions": "none",
+                            "mime_types": "unknown",
+                            "file_count": 1,
+                            "file_sizes": "1024",
+                            "transfer_size": 1024
+                        }""",
+                            """{
+                            "type": "transfer_state",
+                            "protocol_version": 6,
+                            "result": 0
+                        }""",
+                            """{
+                            "type": "file",
+                            "result": 0,
+                            "phase": "finished",
+                            "transfer_id": "*",
+                            "transfer_time": ">0",
+                            "transferred": ">=0",
+                            "path_id": \""""
+                            + FILES["testfile-small"].id
+                            + """\",
+                            "direction": "upload"
+                        }""",
+                        ]
+                    ),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-small"].id,
+                        "/tmp/received/26-2",
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileDownloaded(
+                            0,
+                            FILES["testfile-small"].id,
+                            "/tmp/received/26-2/testfile-small",
+                        )
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File("/tmp/received/26-2/testfile-small", 1048576),
+                        ],
+                    ),
+                    action.CancelTransferRequest([0]),
+                    action.ExpectCancel([0], False),
+                ]
+            ),
+        },
+        tags=["moose"],
     ),
     Scenario(
         "scenario48",


### PR DESCRIPTION
In multi-file transfers, it's not worth to pendatically check for specific file ID's we already know that the batch event contains the correct information, so it should be safe enough, this was the main cause of flakyness, in addition, the check for protocol version has also been made pedantic, as this could in theory help catch a super obscure bug and isn't too big of pain to update, given the frequency of new protocol versions coming out

And also moved all of the analytics tests to be close together