### PR TITLE
Forbid emitting file events after reaching termianl state

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Update moose tracker to v5.0.0 which introduces automatic context sharing and QoL improvements to development
 * Removed `moose_app_version` field from config (it will be ignored, if present)
 * Add `peer` field to `TransferQueued` event
+* Fix ocassional `TransferStarted` after file rejection
 
 ---
 <br>


### PR DESCRIPTION
The issue stems from throttling logic which waits for a semaphore permit. After receiving the permit it emits a `Started` event without any checks.
I've introduced the `Terminal` state in the file event emitter which drops all events emitted after reaching the terminal state.