### PR TITLE
Introduce uniffi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ target/
 *.sqlite-wal
 /drop-storage/.env
 default*.profraw
+test/bindings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +119,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +215,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +270,38 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34637b3140142bdf929fb439e8aa4ebad7651ebf7b1080b3930aa16ac1459ff"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -248,6 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d04704f56c2cde07f43e8e2c154b43f216dc5c92fc98ada720177362f953b956"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -260,6 +361,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -555,6 +668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +772,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc16584ff22b460a382b7feec54b23d2908d858152e5739a120b949293bd74e"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,6 +810,23 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "goblin"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
 
 [[package]]
 name = "governor"
@@ -983,6 +1135,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "loom"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "pin-utils",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1178,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1031,6 +1212,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nonzero_ext"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,10 +1244,21 @@ dependencies = [
  "serde_json",
  "slog",
  "tokio",
+ "uniffi",
  "url",
  "uuid",
  "winapi",
  "winresource",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -1103,6 +1305,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "oneshot"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
+dependencies = [
+ "loom",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1341,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "percent-encoding"
@@ -1168,6 +1391,12 @@ name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "platforms"
@@ -1257,6 +1486,50 @@ dependencies = [
  "redox_syscall 0.2.16",
  "thiserror",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rusqlite"
@@ -1356,10 +1629,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scroll"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -1447,6 +1743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1759,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -1513,6 +1824,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1531,6 +1848,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1605,6 +1928,17 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1749,6 +2083,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
@@ -1795,7 +2138,19 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1805,6 +2160,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1860,12 +2245,155 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "uniffi"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+]
+
+[[package]]
+name = "uniffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "uniffi",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata",
+ "clap",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck",
+ "once_cell",
+ "paste",
+ "serde",
+ "textwrap",
+ "toml 0.5.11",
+ "uniffi_meta",
+ "uniffi_testing",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_checksum_derive"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "log",
+ "once_cell",
+ "oneshot",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "bincode",
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml 0.5.11",
+ "uniffi_build",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.3.1+v0.25.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "anyhow",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
 ]
 
 [[package]]
