### PR TITLE
Sender and receiver have mismatched file states after transfer cancellation while offline

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 * Fix a Windows bug where a permissions error is reported when there exists a folder with the same name as one of the transfer files in the destination
 * Fix directories contents being merged in case their normalized name is the same
 * Add `TransferPending` event emitted after successful `norddrop_download()` call
+* Fix occasional sender's state is not completed and equal to the receiver's state when canceling the transfer
 
 ---
 <br>

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -698,6 +698,7 @@ class AssertTransfers(Action):
 
     async def run(self, drop: ffi.Drop):
         transfers = json.loads(drop.get_transfers_since(self._since_timestamp))
+        print(f"Transfers JSON:\n{json.dumps(transfers, indent=2)}")
 
         if len(transfers) != len(self._expected_outputs):
             raise Exception(

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -7460,7 +7460,7 @@ scenarios = [
     ),
     Scenario(
         "scenario29-14",
-        "Send a bunch of files and wait until some of them arrive. Then stop the sender and cancel the transfer on receiver. Expect the file states match on both sides",
+        "Send a bunch of files and wait until some of them arrive. Stop the sender and cancel the transfer on the receiver. Then, start the sender again and wait for the state to sync. Expect the file states to match on both sides",
         # TODO(msz): We should compare the results of `transfer_since()`
         # for both peers. However we don't have such posibitlity in our test
         # framework to test things across containers


### PR DESCRIPTION
When issuing cancel from the receiver while the sender is offline, sometimes the state of files is mismatched for peers.
The solution is to flush the changes to the sender and only then issue the cancel request