### PR TITLE
Lukasp/file 541 checksum events before download begins

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,9 @@
 ### UNRELEASED
-### **UNRELEASED**
+### **Checksummed and Optimized**
 ---
-* Introduce `ChecksumStarted`, `ChecksumProgress`, and `ChecksumFinised` events for checksum computation progress.
-* Add the `checksum_events_size_treshold_bytes` optional config field for controlling how the checksuming events are emitted.
-* Optmize `transfers_since()` function significantly
+* Introduce `ChecksumStarted`, `ChecksumProgress`, and `ChecksumFinished` events on the downloader side when resuming and after the download.
+* Add the `checksum_events_size_treshold_bytes` optional config field for controlling the threshold of file size after which the checksum events are emited.
+* Optimize `transfers_since()`
 
 ---
 <br>

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -151,7 +151,8 @@ fn print_event(ev: &Event) {
         Event::ChecksumStarted {
             transfer_id,
             file_id,
-        } => info!("[EVENT] ChecksumStarted {transfer_id}: {file_id}"),
+            size,
+        } => info!("[EVENT] ChecksumStarted {transfer_id}: {file_id}: {size}"),
 
         Event::ChecksumFinished {
             transfer_id,

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -66,6 +66,7 @@ pub enum Event {
     ChecksumStarted {
         transfer_id: Uuid,
         file_id: FileId,
+        size: u64,
     },
     ChecksumFinished {
         transfer_id: Uuid,

--- a/drop-transfer/src/storage_dispatch.rs
+++ b/drop-transfer/src/storage_dispatch.rs
@@ -157,6 +157,7 @@ impl<'a> StorageDispatch<'a> {
             crate::Event::ChecksumStarted {
                 transfer_id: _,
                 file_id: _,
+                size: _,
             } => {
                 // not stored in the database
             }

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -884,15 +884,7 @@ impl FileXferTask {
             let size = tmp_size.unwrap_or(0);
             events.checksum_start(size).await;
 
-            Some({
-                let ev = events.clone();
-                move |progress: u64| {
-                    let ev = ev.clone();
-                    async move {
-                        ev.checksum_progress(progress).await;
-                    }
-                }
-            })
+            Some(|progress| events.checksum_progress(progress))
         } else {
             None
         };

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -1076,7 +1076,7 @@ impl TmpFileState {
 
         let meta = file.metadata()?;
 
-        let csum = file::checksum(&mut io::BufReader::new(file), progress_cb).await?;
+        let csum = file::checksum(file, progress_cb).await?;
         Ok(TmpFileState { meta, csum })
     }
 }

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -23,6 +23,7 @@ use warp::ws::Message;
 use super::{
     handler::{self, MsgToSend},
     socket::WebSocket,
+    TmpFileState,
 };
 use crate::{
     manager::FileTerminalState,
@@ -395,7 +396,12 @@ impl Drop for Downloader {
 
 #[async_trait::async_trait]
 impl handler::Downloader for Downloader {
-    async fn init(&mut self, task: &super::FileXferTask) -> crate::Result<handler::DownloadInit> {
+    // v2 doesn't support resumes, so no checksum logic is happening in here
+    async fn init(
+        &mut self,
+        task: &super::FileXferTask,
+        _: Option<TmpFileState>,
+    ) -> crate::Result<handler::DownloadInit> {
         let mut suffix = sha1::Sha1::new();
 
         suffix.update(task.xfer.id().as_bytes());
@@ -427,7 +433,7 @@ impl handler::Downloader for Downloader {
         self.tmp_loc = Some(tmp_location.clone());
         Ok(handler::DownloadInit::Stream {
             offset: 0,
-            tmp_location,
+            // tmp_location,
         })
     }
 

--- a/drop-transfer/src/ws/server/v6.rs
+++ b/drop-transfer/src/ws/server/v6.rs
@@ -16,6 +16,7 @@ use warp::ws::Message;
 use super::{
     handler::{self, MsgToSend},
     socket::WebSocket,
+    TmpFileState,
 };
 use crate::{
     file::{self, FileToRecv},
@@ -568,27 +569,13 @@ impl Downloader {
 
 #[async_trait::async_trait]
 impl handler::Downloader for Downloader {
-    async fn init(&mut self, task: &super::FileXferTask) -> crate::Result<handler::DownloadInit> {
-        let filename_len = task.file.subpath().name().len();
-
-        if filename_len + super::MAX_FILE_SUFFIX_LEN > super::MAX_FILENAME_LENGTH {
-            return Err(crate::Error::FilenameTooLong);
-        }
-
-        let tmp_location: Hidden<PathBuf> = Hidden(
-            task.base_dir
-                .join(super::temp_file_name(task.xfer.id(), task.file.id())),
-        );
-
-        // Check if we can resume the temporary file
-        match super::TmpFileState::load(&tmp_location.0).await {
-            Ok(super::TmpFileState { meta, csum }) => {
-                debug!(
-                    self.logger,
-                    "Found temporary file: {tmp_location:?}, of size: {}",
-                    meta.len()
-                );
-
+    async fn init(
+        &mut self,
+        task: &super::FileXferTask,
+        tmpstate: Option<TmpFileState>,
+    ) -> crate::Result<handler::DownloadInit> {
+        match tmpstate {
+            Some(TmpFileState { meta, csum }) => {
                 self.offset = match meta.len().cmp(&task.file.size()) {
                     Ordering::Less => {
                         let report = self.request_csum(meta.len()).await?;
@@ -629,16 +616,13 @@ impl handler::Downloader for Downloader {
                         0
                     }
                 };
-            }
-            Err(err) => {
-                debug!(self.logger, "Failed to load temporary file info: {err}");
-            }
-        };
 
-        Ok(handler::DownloadInit::Stream {
-            offset: self.offset,
-            tmp_location,
-        })
+                Ok(handler::DownloadInit::Stream {
+                    offset: self.offset,
+                })
+            }
+            None => Ok(handler::DownloadInit::Stream { offset: 0 }),
+        }
     }
 
     async fn open(&mut self, path: &Hidden<PathBuf>) -> crate::Result<fs::File> {

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -118,6 +118,7 @@ pub enum Event {
     ChecksumStarted {
         transfer: Uuid,
         file: FileId,
+        size: u64,
         timestamp: u64,
     },
     ChecksumFinished {
@@ -305,9 +306,11 @@ impl From<(drop_transfer::Event, SystemTime)> for Event {
             drop_transfer::Event::ChecksumStarted {
                 transfer_id,
                 file_id,
+                size,
             } => Self::ChecksumStarted {
                 transfer: transfer_id,
                 file: file_id,
+                size,
                 timestamp,
             },
 

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -386,7 +386,9 @@ class Wait(Action):
 
     async def run(self, drop: ffi.Drop):
         await drop._events.wait_for(
-            self._event, not isinstance(self._event, event.Progress)
+            self._event,
+            not isinstance(self._event, event.Progress),
+            not isinstance(self._event, event.ChecksumProgress),
         )
 
     def __str__(self):
@@ -624,14 +626,30 @@ class CompareTrees(Action):
 
 
 class WaitForResume(Action):
-    def __init__(self, uuid_slot: int, file_id: str, tmp_file_path_glob: str):
+    def __init__(
+        self,
+        uuid_slot: int,
+        file_id: str,
+        tmp_file_path_glob: str,
+        checksum_events: bool = False,
+    ):
         self._uuid_slot = uuid_slot
         self._file_id = file_id
         self._tmp_file_path = tmp_file_path_glob
+        self._checksum_events = checksum_events
 
     async def run(self, drop: ffi.Drop):
         file_list = glob.glob(self._tmp_file_path)
         stat = os.stat(file_list[0])  # just take the first find
+
+        if self._checksum_events:
+            await drop._events.wait_for(
+                event.ChecksumStarted(self._uuid_slot, self._file_id, stat.st_size)
+            )
+
+            await drop._events.wait_for(
+                event.ChecksumFinished(self._uuid_slot, self._file_id)
+            )
 
         await drop._events.wait_for(
             event.Start(self._uuid_slot, self._file_id, transferred=stat.st_size), False

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -274,7 +274,9 @@ class Paused(Event):
 
 
 class ChecksumProgress(Event):
-    def __init__(self, uuid_slot: int, file: str, checksummed_bytes: int):
+    def __init__(
+        self, uuid_slot: int, file: str, checksummed_bytes: typing.Optional[int] = None
+    ):
         self._uuid_slot = uuid_slot
         self._file = file
         self._checksummed_bytes = checksummed_bytes
@@ -286,19 +288,22 @@ class ChecksumProgress(Event):
             return False
         if self._file != rhs._file:
             return False
-        if self._checksummed_bytes == rhs._checksummed_bytes:
-            return False
+
+        if self._checksummed_bytes is not None and rhs._checksummed_bytes is not None:
+            if self._checksummed_bytes != rhs._checksummed_bytes:
+                return False
 
         return True
 
     def __str__(self):
-        return f"ChecksumProgress(transfer={print_uuid(self._uuid_slot)}, file={self._file}, checksummed_bytes={self._checksummed_bytes}, total_size={self._total_size})"
+        return f"ChecksumProgress(transfer={print_uuid(self._uuid_slot)}, file={self._file}, checksummed_bytes={self._checksummed_bytes})"
 
 
 class ChecksumStarted(Event):
-    def __init__(self, uuid_slot: int, file: str):
+    def __init__(self, uuid_slot: int, file: str, size: int):
         self._uuid_slot = uuid_slot
         self._file = file
+        self._size = size
 
     def __eq__(self, rhs):
         if not isinstance(rhs, ChecksumStarted):
@@ -307,11 +312,13 @@ class ChecksumStarted(Event):
             return False
         if self._file != rhs._file:
             return False
+        if self._size != rhs._size:
+            return False
 
         return True
 
     def __str__(self):
-        return f"ChecksumStarted(transfer={print_uuid(self._uuid_slot)}, file={self._file})"
+        return f"ChecksumStarted(transfer={print_uuid(self._uuid_slot)}, file={self._file}), size={self._size}"
 
 
 class ChecksumFinished(Event):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -759,6 +759,7 @@ def new_event(event_str: str) -> event.Event:
         return event.ChecksumStarted(
             transfer_slot,
             event_data["file"],
+            event_data["size"],
         )
 
     elif event_type == "ChecksumFinished":

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4187,7 +4187,9 @@ scenarios = [
             "DROP_PEER_STIMPY": ActionList(
                 [
                     action.Start(
-                        "DROP_PEER_STIMPY", dbpath="/tmp/db/21-1-stimpy.sqlite"
+                        "DROP_PEER_STIMPY",
+                        dbpath="/tmp/db/21-1-stimpy.sqlite",
+                        checksum_events_size_threshold=0,
                     ),
                     action.Wait(
                         event.Receive(
@@ -4213,12 +4215,24 @@ scenarios = [
                     action.Stop(),
                     action.Wait(event.Paused(0, FILES["testfile-big"].id)),
                     action.Start(
-                        "DROP_PEER_STIMPY", dbpath="/tmp/db/21-1-stimpy.sqlite"
+                        "DROP_PEER_STIMPY",
+                        dbpath="/tmp/db/21-1-stimpy.sqlite",
+                        checksum_events_size_threshold=0,
                     ),
                     action.WaitForResume(
                         0,
                         FILES["testfile-big"].id,
                         "/tmp/received/21-1/*.dropdl-part",
+                        True,
+                    ),
+                    action.Wait(
+                        event.ChecksumStarted(0, FILES["testfile-big"].id, 10485760)
+                    ),
+                    action.Wait(
+                        event.ChecksumFinished(
+                            0,
+                            FILES["testfile-big"].id,
+                        )
                     ),
                     action.Wait(
                         event.FinishFileDownloaded(
@@ -11069,7 +11083,11 @@ scenarios = [
                         "/tmp/received/49",
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
-                    action.Wait(event.ChecksumStarted(0, FILES["testfile-big"].id)),
+                    action.Wait(
+                        event.ChecksumStarted(0, FILES["testfile-big"].id, 10485760)
+                    ),
+                    action.Wait(event.ChecksumProgress(0, FILES["testfile-big"].id)),
+                    action.Wait(event.ChecksumProgress(0, FILES["testfile-big"].id)),
                     action.Wait(event.ChecksumFinished(0, FILES["testfile-big"].id)),
                     action.Wait(
                         event.FinishFileDownloaded(


### PR DESCRIPTION
Introduce downloader side checksumming events when the transfer is being resumed.

For this the previous checksum event was reused but size was added so API user could calculate the progress properly, as well as additional state was added to the file so events could be emited properly.