@@ -1901,6 +2429,12 @@ dependencies = [
  "getrandom",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -2024,6 +2558,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
+name = "weedle2"
+version = "4.0.0"
+source = "git+https://github.com/NordSecurity/uniffi-rs?tag=v0.3.1+v0.25.0#1a5dc527165589456c3d7233107917e065192b03"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,7 +2686,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e2aaaf8cfa92078c0c0375423d631f82f2f57979c2884fdd5f604a11e45329"
 dependencies = [
- "toml",
+ "toml 0.7.8",
  "version_check",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ members = [
     "drop-config",
     "drop-storage",
     "drop-core",
-    "norddrop",
+    "norddrop", 
+    "uniffi-bindgen",
 ]
 
 [workspace.dependencies]

--- a/norddrop/Cargo.toml
+++ b/norddrop/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
+uniffi = { git = "https://github.com/NordSecurity/uniffi-rs", tag = "v0.3.1+v0.25.0" }
+
 uuid = { workspace = true }
 libc = { workspace = true }
 serde = { workspace = true }
@@ -27,6 +29,7 @@ drop-storage = { version = "1.0", path = "../drop-storage" }
 [build-dependencies]
 cc = "1.0.83"
 winresource = "0.1.17"
+uniffi = { git = "https://github.com/NordSecurity/uniffi-rs", tag = "v0.3.1+v0.25.0", features = ["build"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["netioapi", "ntdef", "winerror", "ws2def"] }

--- a/norddrop/build.rs
+++ b/norddrop/build.rs
@@ -60,6 +60,8 @@ fn create_winres(version: &str) -> Result<(), Box<dyn Error>> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    uniffi::generate_scaffolding("src/norddrop.udl")?;
+
     let langs: HashSet<&str> = HashSet::from_iter(["GO", "JAVA", "CS"].iter().copied());
     let ffis = env::var("FFI").unwrap_or_default();
 

--- a/norddrop/src/device/utils.rs
+++ b/norddrop/src/device/utils.rs
@@ -1,9 +1,9 @@
 use std::time::SystemTime;
 
 /// Get the current system timestamp in milliseconds, used for event timestamps
-pub fn current_timestamp() -> u64 {
+pub fn current_timestamp() -> i64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis() as u64
+        .as_millis() as i64
 }

--- a/norddrop/src/ffi/mod.rs
+++ b/norddrop/src/ffi/mod.rs
@@ -1,4 +1,5 @@
 pub mod types;
+pub mod uni;
 mod version;
 
 use std::{
@@ -612,7 +613,10 @@ pub extern "C" fn norddrop_get_transfers_since(
 
         let transfers = dev.transfers_since(since_timestamp)?;
 
-        Ok::<Vec<u8>, norddrop_result>(transfers.into_bytes())
+        let json = serde_json::to_string(&transfers)
+            .map_err(|_| norddrop_result::NORDDROP_RES_JSON_PARSE)?;
+
+        Ok::<Vec<u8>, norddrop_result>(json.into_bytes())
     });
 
     match res {

--- a/norddrop/src/ffi/types.rs
+++ b/norddrop/src/ffi/types.rs
@@ -1,4 +1,7 @@
-use std::ffi::{c_int, c_void};
+use std::{
+    ffi::{c_int, c_void},
+    fmt,
+};
 
 use libc::c_char;
 use slog::Level;
@@ -48,6 +51,14 @@ pub enum norddrop_result {
     NORDDROP_RES_DB_ERROR = 11,
 }
 
+impl fmt::Display for norddrop_result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for norddrop_result {}
+
 pub use norddrop_result::*;
 
 #[allow(non_camel_case_types)]
@@ -73,9 +84,9 @@ pub type norddrop_event_fn = unsafe extern "C" fn(*mut c_void, *const c_char);
 pub struct norddrop_event_cb {
     /// Context to pass to callback.
     /// User must ensure safe access of this var from multitheaded context.
-    ctx: *mut c_void,
+    pub ctx: *mut c_void,
     /// Function to be called
-    cb: norddrop_event_fn,
+    pub cb: norddrop_event_fn,
 }
 
 impl norddrop_event_cb {

--- a/norddrop/src/ffi/uni.rs
+++ b/norddrop/src/ffi/uni.rs
@@ -1,0 +1,479 @@
+use std::{ffi::CStr, sync::Mutex};
+
+use drop_auth::SecretKey;
+use libc::{c_char, c_int, c_void};
+use slog::{o, Drain};
+
+use crate::{
+    device::{types, NordDropFFI},
+    ffi, Event,
+};
+
+pub type Result<T> = std::result::Result<T, crate::Error>;
+
+pub trait EventCallback: Send + Sync {
+    fn on_event(&self, event: Event);
+}
+
+pub trait Logger: Send + Sync {
+    fn on_log(&self, level: crate::LogLevel, msg: String);
+    fn level(&self) -> crate::LogLevel;
+}
+
+pub trait KeyStore: Send + Sync {
+    fn on_pubkey(&self, peer: String) -> Option<Vec<u8>>;
+    fn privkey(&self) -> Vec<u8>;
+}
+
+pub trait FdResolver: Send + Sync {
+    fn on_fd(&self, content_uri: String) -> Option<i32>;
+}
+
+pub struct NordDrop {
+    dev: Mutex<NordDropFFI>,
+    _cb: Box<CbContext>,
+    #[cfg(unix)]
+    fd_resolv: Mutex<Option<Box<FdResolverContext>>>,
+}
+
+#[cfg(unix)]
+struct FdResolverContext {
+    resolver: Box<dyn FdResolver>,
+}
+
+struct CbContext {
+    event_callback: Box<dyn EventCallback>,
+    key_store: Box<dyn KeyStore>,
+    logger: Box<dyn Logger>,
+}
+
+pub enum TransferDescriptor {
+    Path {
+        path: String,
+    },
+    Fd {
+        filename: String,
+        content_uri: String,
+        fd: Option<i32>,
+    },
+}
+
+pub enum TransferStateKind {
+    Cancel { by_peer: bool },
+    Failed { status: i64 },
+}
+
+pub struct TransferState {
+    pub created_at: i64,
+    pub kind: TransferStateKind,
+}
+
+pub enum IncomingPathStateKind {
+    Pending { base_dir: String },
+    Started { bytes_received: u64 },
+    Failed { status: i64, bytes_received: u64 },
+    Completed { final_path: String },
+    Rejected { by_peer: bool, bytes_received: u64 },
+    Paused { bytes_received: u64 },
+}
+
+pub struct IncomingPathState {
+    pub created_at: i64,
+    pub kind: IncomingPathStateKind,
+}
+
+pub struct IncomingPath {
+    pub file_id: String,
+    pub relative_path: String,
+    pub bytes: u64,
+    pub bytes_received: u64,
+    pub states: Vec<IncomingPathState>,
+}
+
+pub enum OutgoingPathStateKind {
+    Started { bytes_sent: u64 },
+    Failed { status: i64, bytes_sent: u64 },
+    Completed,
+    Rejected { by_peer: bool, bytes_sent: u64 },
+    Paused { bytes_sent: u64 },
+}
+
+pub struct OutgoingPathState {
+    pub created_at: i64,
+    pub kind: OutgoingPathStateKind,
+}
+
+pub enum OutgoingFileSource {
+    BasePath { base_path: String },
+    ContentUri { uri: String },
+}
+
+pub struct OutgoingPath {
+    pub file_id: String,
+    pub relative_path: String,
+    pub bytes: u64,
+    pub bytes_sent: u64,
+    pub source: OutgoingFileSource,
+    pub states: Vec<OutgoingPathState>,
+}
+
+pub enum TransferKind {
+    Incoming { paths: Vec<IncomingPath> },
+    Outgoing { paths: Vec<OutgoingPath> },
+}
+
+pub struct TransferInfo {
+    pub id: String,
+    pub created_at: i64,
+    pub peer: String,
+    pub states: Vec<TransferState>,
+    pub kind: TransferKind,
+}
+
+impl NordDrop {
+    pub fn new(
+        event_callback: Box<dyn EventCallback>,
+        key_store: Box<dyn KeyStore>,
+        logger: Box<dyn Logger>,
+    ) -> Result<Self> {
+        // TODO(msz): remove indirection
+
+        let mut cb = Box::new(CbContext {
+            event_callback,
+            key_store,
+            logger,
+        });
+
+        unsafe extern "C" fn call_on_event(ctx: *mut c_void, ev: *const c_char) {
+            let ctx = ctx as *const CbContext;
+            (*ctx).event_callback.on_event(
+                serde_json::from_str(CStr::from_ptr(ev as _).to_str().expect("Invalid C string"))
+                    .expect("Failed to deserialize event"),
+            );
+        }
+
+        let event_callback_c = ffi::norddrop_event_cb {
+            ctx: cb.as_mut() as *mut _ as *mut _,
+            cb: call_on_event,
+        };
+
+        unsafe extern "C" fn call_on_pubkey(
+            ctx: *mut c_void,
+            peer: *const c_char,
+            pubkey: *mut c_char,
+        ) -> c_int {
+            let ctx = ctx as *const CbContext;
+            let key = (*ctx).key_store.on_pubkey(
+                CStr::from_ptr(peer as _)
+                    .to_str()
+                    .expect("Invalid C string")
+                    .to_owned(),
+            );
+            match key {
+                Some(key) => {
+                    if key.len() != drop_auth::PUBLIC_KEY_LENGTH {
+                        1
+                    } else {
+                        pubkey.copy_from_nonoverlapping(
+                            key.as_ptr().cast(),
+                            drop_auth::PUBLIC_KEY_LENGTH,
+                        );
+                        0
+                    }
+                }
+                None => 1,
+            }
+        }
+
+        let pubkey_callback_c = ffi::norddrop_pubkey_cb {
+            ctx: cb.as_mut() as *mut _ as *mut _,
+            cb: call_on_pubkey,
+        };
+
+        unsafe extern "C" fn call_on_log(
+            ctx: *mut c_void,
+            lvl: crate::LogLevel,
+            msg: *const c_char,
+        ) {
+            let ctx = ctx as *const CbContext;
+            (*ctx).logger.on_log(
+                lvl,
+                CStr::from_ptr(msg as _)
+                    .to_str()
+                    .expect("Invalid C string")
+                    .to_owned(),
+            );
+        }
+
+        let logger_callback_c = ffi::norddrop_logger_cb {
+            ctx: cb.as_mut() as *mut _ as *mut _,
+            cb: call_on_log,
+        };
+
+        let logger = slog::Logger::root(
+            logger_callback_c
+                .filter_level(cb.logger.level().into())
+                .fuse(),
+            o!(),
+        );
+
+        let privkey = cb.key_store.privkey();
+        if privkey.len() != drop_auth::SECRET_KEY_LENGTH {
+            return Err(crate::Error::NORDDROP_RES_INVALID_PRIVKEY);
+        }
+        let mut privkey_buf = [0u8; drop_auth::SECRET_KEY_LENGTH];
+        privkey_buf.copy_from_slice(&privkey);
+        let privkey = SecretKey::from(privkey_buf);
+
+        let dev = NordDropFFI::new(event_callback_c, pubkey_callback_c, privkey, logger)?;
+
+        Ok(Self {
+            dev: Mutex::new(dev),
+            _cb: cb,
+            fd_resolv: Mutex::new(None),
+        })
+    }
+
+    #[cfg(not(unix))]
+    pub fn set_fd_resolver(&self, resolver: Box<dyn FdResolver>) -> Result<()> {
+        Err(crate::Error::NORDDROP_RES_ERROR)
+    }
+
+    #[cfg(unix)]
+    pub fn set_fd_resolver(&self, resolver: Box<dyn FdResolver>) -> Result<()> {
+        unsafe extern "C" fn call_on_fd(ctx: *mut c_void, uri: *const c_char) -> c_int {
+            let ctx = ctx as *const FdResolverContext;
+            (*ctx)
+                .resolver
+                .on_fd(
+                    CStr::from_ptr(uri as _)
+                        .to_str()
+                        .expect("Invalid C string")
+                        .to_owned(),
+                )
+                .unwrap_or(-1)
+        }
+
+        let mut ctx = Box::new(FdResolverContext { resolver });
+
+        let fd_callback_c = ffi::types::norddrop_fd_cb {
+            ctx: ctx.as_mut() as *mut _ as *mut _,
+            cb: call_on_fd,
+        };
+
+        self.dev
+            .lock()
+            .expect("Poisoned lock")
+            .set_fd_resolver_callback(fd_callback_c)?;
+
+        *self.fd_resolv.lock().expect("Poisoned lock") = Some(ctx);
+
+        Ok(())
+    }
+
+    pub fn start(&self, addr: &str, config: crate::Config) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").start(
+            addr,
+            &serde_json::to_string(&config).expect("Failed to serialize JSON"),
+        )
+    }
+
+    pub fn stop(&self) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").stop()
+    }
+
+    pub fn purge_transfers(&self, transfer_ids: &[String]) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").purge_transfers(
+            &serde_json::to_string(transfer_ids).expect("Failed to serialize JSON"),
+        )
+    }
+
+    pub fn purge_transfers_until(&self, until: i64) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        // The `device` function takes in seconds as an argument and this function takes
+        // in ms
+        self.dev
+            .lock()
+            .expect("Poisoned lock")
+            .purge_transfers_until(until / 100)
+    }
+
+    pub fn transfers_since(&self, since: i64) -> Result<Vec<TransferInfo>> {
+        // TODO(msz): remove indirection
+
+        // The `device` function takes in seconds as an argument and this function takes
+        // in ms
+        let infos = self
+            .dev
+            .lock()
+            .expect("Poisoned lock")
+            .transfers_since(since / 100)?;
+
+        let xfers =infos.into_iter().map(|info| {
+            let kind = match info.transfer_type {
+                drop_storage::types::DbTransferType::Incoming(paths) => {
+                    TransferKind::Incoming {
+                         paths: paths.into_iter().map(|path| IncomingPath {
+                            file_id: path.file_id,
+                            relative_path: path.relative_path,
+                            bytes: path.bytes as _,
+                            bytes_received: path.bytes_received as _,
+                            states: path.states.into_iter().map(|state| {
+                                let kind = match state.data {
+                                    drop_storage::types::IncomingPathStateEventData::Pending { base_dir } => IncomingPathStateKind::Pending { base_dir },
+                                    drop_storage::types::IncomingPathStateEventData::Started { bytes_received } => IncomingPathStateKind::Started { bytes_received : bytes_received as _ },
+                                    drop_storage::types::IncomingPathStateEventData::Failed { status_code, bytes_received } => IncomingPathStateKind::Failed { status: status_code, bytes_received: bytes_received as _  },
+                                    drop_storage::types::IncomingPathStateEventData::Completed { final_path } => IncomingPathStateKind::Completed { final_path },
+                                    drop_storage::types::IncomingPathStateEventData::Rejected { by_peer, bytes_received } => IncomingPathStateKind::Rejected { by_peer, bytes_received: bytes_received as _  },
+                                    drop_storage::types::IncomingPathStateEventData::Paused { bytes_received } => IncomingPathStateKind::Paused { bytes_received: bytes_received as _ },
+                                };
+
+                                IncomingPathState { created_at: state.created_at.timestamp_millis(), kind }
+                                }).collect(),
+                            }).collect()
+                         }
+                },
+                drop_storage::types::DbTransferType::Outgoing(paths) => TransferKind::Outgoing {
+                     paths: paths.into_iter().map(|path| OutgoingPath {
+                            file_id: path.file_id,
+                            relative_path: path.relative_path,
+                            bytes: path.bytes as _,
+                            bytes_sent: path.bytes_sent as _,
+                            source: match path.content_uri {
+                                Some(uri) => OutgoingFileSource::ContentUri{uri: uri.to_string()},
+                                None => OutgoingFileSource::BasePath{base_path: path.base_path.and_then(|p|p.to_str().map(|s| s.to_owned())).unwrap_or_default()},
+                            },
+                            states: path.states.into_iter().map(|state| {
+                                let kind = match state.data {
+                                    drop_storage::types::OutgoingPathStateEventData::Started { bytes_sent } => OutgoingPathStateKind::Started{ bytes_sent: bytes_sent as _ },
+                                    drop_storage::types::OutgoingPathStateEventData::Failed { status_code, bytes_sent } => OutgoingPathStateKind::Failed{ status: status_code, bytes_sent: bytes_sent as _  },
+                                    drop_storage::types::OutgoingPathStateEventData::Completed => OutgoingPathStateKind::Completed,
+                                    drop_storage::types::OutgoingPathStateEventData::Rejected { by_peer, bytes_sent } => OutgoingPathStateKind::Rejected{ by_peer, bytes_sent: bytes_sent as _  },
+                                    drop_storage::types::OutgoingPathStateEventData::Paused { bytes_sent } => OutgoingPathStateKind::Paused{ bytes_sent: bytes_sent as _  },
+                                };
+                                OutgoingPathState{created_at: state.created_at.timestamp_millis(), kind}
+                            }).collect(),
+                    }).collect()
+                     }
+            };
+
+            TransferInfo  {
+                id: info.id.to_string(),
+                created_at: info.created_at.timestamp_millis(),
+                peer: info.peer_id,
+                        states: info.states.into_iter().map(|state| TransferState {
+                            created_at: state.created_at.timestamp_millis(),
+                            kind: match state.data {
+                                drop_storage::types::TransferStateEventData::Cancel { by_peer } => TransferStateKind::Cancel { by_peer  },
+                                drop_storage::types::TransferStateEventData::Failed { status_code } => TransferStateKind::Failed { status:status_code  },
+                            },
+                }).collect(),
+                kind,
+            }
+        }).collect();
+
+        Ok(xfers)
+    }
+
+    pub fn new_transfer(&self, peer: &str, descriptors: &[TransferDescriptor]) -> Result<String> {
+        // TODO(msz): remove indirection
+
+        let descrs: Vec<_> = descriptors
+            .iter()
+            .map(|td| {
+                let desc = match td {
+                    TransferDescriptor::Path { path } => types::TransferDescriptor {
+                        path: path.clone().into(),
+                        content_uri: None,
+                        fd: None,
+                    },
+                    TransferDescriptor::Fd {
+                        filename,
+                        content_uri,
+                        fd,
+                    } => types::TransferDescriptor {
+                        path: filename.clone().into(),
+                        content_uri: Some(
+                            content_uri
+                                .parse()
+                                .map_err(|_| crate::Error::NORDDROP_RES_INVALID_STRING)?,
+                        ),
+                        fd: *fd,
+                    },
+                };
+                Ok(desc)
+            })
+            .collect::<Result<_>>()?;
+
+        let transfer_id = self.dev.lock().expect("Poisoned lock").new_transfer(
+            peer,
+            &serde_json::to_string(&descrs).expect("Failed to serialize JSON"),
+        )?;
+
+        Ok(transfer_id.to_string())
+    }
+
+    pub fn finish_transfer(&self, transfer_id: &str) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").cancel_transfer(
+            transfer_id
+                .parse()
+                .map_err(|_| crate::Error::NORDDROP_RES_INVALID_STRING)?,
+        )
+    }
+
+    pub fn remove_file(&self, transfer_id: &str, file_id: &str) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev
+            .lock()
+            .expect("Poisoned lock")
+            .remove_transfer_file(
+                transfer_id
+                    .parse()
+                    .map_err(|_| crate::Error::NORDDROP_RES_INVALID_STRING)?,
+                file_id,
+            )
+    }
+
+    pub fn download_file(&self, transfer_id: &str, file_id: &str, destination: &str) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").download(
+            transfer_id
+                .parse()
+                .map_err(|_| crate::Error::NORDDROP_RES_INVALID_STRING)?,
+            file_id.to_string(),
+            destination.to_string(),
+        )
+    }
+
+    pub fn reject_file(&self, transfer_id: &str, file_id: &str) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").reject_file(
+            transfer_id
+                .parse()
+                .map_err(|_| crate::Error::NORDDROP_RES_INVALID_STRING)?,
+            file_id.to_string(),
+        )
+    }
+
+    pub fn network_refresh(&self) -> Result<()> {
+        // TODO(msz): remove indirection
+
+        self.dev.lock().expect("Poisoned lock").network_refresh()
+    }
+}
+
+pub fn version() -> String {
+    env!("DROP_VERSION").to_string()
+}

