### PR TITLE
Add a separate status for permissions error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ---
 * Add `MOOSE_RELEASE_TAG` file
 * Broaden the set of illegal filename characters to encompass FAT and EXT filesystems
+* Add `PermissionDenied` (40) status code
 
 ---
 <br>

--- a/drop-core/src/status.rs
+++ b/drop-core/src/status.rs
@@ -24,6 +24,7 @@ pub enum Status {
     EmptyTransfer = 37,
     ConnectionClosedByPeer = 38,
     TooManyRequests = 39,
+    PermissionDenied = 40,
 }
 
 impl serde::Serialize for Status {

--- a/drop-transfer/src/error.rs
+++ b/drop-transfer/src/error.rs
@@ -1,4 +1,4 @@
-use std::io::Error as IoError;
+use std::io::{Error as IoError, ErrorKind};
 
 use drop_analytics::MOOSE_STATUS_SUCCESS;
 use tokio_tungstenite::tungstenite;
@@ -85,7 +85,14 @@ impl From<&Error> for u32 {
             Error::BadTransfer => Status::BadTransfer as _,
             Error::BadTransferState(_) => Status::BadTransferState as _,
             Error::BadFileId => Status::BadFileId as _,
-            Error::Io(_) => Status::IoError as _,
+            Error::Io(io) => {
+                let status = match io.kind() {
+                    ErrorKind::PermissionDenied => Status::PermissionDenied,
+                    _ => Status::IoError,
+                };
+
+                status as _
+            }
             Error::DirectoryNotExpected => Status::BadFile as _,
             Error::TransferLimitsExceeded => Status::TransferLimitsExceeded as _,
             Error::MismatchedSize => Status::MismatchedSize as _,

--- a/test/drop_test/error.py
+++ b/test/drop_test/error.py
@@ -25,6 +25,7 @@ class Error(IntEnum):
     EMPTY_TRANSFER = (37,)
     CONNECTION_CLOSED_BY_PEER = (38,)
     TOO_MANY_REQUESTS = (39,)
+    PERMISSION_DENIED = (40,)
 
 
 class ReturnCodes(IntEnum):

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4947,7 +4947,7 @@ scenarios = [
                         event.FinishFileFailed(
                             0,
                             FILES["testfile-small"].id,
-                            Error.IO,
+                            Error.PERMISSION_DENIED,
                             13,
                         )
                     ),


### PR DESCRIPTION
This commit captures permissions errors from the IO errors and reports them under a separate status code