### PR TITLE
Use constant number of queries in `transfers_since`

### DIFF
--- a/drop-storage/src/types.rs
+++ b/drop-storage/src/types.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use crate::sync;
 
-type TransferId = uuid::Uuid;
+pub(crate) type TransferId = uuid::Uuid;
 type FileId = String;
 
 fn serialize_datetime<S>(timestamp: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Improves the performance by reducing the number of queries from a variable number (based on transfers and paths in them) to a constant 3