--- a/norddrop/src/lib.rs
+++ b/norddrop/src/lib.rs
@@ -4,3 +4,11 @@ pub mod ffi;
 
 /// cbindgen:ignore
 pub mod device;
+
+uniffi::include_scaffolding!("norddrop");
+
+pub use device::types::{Config, Event, File, FinishEvent, Status};
+pub use ffi::{
+    types::{norddrop_log_level as LogLevel, norddrop_result as Error},
+    uni::*,
+};

--- a/norddrop/src/norddrop.udl
+++ b/norddrop/src/norddrop.udl
@@ -1,0 +1,218 @@
+[Error]
+enum Error {
+    "NORDDROP_RES_OK",
+    "NORDDROP_RES_ERROR",
+    "NORDDROP_RES_INVALID_STRING",
+    "NORDDROP_RES_BAD_INPUT",
+    "NORDDROP_RES_JSON_PARSE",
+    "NORDDROP_RES_TRANSFER_CREATE",
+    "NORDDROP_RES_NOT_STARTED",
+    "NORDDROP_RES_ADDR_IN_USE",
+    "NORDDROP_RES_INSTANCE_START",
+    "NORDDROP_RES_INSTANCE_STOP",
+    "NORDDROP_RES_INVALID_PRIVKEY",
+    "NORDDROP_RES_DB_ERROR",
+};
+
+dictionary Config {
+    u64 dir_depth_limit;
+    u64 transfer_file_limit;
+    string moose_event_path;
+    boolean moose_prod;
+    string storage_path;
+    u64? checksum_events_size_threshold;
+    u32 connection_retries;
+};
+
+enum LogLevel {
+    "NORDDROP_LOG_CRITICAL",
+    "NORDDROP_LOG_ERROR",
+    "NORDDROP_LOG_WARNING",
+    "NORDDROP_LOG_INFO",
+    "NORDDROP_LOG_DEBUG",
+    "NORDDROP_LOG_TRACE",
+};
+
+callback interface Logger {
+	void on_log(LogLevel level, string msg);
+	LogLevel level();
+};
+
+callback interface KeyStore {
+	bytes? on_pubkey(string peer);
+	bytes privkey();
+};
+
+callback interface FdResolver {
+	i32? on_fd(string content_uri);
+};
+
+[Enum]
+interface TransferDescriptor {
+	Path(string path);
+	Fd(string filename, string content_uri, i32? fd);
+};
+
+dictionary Status {
+    u32 status;
+    i32? os_error_code;
+};
+
+dictionary File {
+	string id;
+	string path;
+	u64 size;
+};
+
+[Enum]
+interface FinishEvent {
+    TransferCanceled(boolean by_peer);
+    FileDownloaded(string file_id, string final_path);
+    FileUploaded(string file_id);
+    FileFailed(string file_id, Status status);
+    TransferFailed(Status status);
+    FileRejected(string file_id, boolean by_peer);
+};
+
+[Enum]
+interface Event {
+	RequestReceived(string peer, string transfer_id, sequence<File> files, i64 timestamp);
+	RequestQueued(string peer, string transfer_id, sequence<File> files, i64 timestamp);
+	TransferStarted(string transfer_id, string file_id, u64 transfered, i64 timestamp);
+	TransferProgress(string transfer_id, string file_id, u64 transfered, i64 timestamp);
+	TransferFinished(string transfer_id, FinishEvent data, i64 timestamp);
+	RuntimeError(u32 status, i64 timestamp);
+	TransferPaused(string transfer_id, string file_id, i64 timestamp);
+	TransferThrottled(string transfer_id, string file_id, u64 transfered, i64 timestamp);
+	TransferDeferred(string transfer_id, string peer, Status status);
+	TransferPending(string transfer_id, string file_id);
+	ChecksumStarted(string transfer_id, string file_id, u64 size, i64 timestamp);
+	ChecksumFinished(string transfer_id, string file_id, i64 timestamp);
+	ChecksumProgress(string transfer_id, string file_id, u64 bytes_checksummed, i64 timestamp);
+};
+
+callback interface EventCallback {
+	void on_event(Event event);
+};
+
+[Enum]
+interface TransferStateKind {
+	Cancel(boolean by_peer);
+	Failed(i64 status);
+};
+
+dictionary TransferState {
+	i64 created_at;
+	TransferStateKind kind;
+};
+
+[Enum]
+interface IncomingPathStateKind {
+    Pending(string base_dir);
+    Started(u64 bytes_received);
+    Failed(i64 status, u64 bytes_received);
+    Completed(string final_path);
+    Rejected(boolean by_peer, u64 bytes_received);
+    Paused(u64 bytes_received);
+};
+
+dictionary IncomingPathState {
+    i64 created_at;
+    IncomingPathStateKind kind;
+};
+
+dictionary IncomingPath {
+    string file_id;
+    string relative_path;
+    u64 bytes;
+    u64 bytes_received;
+    sequence<IncomingPathState> states;
+};
+
+[Enum]
+interface OutgoingPathStateKind {
+    Started(u64 bytes_sent);
+    Failed(i64 status, u64 bytes_sent);
+    Completed();
+    Rejected(boolean by_peer, u64 bytes_sent);
+    Paused(u64 bytes_sent);
+};
+
+dictionary OutgoingPathState {
+    i64 created_at;
+    OutgoingPathStateKind kind;
+};
+
+[Enum]
+interface OutgoingFileSource {
+    BasePath(string base_path);
+    ContentUri(string uri);
+};
+
+dictionary OutgoingPath {
+    string file_id;
+    string relative_path;
+    u64 bytes;
+    u64 bytes_sent;
+    OutgoingFileSource source;
+    sequence<OutgoingPathState> states;
+};
+
+[Enum]
+interface TransferKind {
+    Incoming(sequence<IncomingPath> paths);
+    Outgoing(sequence<OutgoingPath> paths);
+};
+
+dictionary TransferInfo {
+    string id;
+    i64 created_at;
+    string peer;
+    sequence<TransferState> states;
+    TransferKind kind;
+};
+
+interface NordDrop {
+	[Throws=Error]
+	constructor(EventCallback event_cb, KeyStore key_store, Logger logger);
+
+	[Throws=Error]
+	void start([ByRef] string addr, Config config);
+
+	[Throws=Error]
+	void stop();
+
+	[Throws=Error]
+	void purge_transfers([ByRef] sequence<string> transfer_ids);
+
+	[Throws=Error]
+	void purge_transfers_until(i64 until);
+
+	[Throws=Error]
+	sequence<TransferInfo> transfers_since(i64 since);
+
+	[Throws=Error]
+	string new_transfer([ByRef] string peer, [ByRef] sequence<TransferDescriptor> descriptors);
+
+	[Throws=Error]
+	void finish_transfer([ByRef] string transfer_id);
+
+	[Throws=Error]
+	void remove_file([ByRef] string transfer_id, [ByRef] string file_id);
+
+	[Throws=Error]
+	void download_file([ByRef] string transfer_id, [ByRef] string file_id, [ByRef] string destination);
+
+	[Throws=Error]
+	void reject_file([ByRef] string transfer_id, [ByRef] string file_id);
+
+	[Throws=Error]
+	void network_refresh();
+
+	[Throws=Error]
+	void set_fd_resolver(FdResolver resolver);
+};
+
+namespace norddrop {
+	string version();
+};

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,7 @@ SCENARIOS_AT_ONCE ?= 10
 TESTCASE_TIMEOUT ?= 100
 
 .DEFAULT_GOAL := test
