### PR TITLE
Fix directories contents being merged in case their normalized name i…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Broaden the set of illegal filename characters to encompass FAT and EXT filesystems
 * Add `PermissionDenied` (40) status code
 * Fix a Windows bug where a permissions error is reported when there exists a folder with the same name as one of the transfer files in the destination
+* Fix directories contents being merged in case their normalized name is the same
 
 ---
 <br>

--- a/drop-transfer/src/file/id.rs
+++ b/drop-transfer/src/file/id.rs
@@ -101,6 +101,10 @@ impl FileSubPath {
         self.0.last().expect("Missing last path component")
     }
 
+    pub fn root(&self) -> &String {
+        self.0.first().expect("Missing first path component")
+    }
+
     pub fn from_path(path: impl AsRef<Path>) -> crate::Result<Self> {
         let vec = path
             .as_ref()

--- a/drop-transfer/src/file/mod.rs
+++ b/drop-transfer/src/file/mod.rs
@@ -145,11 +145,7 @@ impl File for FileToRecv {
 }
 
 impl FileToRecv {
-    pub fn new(file_id: FileId, mut subpath: FileSubPath, size: u64) -> Self {
-        subpath.iter_mut().for_each(|s| {
-            *s = crate::utils::normalize_filename(&*s);
-        });
-
+    pub fn new(file_id: FileId, subpath: FileSubPath, size: u64) -> Self {
         Self {
             file_id,
             subpath,

--- a/test/drop_test/config.py
+++ b/test/drop_test/config.py
@@ -137,6 +137,12 @@ FILES = {
     "utf8-testfile-\u5b81\u5BDF": TestFile(
         size=1 * 1024, id="iYHFSaSzwOXygOqayOaVNlF4cQUF2nyZyTzaIpnVau8"
     ),
+    "dir-with-invalid_char-</file-01": TestFile(
+        size=1 * 1024, id="ud9-3O_ym2LGed16d_kgAt3ocF2DSZ5C3beII-nG1MU"
+    ),
+    "dir-with-invalid_char->/file-01": TestFile(
+        size=1 * 1024, id="XIF2Dwumm68nQvewqbSkp5R5tAUGIIG_PscdNzBTnjw"
+    ),
 }
 
 DBFILES = {"26-1-corrupted.sqlite": b"this is a corrupted sqlite file"}

--- a/test/prepare_files.sh
+++ b/test/prepare_files.sh
@@ -13,6 +13,8 @@ mkdir -p /tmp/empty-dir
 mkdir -p /tmp/empty-dir/one
 mkdir -p /tmp/empty-dir/one/two
 mkdir -p /tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+mkdir -p /tmp/dir-with-invalid_char-\<
+mkdir -p /tmp/dir-with-invalid_char-\>
 
 # FILES dictionary
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt"
@@ -44,6 +46,8 @@ dd bs=10240K count=2 if=/dev/urandom of="/tmp/duplicate/testfile-big"
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/name/file-01"
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/different/name/file-02"
 dd bs=1024K count=1 if=/dev/urandom of="/tmp/utf8-testfile-宁察"
+dd bs=1024K count=1 if=/dev/urandom of="/tmp/dir-with-invalid_char-</file-01"
+dd bs=1024K count=1 if=/dev/urandom of="/tmp/dir-with-invalid_char->/file-01"
 
 # Create tiny jpeg and gif files to test analytics
 # "/tmp/tiny-jpeg.jpg"

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -4223,6 +4223,162 @@ scenarios = [
         },
     ),
     Scenario(
+        "scenario19-5",
+        "Send two dirs for which their name is going to be the same after normalization. Expect their contents in not merged",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.Start("DROP_PEER_REN"),
+                    # Wait for another peer to appear
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.NewTransfer(
+                        "DROP_PEER_STIMPY",
+                        [
+                            "/tmp/dir-with-invalid_char-<",
+                            "/tmp/dir-with-invalid_char->",
+                        ],
+                    ),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            "DROP_PEER_STIMPY",
+                            {
+                                event.File(
+                                    FILES["dir-with-invalid_char-</file-01"].id,
+                                    "dir-with-invalid_char-</file-01",
+                                    1048576,
+                                ),
+                                event.File(
+                                    FILES["dir-with-invalid_char->/file-01"].id,
+                                    "dir-with-invalid_char->/file-01",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.WaitRacy(
+                        [
+                            event.Start(0, FILES["dir-with-invalid_char-</file-01"].id),
+                            event.Start(0, FILES["dir-with-invalid_char->/file-01"].id),
+                            event.FinishFileUploaded(
+                                0,
+                                FILES["dir-with-invalid_char-</file-01"].id,
+                            ),
+                            event.FinishFileUploaded(
+                                0,
+                                FILES["dir-with-invalid_char->/file-01"].id,
+                            ),
+                        ]
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start("DROP_PEER_STIMPY"),
+                    action.WaitForOneOf(
+                        [
+                            event.Receive(
+                                0,
+                                "DROP_PEER_REN",
+                                {
+                                    event.File(
+                                        FILES["dir-with-invalid_char-</file-01"].id,
+                                        "dir-with-invalid_char-_/file-01",
+                                        1048576,
+                                    ),
+                                    event.File(
+                                        FILES["dir-with-invalid_char->/file-01"].id,
+                                        "dir-with-invalid_char-_(1)/file-01",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                            event.Receive(
+                                0,
+                                "DROP_PEER_REN",
+                                {
+                                    event.File(
+                                        FILES["dir-with-invalid_char-</file-01"].id,
+                                        "dir-with-invalid_char-_(1)/file-01",
+                                        1048576,
+                                    ),
+                                    event.File(
+                                        FILES["dir-with-invalid_char->/file-01"].id,
+                                        "dir-with-invalid_char-_/file-01",
+                                        1048576,
+                                    ),
+                                },
+                            ),
+                        ]
+                    ),
+                    action.Download(
+                        0,
+                        FILES["dir-with-invalid_char-</file-01"].id,
+                        "/tmp/received/19-5",
+                    ),
+                    action.Wait(
+                        event.Start(0, FILES["dir-with-invalid_char-</file-01"].id)
+                    ),
+                    action.WaitForOneOf(
+                        [
+                            event.FinishFileDownloaded(
+                                0,
+                                FILES["dir-with-invalid_char-</file-01"].id,
+                                "/tmp/received/19-5/dir-with-invalid_char-_/file-01",
+                            ),
+                            event.FinishFileDownloaded(
+                                0,
+                                FILES["dir-with-invalid_char-</file-01"].id,
+                                "/tmp/received/19-5/dir-with-invalid_char-_(1)/file-01",
+                            ),
+                        ]
+                    ),
+                    action.Download(
+                        0,
+                        FILES["dir-with-invalid_char->/file-01"].id,
+                        "/tmp/received/19-5",
+                    ),
+                    action.Wait(
+                        event.Start(0, FILES["dir-with-invalid_char->/file-01"].id)
+                    ),
+                    action.WaitForOneOf(
+                        [
+                            event.FinishFileDownloaded(
+                                0,
+                                FILES["dir-with-invalid_char->/file-01"].id,
+                                "/tmp/received/19-5/dir-with-invalid_char-_(1)/file-01",
+                            ),
+                            event.FinishFileDownloaded(
+                                0,
+                                FILES["dir-with-invalid_char->/file-01"].id,
+                                "/tmp/received/19-5/dir-with-invalid_char-_/file-01",
+                            ),
+                        ]
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File(
+                                "/tmp/received/19-5/dir-with-invalid_char-_/file-01",
+                                1048576,
+                            ),
+                            action.File(
+                                "/tmp/received/19-5/dir-with-invalid_char-_(1)/file-01",
+                                1048576,
+                            ),
+                        ],
+                    ),
+                    action.CancelTransferRequest([0]),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
         "scenario20",
         "Send multiple files within a single transfer",
         {


### PR DESCRIPTION
…s the same

This PR fixes the simple case when two directories `</a` and `>/b` after normalization are merged into one directory `_/a` and `_/b`