### PR TITLE
Emit transfer events from a mutex-protected closed structure

### DIFF
--- a/drop-transfer/src/check.rs
+++ b/drop-transfer/src/check.rs
@@ -43,9 +43,7 @@ pub(crate) fn spawn(
                         Err(err) => {
                             warn!(logger, "Failed to clear incoming transfer: {err:?}");
                         }
-                        Ok(false) => state
-                            .emit_event(crate::Event::IncomingTransferCanceled(xfer.clone(), true)),
-                        _ => (),
+                        Ok(state) => state.xfer_events.cancel(true).await,
                     }
 
                     break;

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -31,7 +31,7 @@ pub trait HandlerLoop {
     async fn issue_reject(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
     async fn issue_failure(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
 
-    async fn on_close(&mut self, by_peer: bool);
+    async fn on_close(&mut self);
     async fn on_text_msg(
         &mut self,
         ws: &mut WebSocket,

--- a/drop-transfer/src/ws/client/v2.rs
+++ b/drop-transfer/src/ws/client/v2.rs
@@ -275,18 +275,9 @@ impl<const PING: bool> handler::HandlerLoop for HandlerLoop<'_, PING> {
         Ok(())
     }
 
-    async fn on_close(&mut self, by_peer: bool) {
-        debug!(self.logger, "ClientHandler::on_close(by_peer: {})", by_peer);
-
+    async fn on_close(&mut self) {
+        debug!(self.logger, "ClientHandler::on_close()");
         self.on_stop().await;
-
-        if by_peer {
-            self.state
-                .emit_event(crate::Event::OutgoingTransferCanceled(
-                    self.xfer.clone(),
-                    by_peer,
-                ));
-        }
     }
 
     async fn on_text_msg(

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -324,18 +324,9 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn on_close(&mut self, by_peer: bool) {
-        debug!(self.logger, "ClientHandler::on_close(by_peer: {})", by_peer);
-
+    async fn on_close(&mut self) {
+        debug!(self.logger, "ClientHandler::on_close()");
         self.on_stop().await;
-
-        if by_peer {
-            self.state
-                .emit_event(crate::Event::OutgoingTransferCanceled(
-                    self.xfer.clone(),
-                    by_peer,
-                ));
-        }
     }
 
     async fn on_text_msg(

--- a/drop-transfer/src/ws/client/v6.rs
+++ b/drop-transfer/src/ws/client/v6.rs
@@ -340,18 +340,9 @@ impl handler::HandlerLoop for HandlerLoop<'_> {
         Ok(())
     }
 
-    async fn on_close(&mut self, by_peer: bool) {
-        debug!(self.logger, "ClientHandler::on_close(by_peer: {})", by_peer);
-
+    async fn on_close(&mut self) {
+        debug!(self.logger, "ClientHandler::on_close()");
         self.on_stop().await;
-
-        if by_peer {
-            self.state
-                .emit_event(crate::Event::OutgoingTransferCanceled(
-                    self.xfer.clone(),
-                    by_peer,
-                ));
-        }
     }
 
     async fn on_text_msg(


### PR DESCRIPTION
This allows for checks if the transfer is ongoing
and in case of closed transfers suppress event emission.