-.PHONY: build build-coverage test coverage clean docker-prepare build-image
+.PHONY: build build-coverage test coverage clean docker-prepare build-image gen-bindings
 
 $(LIB): $(shell find ../ -type f \( -name '*.rs' -o -name '*.toml' -o -name '*.sql' -o -name '*.lock' \))
 	cargo build $(FEATURES)
@@ -28,8 +28,8 @@ docker-prepare:
 	docker container prune -f
 
 # Test the project
-test: $(LIB) build-image docker-prepare
-	LIB_PATH=$(LIB_DOCKER) ./runner.py --testcase-timeout=$(TESTCASE_TIMEOUT) --scenarios-at-once=$(SCENARIOS_AT_ONCE)
+test: $(LIB) build-image docker-prepare gen-bindings
+	./runner.py --testcase-timeout=$(TESTCASE_TIMEOUT) --scenarios-at-once=$(SCENARIOS_AT_ONCE)
 
 # Generate and view coverage report
 coverage: docker-prepare build-coverage
@@ -48,3 +48,9 @@ coverage: docker-prepare build-coverage
 clean:
 	cargo clean
 	git clean -fd
+
+gen-bindings:
+	mkdir -p bindings
+	cargo r -p uniffi-bindgen -- generate --library $(LIB) -l python -o bindings
+	cp $(LIB) bindings/
+

