### PR TITLE
Ensure there is no race condition in events

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * Add `connection_retries` config parameter
 * Add `TransferDeffered` event indicating the connection to peer couldn't be establish at this time
 * Disallow downloading file for which any path component is larger than 250 characters
+* Fix ocassional missing of `TransferPaused` event when toggling libdrop on and off quickly
 
 ---
 <br>

--- a/drop-transfer/src/manager.rs
+++ b/drop-transfer/src/manager.rs
@@ -131,6 +131,12 @@ impl TransferManager {
                         drop(conn)
                     }
                     _ => {
+                        if let Some(conn) = &state.conn {
+                            if !conn.is_closed() {
+                                anyhow::bail!("The transfer connection is in progress already");
+                            }
+                        }
+
                         info!(self.logger, "Issuing pending requests for: {}", xfer.id());
                         state.issue_pending_requests(&conn, &self.logger);
                         state.conn = Some(conn);

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -404,22 +404,22 @@ class Wait(Action):
 class WaitAndIgnoreExcept(Action):
     def __init__(self, events: typing.List[Event]):
         self._events: typing.List[Event] = events
-        self._found: typing.List[Event] = []
 
     async def run(self, drop: ffi.Drop):
         fuse = 0
         limit = 100
+        found = []
 
         while True:
             e = await drop._events.wait_for_any_event(100, ignore_progress=True)
 
             if e in self._events:
-                if e in self._found:
+                if e in found:
                     raise Exception(f"Event {e} was received twice")
 
-                self._found.append(e)
+                found.append(e)
 
-                if len(self._found) == len(self._events):
+                if len(found) == len(self._events):
                     break
                 else:
                     continue

--- a/test/drop_test/event.py
+++ b/test/drop_test/event.py
@@ -303,7 +303,7 @@ class ChecksumProgress(Event):
 
 
 class ChecksumStarted(Event):
-    def __init__(self, uuid_slot: int, file: str, size: int):
+    def __init__(self, uuid_slot: int, file: str, size: typing.Optional[int] = None):
         self._uuid_slot = uuid_slot
         self._file = file
         self._size = size
@@ -315,8 +315,9 @@ class ChecksumStarted(Event):
             return False
         if self._file != rhs._file:
             return False
-        if self._size != rhs._size:
-            return False
+        if self._size is not None and rhs._size is not None:
+            if self._size != rhs._size:
+                return False
 
         return True
 


### PR DESCRIPTION
By ensuring there's only one connection for a given transfer at a time we prevent events from mixing with each other