### PR TITLE
Disallow filename characters illega in FAT and EXT filesystems

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ### UNRELEASED
 ---
 * Add `MOOSE_RELEASE_TAG` file
+* Broaden the set of illegal filename characters to encompass FAT and EXT filesystems
 
 ---
 <br>


### PR DESCRIPTION
As discussed in the issue ticket, we should ban characters illegal in both FAT and EXT filesystems