--- a/test/run.py
+++ b/test/run.py
@@ -3,15 +3,12 @@
 import argparse
 import asyncio
 import os
-import shutil
-import subprocess
 import sys
-import typing
 
 from drop_test.logger import logger
 from scenarios import scenarios
 
-from drop_test import ffi, config
+from drop_test import ffi
 
 
 async def main():
@@ -20,13 +17,11 @@ async def main():
     parser = argparse.ArgumentParser(description="Run drop instance")
     parser.add_argument("--runner", required=True, help="peer name for the scenario")
     parser.add_argument("--scenario", required=True, help="scenario name")
-    parser.add_argument("--lib", required=True, help="path to library")
 
     args = parser.parse_args()
 
     runner = args.runner
     scenario = args.scenario
-    lib = args.lib
 
     os.environ["LLVM_PROFILE_FILE"] = f"./coverage/{scenario}-{runner}.profraw"
 
@@ -39,7 +34,7 @@ async def main():
     if script is None:
         raise Exception("unrecognized scenario", scenario)
 
-    drop = ffi.Drop(lib, ffi.KeysCtx(runner))
+    drop = ffi.Drop(ffi.KeysCtx(runner))
     logger.info(f"NordDrop version: {drop.version}")
 
     exit_code = 0

--- a/test/runner.py
+++ b/test/runner.py
@@ -1,14 +1,10 @@
 #!/usr/bin/python3
 import argparse
-import json
 import math
 import os
 import re
-import subprocess
-import sys
 import time
-import typing
-from threading import Semaphore, Thread
+from threading import Semaphore
 from typing import Tuple
 
 import docker
@@ -176,9 +172,8 @@ def run():
 
                     hostname = f"{runner}-{scenario.id()}"
                     print(f"Starting {hostname}...")
-                    LIB_PATH = os.environ["LIB_PATH"]
                     # TODO: would be great to notify each container that all of their peers are online and DNS resolving now works instead of sleeping
