### PR TITLE
Allow for test running via label

### DIFF
--- a/.github/workflows/analytics-tests.yml
+++ b/.github/workflows/analytics-tests.yml
@@ -2,6 +2,7 @@ name: Analytics tests
 run-name: ${{ github.actor }} is running analytics tests
 on:
   - push
+  - pull_request_target
 jobs:
   tests:
     runs-on: ubuntu-latest    

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   trigger-gitlab-pipeline:
     runs-on: [self-hosted, gitlab]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'run tests')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'gitlab')) }}
     steps:
       - uses: NordSecurity/trigger-gitlab-pipeline@v1
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,7 @@ name: Integration tests
 run-name: ${{ github.actor }} is running integration tests
 on:
   - push
+  - pull_request_target
 jobs:
   tests:
     runs-on: ubuntu-latest    

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -2,6 +2,7 @@ name: Unit tests
 run-name: ${{ github.actor }} is running unit tests
 on:
   - push
+  - pull_request_target
 jobs:
   tests:
     runs-on: ubuntu-latest    


### PR DESCRIPTION
Previous label of `run tests` was obsolete as it actually didn't trigger tests in gitlab but rather internal stuff, so I renamed it.

I also added the same workflow to unit and integration tests. It should trigger the tests after adding the label of `run tests`