-                    cmd = f"sh -c 'sleep 5 && ./run.py --runner={runner} --scenario={scenario.id()} --lib={LIB_PATH}'"
+                    cmd = f"sh -c 'sleep 5 && ./run.py --runner={runner} --scenario={scenario.id()}'"
 
                     env = [
                         "RUST_BACKTRACE=1",

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -1,9 +1,10 @@
 from drop_test import action, event
 from drop_test.scenario import Scenario, ActionList
-from drop_test.error import Error, ReturnCodes
+from drop_test.error import Error
 from drop_test.config import FILES
-
 from drop_test.action import PeerState
+
+import bindings.norddrop as norddrop  # type: ignore
 
 from pathlib import Path
 from tempfile import gettempdir
@@ -28,11 +29,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -91,11 +92,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -180,13 +181,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -201,11 +202,11 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(1, FILES["testfile-big"].id)),
@@ -293,13 +294,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -320,11 +321,11 @@ scenarios = [
                         event.Receive(
                             1,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -444,11 +445,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -462,13 +463,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.WaitRacy(
@@ -499,13 +500,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Download(
@@ -524,13 +525,13 @@ scenarios = [
                         event.Receive(
                             1,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Download(
@@ -590,11 +591,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -612,11 +613,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -648,11 +649,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2),
@@ -669,11 +670,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -701,11 +702,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -724,11 +725,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -764,11 +765,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.FinishTransferCanceled(0, True)),
@@ -784,11 +785,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.CancelTransferRequest([0]),
@@ -816,18 +817,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["nested/big/testfile-01"].id,
                                     "big/testfile-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["nested/big/testfile-02"].id,
                                     "big/testfile-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -857,18 +858,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["nested/big/testfile-01"].id,
                                     "big/testfile-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["nested/big/testfile-02"].id,
                                     "big/testfile-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -929,11 +930,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(0.2),
@@ -950,11 +951,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.FinishTransferCanceled(0, True)),
@@ -987,13 +988,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1031,13 +1032,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1065,13 +1066,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1103,13 +1104,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1152,28 +1153,28 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1236,28 +1237,28 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1390,28 +1391,28 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1474,28 +1475,28 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1631,13 +1632,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1660,13 +1661,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Download(
@@ -1714,13 +1715,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -1734,13 +1735,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["duplicate/testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(1, FILES["duplicate/testfile-small"].id)),
@@ -1761,13 +1762,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1788,13 +1789,13 @@ scenarios = [
                         event.Receive(
                             1,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["duplicate/testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1842,15 +1843,15 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES[
                                         "testfile.small.with.complicated.extension"
                                     ].id,
                                     "testfile.small.with.complicated.extension",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1873,15 +1874,15 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES[
                                         "duplicate/testfile.small.with.complicated.extension"
                                     ].id,
                                     "testfile.small.with.complicated.extension",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -1912,15 +1913,15 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES[
                                         "testfile.small.with.complicated.extension"
                                     ].id,
                                     "testfile.small.with.complicated.extension",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -1949,15 +1950,15 @@ scenarios = [
                         event.Receive(
                             1,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES[
                                         "duplicate/testfile.small.with.complicated.extension"
                                     ].id,
                                     "testfile.small.with.complicated.extension",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2024,13 +2025,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -2055,13 +2056,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2102,25 +2103,25 @@ scenarios = [
                     action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     # fmt: off
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(1, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(1, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(2, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(2, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(3, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(3, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(4, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(4, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(5, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(5, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(6, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(6, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(7, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(7, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(8, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(8, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-bulk-01"]),
-                    action.Wait(event.Queued(9, "DROP_PEER_STIMPY", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), })),
+                    action.Wait(event.Queued(9, "DROP_PEER_STIMPY", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ])),
                     # fmt: on
                     # fmt: off
                     action.WaitRacy(
@@ -2159,16 +2160,16 @@ scenarios = [
                     # fmt: off
                     action.WaitRacy(
                         [
-                            event.Receive(0, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(1, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(2, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(3, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(4, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(5, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(6, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(7, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(8, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
-                            event.Receive(9, "DROP_PEER_REN", { event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), }),
+                            event.Receive(0, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(1, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(2, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(3, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(4, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(5, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(6, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(7, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(8, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
+                            event.Receive(9, "DROP_PEER_REN", [ norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760), ]),
                         ]
                     ),
                     # fmt: on
@@ -2252,30 +2253,30 @@ scenarios = [
                     ),
                     # fmt: off
                     action.WaitRacy([
-                        event.Queued(0, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(1, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(2, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(3, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
+                        event.Queued(0, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(1, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(2, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(3, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
                     ]),
                     # fmt: on
                     # fmt: off
@@ -2308,30 +2309,30 @@ scenarios = [
                     # fmt: off
                     action.WaitRacy(
                         [
-                            event.Receive(0, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(1, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(2, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(3, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
+                            event.Receive(0, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(1, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(2, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(3, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
                         ]
                     ),
                     # fmt: on
@@ -2434,30 +2435,30 @@ scenarios = [
                     ),
                     # fmt: off
                     action.WaitRacy([
-                        event.Queued(0, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(1, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(2, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
-                        event.Queued(3, "DROP_PEER_STIMPY", {
-                            event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                            event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                            event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                            event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        }),
+                        event.Queued(0, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(1, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(2, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
+                        event.Queued(3, "DROP_PEER_STIMPY", [
+                            norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                            norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                            norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                            norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        ]),
                     ]),
                     # fmt: on
                     # fmt: off
@@ -2506,30 +2507,30 @@ scenarios = [
                     # fmt: off
                     action.WaitRacy(
                         [
-                            event.Receive(0, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(1, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(2, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
-                            event.Receive(3, "DROP_PEER_REN", { 
-                                event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                                event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                                event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                                event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                            }),
+                            event.Receive(0, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(1, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(2, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
+                            event.Receive(3, "DROP_PEER_REN", [ 
+                                norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                                norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                                norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                                norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                            ]),
                         ]
                     ),
                     # fmt: on
@@ -2630,24 +2631,24 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                         "testfile-big",
                                         10485760,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 1,
                                 "DROP_PEER_GEORGE",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                         "testfile-big",
                                         10485760,
                                     ),
-                                },
+                                ],
                             ),
                             event.Start(
                                 1, "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw"
@@ -2678,13 +2679,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2723,13 +2724,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2783,24 +2784,24 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                         "testfile-small",
                                         1024 * 1024,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 1,
                                 "DROP_PEER_GEORGE",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                         "testfile-small",
                                         1024 * 1024,
                                     ),
-                                },
+                                ],
                             ),
                             event.Start(
                                 0, "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI"
@@ -2831,13 +2832,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                     "testfile-small",
                                     1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2878,13 +2879,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "btveSO3-H7_lCgrUDAdTHFyY8oxDGed4j8VWaaQLnTI",
                                     "testfile-small",
                                     1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -2934,13 +2935,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -2964,13 +2965,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3016,13 +3017,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.ExpectCancel([0], True),
@@ -3037,13 +3038,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3084,13 +3085,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -3114,13 +3115,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3182,13 +3183,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -3212,13 +3213,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1 * 1024 * 1024,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3264,13 +3265,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -3292,13 +3293,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3351,18 +3352,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -3390,18 +3391,18 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -3436,18 +3437,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3494,18 +3495,18 @@ scenarios = [
                         event.Receive(
                             1,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3579,18 +3580,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["name/file-01"].id,
                                     "name/file-01",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["different/name/file-02"].id,
                                     "name(1)/file-02",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -3625,18 +3626,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["name/file-01"].id,
                                     "name/file-01",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["different/name/file-02"].id,
                                     "name(1)/file-02",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3707,11 +3708,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -3771,11 +3772,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3874,13 +3875,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -3901,13 +3902,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -3966,46 +3967,46 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 1,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 2,
                                 "DROP_PEER_GEORGE",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 3,
                                 "DROP_PEER_GEORGE",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.FinishFileFailed(
                                 0,
@@ -4045,24 +4046,24 @@ scenarios = [
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Receive(
                                 1,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -4112,24 +4113,24 @@ scenarios = [
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Receive(
                                 1,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["a" * 251 + ".txt"].id,
                                         "a" * 251 + ".txt",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -4190,13 +4191,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["with-illegal-char-\x0A-"].id,
                                     "with-illegal-char-\x0A-",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["with-illegal-char-\x0A-"].id)),
@@ -4218,13 +4219,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["with-illegal-char-\x0A-"].id,
                                     "with-illegal-char-_-",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -4270,13 +4271,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["utf8-testfile-\u5b81\u5BDF"].id,
                                     "utf8-testfile-\u5b81\u5BDF",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["utf8-testfile-\u5b81\u5BDF"].id)),
@@ -4298,13 +4299,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["utf8-testfile-\u5b81\u5BDF"].id,
                                     "utf8-testfile-\u5b81\u5BDF",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -4355,13 +4356,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["a" * 251 + "/testfile.txt"].id,
                                     "a" * 251 + "/testfile.txt",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -4383,13 +4384,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["a" * 251 + "/testfile.txt"].id,
                                     "a" * 251 + "/testfile.txt",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -4438,18 +4439,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["dir-with-invalid_char-</file-01"].id,
                                     "dir-with-invalid_char-</file-01",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["dir-with-invalid_char->/file-01"].id,
                                     "dir-with-invalid_char->/file-01",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -4479,34 +4480,34 @@ scenarios = [
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["dir-with-invalid_char-</file-01"].id,
                                         "dir-with-invalid_char-_/file-01",
                                         1048576,
                                     ),
-                                    event.File(
+                                    norddrop.File(
                                         FILES["dir-with-invalid_char->/file-01"].id,
                                         "dir-with-invalid_char-_(1)/file-01",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["dir-with-invalid_char-</file-01"].id,
                                         "dir-with-invalid_char-_(1)/file-01",
                                         1048576,
                                     ),
-                                    event.File(
+                                    norddrop.File(
                                         FILES["dir-with-invalid_char->/file-01"].id,
                                         "dir-with-invalid_char-_/file-01",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -4600,36 +4601,36 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -4668,36 +4669,36 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "deep/path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "deep/path/file2.ext2",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file3.ext3"].id,
                                     "deep/another-path/file3.ext3",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/another-path/file4.ext4"].id,
                                     "deep/another-path/file4.ext4",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(0, FILES["testfile-small"].id, "/tmp/received/20"),
@@ -4800,11 +4801,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -4831,11 +4832,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -4906,11 +4907,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -4938,11 +4939,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -5001,18 +5002,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["nested/big/testfile-01"].id,
                                     "nested/big/testfile-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["nested/big/testfile-02"].id,
                                     "nested/big/testfile-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -5064,18 +5065,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["nested/big/testfile-01"].id,
                                     "nested/big/testfile-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["nested/big/testfile-02"].id,
                                     "nested/big/testfile-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -5164,11 +5165,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["zero-sized-file"].id, "zero-sized-file", 0
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["zero-sized-file"].id)),
@@ -5190,11 +5191,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["zero-sized-file"].id, "zero-sized-file", 0
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -5240,18 +5241,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["duplicate/testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -5280,18 +5281,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["duplicate/testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -5351,13 +5352,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -5378,13 +5379,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.DropPrivileges(),
@@ -5425,13 +5426,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -5453,13 +5454,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -5495,13 +5496,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -5520,13 +5521,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5554,13 +5555,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5578,13 +5579,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -5614,11 +5615,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -5639,11 +5640,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-3"),
@@ -5675,11 +5676,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -5699,11 +5700,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(0, FILES["testfile-big"].id, "/tmp/received/27-4"),
@@ -5735,13 +5736,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -5760,13 +5761,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5802,13 +5803,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5826,13 +5827,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -5869,13 +5870,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -5902,13 +5903,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5943,13 +5944,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -5973,13 +5974,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -6016,13 +6017,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -6047,13 +6048,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -6097,13 +6098,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY6",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -6161,13 +6162,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN6",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -6252,13 +6253,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -6338,13 +6339,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -6441,13 +6442,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -6479,13 +6480,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -6551,23 +6552,23 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -6607,23 +6608,23 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-bulk-01"].id),
@@ -6684,23 +6685,23 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -6735,23 +6736,23 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-bulk-01"].id),
@@ -6814,13 +6815,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -6873,13 +6874,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     "jbKuIzVPNMpYyBXk0DGoiEFXi3HoJ3wnGrygOYgdoKw",
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -6936,11 +6937,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -6964,11 +6965,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                 ]
@@ -6989,11 +6990,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -7022,11 +7023,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -7051,11 +7052,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -7097,13 +7098,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -7130,13 +7131,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -7183,13 +7184,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     # give it some time to arrive
@@ -7218,13 +7219,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
@@ -7267,13 +7268,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     # give it some time to arrive
@@ -7296,13 +7297,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
@@ -7328,13 +7329,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     # give it some time to arrive
@@ -7356,13 +7357,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitForAnotherPeer("DROP_PEER_REN", PeerState.Offline),
@@ -7387,13 +7388,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -7428,13 +7429,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -7483,28 +7484,28 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-03"].id,
                                     "testfile-bulk-03",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-04"].id,
                                     "testfile-bulk-04",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -7548,28 +7549,28 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-bulk-01"].id,
                                     "testfile-bulk-01",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-02"].id,
                                     "testfile-bulk-02",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-03"].id,
                                     "testfile-bulk-03",
                                     10485760,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["testfile-bulk-04"].id,
                                     "testfile-bulk-04",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -7677,13 +7678,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -7741,13 +7742,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -7796,13 +7797,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -7846,13 +7847,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.RejectTransferFile(0, FILES["testfile-small"].id),
@@ -7915,13 +7916,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.AssertTransfers(
@@ -7944,7 +7945,7 @@ scenarios = [
                     ),
                     action.ExpectError(
                         action.RemoveTransferFile(0, FILES["testfile-small"].id),
-                        Error.BAD_FILE,
+                        norddrop.Error.NorddropResBadInput,
                     ),
                     action.AssertTransfers(
                         [
@@ -7980,13 +7981,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2),
@@ -8027,13 +8028,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2),
@@ -8070,13 +8071,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2),
@@ -8099,7 +8100,7 @@ scenarios = [
                     ),
                     action.ExpectError(
                         action.RemoveTransferFile(0, FILES["testfile-small"].id),
-                        Error.BAD_FILE,
+                        norddrop.Error.NorddropResBadInput,
                     ),
                     action.AssertTransfers(
                         [
@@ -8139,13 +8140,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -8206,13 +8207,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(0, FILES["testfile-small"].id, "/tmp/recv/31-5"),
@@ -8279,13 +8280,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -8334,13 +8335,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(0, FILES["testfile-small"].id, "/tmp/recv/31-6"),
@@ -8419,13 +8420,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.AssertTransfers(
@@ -8449,7 +8450,7 @@ scenarios = [
                     ),
                     action.ExpectError(
                         action.RemoveTransferFile(0, FILES["testfile-small"].id),
-                        ReturnCodes.BAD_INPUT,
+                        norddrop.Error.NorddropResBadInput,
                     ),
                     action.AssertTransfers(
                         [
@@ -8484,13 +8485,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.AssertTransfers(
@@ -8513,7 +8514,7 @@ scenarios = [
                     ),
                     action.ExpectError(
                         action.RemoveTransferFile(0, FILES["testfile-small"].id),
-                        ReturnCodes.BAD_INPUT,
+                        norddrop.Error.NorddropResBadInput,
                     ),
                     action.AssertTransfers(
                         [
@@ -8555,18 +8556,18 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -8600,18 +8601,18 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["deep/path/file1.ext1"].id,
                                     "path/file1.ext1",
                                     1048576,
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["deep/path/file2.ext2"].id,
                                     "path/file2.ext2",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -8665,24 +8666,24 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 1,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Start(
                                 0,
@@ -8715,24 +8716,24 @@ scenarios = [
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Receive(
                                 1,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -8788,13 +8789,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -8879,13 +8880,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.AssertNoEventOfType(
@@ -8928,13 +8929,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Repeated(
@@ -8966,13 +8967,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9027,13 +9028,13 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -9064,13 +9065,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9115,13 +9116,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
@@ -9129,13 +9130,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.ConfigureNetwork(latency="10ms"),
@@ -9181,24 +9182,24 @@ scenarios = [
                             event.Receive(
                                 0,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-big"].id,
                                         "testfile-big",
                                         10485760,
                                     ),
-                                },
+                                ],
                             ),
                             event.Receive(
                                 1,
                                 "DROP_PEER_REN",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                         ]
                     ),
@@ -9263,13 +9264,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(1),
@@ -9284,11 +9285,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9314,13 +9315,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -9334,10 +9335,13 @@ scenarios = [
                     # try again and expect no events and no activity
                     action.ExpectError(
                         action.Start("DROP_PEER_REN", "/tmp/data.base"),
-                        ReturnCodes.ADDR_IN_USE,
+                        norddrop.Error.NorddropResAddrInUse,
                     ),
                     action.NoEvent(),
-                    action.ExpectError(action.Stop(), ReturnCodes.NOT_STARTED),
+                    action.ExpectError(
+                        action.Stop(),
+                        norddrop.Error.NorddropResNotStarted,
+                    ),
                 ]
             ),
             "DROP_PEER_STIMPY": ActionList(
@@ -9364,13 +9368,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -9393,13 +9397,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9441,11 +9445,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -9466,11 +9470,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9502,13 +9506,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(0.2),
@@ -9528,13 +9532,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2.0),
@@ -9583,13 +9587,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.NoEvent(
@@ -9625,13 +9629,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.NoEvent(
@@ -9704,13 +9708,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.NoEvent(),
@@ -9741,13 +9745,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.ExpectCancel([0], True),
@@ -9773,13 +9777,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(0.5),
@@ -9798,13 +9802,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(1),
@@ -9830,13 +9834,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(0.5),
@@ -9859,13 +9863,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Stop(),
@@ -9894,13 +9898,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -9921,13 +9925,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -9971,24 +9975,24 @@ scenarios = [
                             event.Queued(
                                 0,
                                 "DROP_PEER_STIMPY",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-small"].id,
                                         "testfile-small",
                                         1048576,
                                     ),
-                                },
+                                ],
                             ),
                             event.Queued(
                                 1,
                                 "DROP_PEER_GEORGE",
-                                {
-                                    event.File(
+                                [
+                                    norddrop.File(
                                         FILES["testfile-big"].id,
                                         "testfile-big",
                                         10485760,
                                     ),
-                                },
+                                ],
                             ),
                             event.Start(0, FILES["testfile-small"].id),
                             event.Start(1, FILES["testfile-big"].id),
@@ -10015,13 +10019,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(2),
@@ -10050,13 +10054,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10093,13 +10097,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -10112,13 +10116,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_GEORGE",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Wait(
@@ -10157,13 +10161,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10192,13 +10196,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10237,13 +10241,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.NewTransfer("DROP_PEER_GEORGE", ["/tmp/testfile-big"]),
@@ -10251,13 +10255,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_GEORGE",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Repeated(
@@ -10294,13 +10298,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(5),  # synchronize
@@ -10346,13 +10350,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(5),  # synchronize
@@ -10406,13 +10410,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.WaitForAnotherPeer("DROP_PEER_GEORGE"),
@@ -10421,13 +10425,13 @@ scenarios = [
                         event.Queued(
                             1,
                             "DROP_PEER_GEORGE",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         ),
                     ),
                     action.Repeated(
@@ -10470,13 +10474,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(5),  # synchronize
@@ -10523,13 +10527,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Sleep(5),  # synchronize
@@ -10584,13 +10588,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.CancelTransferRequest([0]),
@@ -10617,20 +10621,21 @@ scenarios = [
                     action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
                     action.Start("DROP_PEER_REN"),
                     action.ExpectError(
-                        action.Start("DROP_PEER_REN"), ReturnCodes.INSTANCE_START
+                        action.Start("DROP_PEER_REN"),
+                        norddrop.Error.NorddropResInstanceStart,
                     ),
                     action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
                     action.Wait(
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -10649,19 +10654,20 @@ scenarios = [
                 [
                     action.Start("DROP_PEER_STIMPY"),
                     action.ExpectError(
-                        action.Start("DROP_PEER_STIMPY"), ReturnCodes.INSTANCE_START
+                        action.Start("DROP_PEER_STIMPY"),
+                        norddrop.Error.NorddropResInstanceStart,
                     ),
                     action.Wait(
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10705,13 +10711,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -10730,13 +10736,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10781,13 +10787,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -10811,13 +10817,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10856,13 +10862,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -10881,13 +10887,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id,
                                     "testfile-big",
                                     10485760,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -10925,11 +10931,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -10991,11 +10997,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11064,16 +11070,16 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["tiny-jpeg.jpg"].id, "tiny-jpeg.jpg", 134
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["tiny-gif.gif"].id,
                                     "tiny-gif.gif",
                                     26,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -11152,16 +11158,16 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["tiny-jpeg.jpg"].id, "tiny-jpeg.jpg", 134
                                 ),
-                                event.File(
+                                norddrop.File(
                                     FILES["tiny-gif.gif"].id,
                                     "tiny-gif.gif",
                                     26,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11251,11 +11257,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.WaitRacy(
@@ -11320,11 +11326,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11394,11 +11400,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -11480,11 +11486,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11585,11 +11591,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -11654,11 +11660,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11760,13 +11766,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-small"].id)),
@@ -11876,13 +11882,13 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -11928,13 +11934,13 @@ scenarios = [
                         "/tmp/testfile-bulk-04",
                         "/tmp/testfile-bulk-05",
                     ]),
-                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY",{ 
-                        event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                        event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                        event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                        event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        event.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
-                    })),
+                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY",[ 
+                        norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                        norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                        norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                        norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        norddrop.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
+                    ])),
                     action.WaitRacy(
                         [
                             event.Start(0, FILES["testfile-bulk-01"].id),
@@ -11961,13 +11967,13 @@ scenarios = [
                     action.ConfigureNetwork(rate="100mbit"),
                     action.Start("DROP_PEER_STIMPY"),
                     # fmt: off
-                    action.Wait(event.Receive(0, "DROP_PEER_REN", { 
-                        event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                        event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                        event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                        event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        event.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
-                    })),
+                    action.Wait(event.Receive(0, "DROP_PEER_REN", [ 
+                        norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                        norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                        norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                        norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        norddrop.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
+                    ])),
                     action.Download(0, FILES["testfile-bulk-01"].id, "/tmp/received/48"),
                     action.Download(0, FILES["testfile-bulk-02"].id, "/tmp/received/48"),
                     action.Download(0, FILES["testfile-bulk-03"].id, "/tmp/received/48"),
@@ -12015,11 +12021,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(event.Start(0, FILES["testfile-big"].id)),
@@ -12041,11 +12047,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(
@@ -12102,13 +12108,13 @@ scenarios = [
                         ],
                     ),
                     # fmt: off
-                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY", {
-                        event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                        event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                        event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                        event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        event.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
-                    })),
+                    action.Wait(event.Queued(0, "DROP_PEER_STIMPY", [
+                        norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                        norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                        norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                        norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        norddrop.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
+                    ])),
                     action.WaitRacy([
                         event.Start(0,     FILES["testfile-bulk-01"].id),
                         event.Start(0,     FILES["testfile-bulk-02"].id),
@@ -12138,13 +12144,13 @@ scenarios = [
                     action.ConfigureNetwork(),
                     action.Start("DROP_PEER_STIMPY"),
                     # fmt: off
-                    action.Wait(event.Receive(0, "DROP_PEER_REN", { 
-                        event.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
-                        event.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
-                        event.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
-                        event.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
-                        event.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
-                    })),
+                    action.Wait(event.Receive(0, "DROP_PEER_REN", [ 
+                        norddrop.File(FILES["testfile-bulk-01"].id, "testfile-bulk-01", 10485760),
+                        norddrop.File(FILES["testfile-bulk-02"].id, "testfile-bulk-02", 10485760),
+                        norddrop.File(FILES["testfile-bulk-03"].id, "testfile-bulk-03", 10485760),
+                        norddrop.File(FILES["testfile-bulk-04"].id, "testfile-bulk-04", 10485760),
+                        norddrop.File(FILES["testfile-bulk-05"].id, "testfile-bulk-05", 10485760),
+                    ])),
                     action.Download(0, FILES["testfile-bulk-01"].id, "/tmp/received/50"),
                     action.Wait(event.Pending(0, FILES["testfile-bulk-01"].id)),
                     action.Wait(event.Start(0, FILES["testfile-bulk-01"].id)),
@@ -12186,13 +12192,13 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-small"].id,
                                     "testfile-small",
                                     1048576,
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Wait(
@@ -12227,11 +12233,11 @@ scenarios = [
                         event.Queued(
                             0,
                             "DROP_PEER_STIMPY",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Repeated(
@@ -12263,11 +12269,11 @@ scenarios = [
                         event.Receive(
                             0,
                             "DROP_PEER_REN",
-                            {
-                                event.File(
+                            [
+                                norddrop.File(
                                     FILES["testfile-big"].id, "testfile-big", 10485760
                                 ),
-                            },
+                            ],
                         )
                     ),
                     action.Download(

--- a/uniffi-bindgen/Cargo.toml
+++ b/uniffi-bindgen/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "uniffi-bindgen"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+uniffi = { git = "https://github.com/NordSecurity/uniffi-rs", tag = "v0.3.1+v0.25.0", features = ["cli"] }

--- a/uniffi-bindgen/src/main.rs
+++ b/uniffi-bindgen/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi::uniffi_bindgen_main();
+}


### PR DESCRIPTION
This PR adds the following:
* UDL definitions of the library API (`norddrop.udl`)
* DB dump and events are strongly typed
* tests are adjusted to use on-the-fly generated Python bindings
* Rust code adjusted to work well with UDL (`uni.rs`)

I've tried not to touch the current swig-generated API hence everything in the `uni.rs` file just wraps around the ffi device and uses C-style callbacks. This should be flattened after swig removal.

The things left to do after removing the swing bindings
* convert timestamps into `SystemTime` - uniffi has direct conversions to this type
* clean the `uni.rs` file and remove the indirection to the device API (possibly removing the latter one)

So this PR is just the beginning of the changes but I want to get some feedback if things are going in the right direction.