### PR TITLE
Add checksum_events_granularity config

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 * Disallow downloading file for which any path component is larger than 250 characters
 * Fix ocassional missing of `TransferPaused` event when toggling libdrop on and off quickly
 * Report file transfer error in case file subpath contains perent directory `..`
+* Add checksum_events_granularity config
 
 ---
 <br>

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -13,6 +13,9 @@ pub struct DropConfig {
     pub storage_path: String,
     // If set the checksum events will be emited for every file of this or bigger size
     pub checksum_events_size_threshold: Option<usize>,
+    // If set the checksum events will be emited for every checksum_events_granularity bytes
+    // Default value is 256KB.
+    pub checksum_events_granularity: u64,
     pub connection_retries: u32,
 }
 
@@ -23,6 +26,7 @@ impl Default for DropConfig {
             transfer_file_limit: 1000,
             storage_path: "libdrop.sqlite".to_string(),
             checksum_events_size_threshold: None,
+            checksum_events_granularity: 256 * 1024,
             connection_retries: 5,
         }
     }

--- a/drop-transfer/src/ws/client/v4.rs
+++ b/drop-transfer/src/ws/client/v4.rs
@@ -140,6 +140,7 @@ impl HandlerLoop<'_> {
                     .checksum::<_, futures::future::Ready<()>>(
                         limit,
                         None::<fn(u64) -> futures::future::Ready<()>>,
+                        None,
                     )
                     .await?;
 

--- a/drop-transfer/src/ws/client/v6.rs
+++ b/drop-transfer/src/ws/client/v6.rs
@@ -172,6 +172,7 @@ impl HandlerLoop<'_> {
                     .checksum::<_, futures::future::Ready<()>>(
                         limit,
                         None::<fn(u64) -> futures::future::Ready<()>>,
+                        None,
                     )
                     .await?;
 

--- a/drop-transfer/src/ws/server/handler.rs
+++ b/drop-transfer/src/ws/server/handler.rs
@@ -82,6 +82,7 @@ pub trait Downloader {
         &mut self,
         location: &Hidden<PathBuf>,
         progress_cb: Option<F>,
+        event_granularity: Option<u64>,
     ) -> crate::Result<()>
     where
         F: FnMut(u64) -> Fut + Send + Sync,

--- a/drop-transfer/src/ws/server/mod.rs
+++ b/drop-transfer/src/ws/server/mod.rs
@@ -693,6 +693,7 @@ impl FileXferTask {
         downloader: &mut impl Downloader,
         offset: u64,
         emit_checksum_events: bool,
+        checksum_events_granularity: u64,
     ) -> crate::Result<PathBuf> {
         let mut out_file = match downloader.open(tmp_loc).await {
             Ok(out_file) => out_file,
@@ -744,14 +745,19 @@ impl FileXferTask {
 
             if emit_checksum_events {
                 events.checksum_start(self.file.size()).await;
-
                 let progress_cb = {
-                    move |progress: u64| async move {
-                        events.checksum_progress(progress).await;
+                    move |progress_bytes: u64| async move {
+                        events.checksum_progress(progress_bytes).await;
                     }
                 };
 
-                downloader.validate(tmp_loc, Some(progress_cb)).await?;
+                downloader
+                    .validate(
+                        tmp_loc,
+                        Some(progress_cb),
+                        Some(checksum_events_granularity),
+                    )
+                    .await?;
 
                 events.checksum_finish().await;
             } else {
@@ -759,6 +765,7 @@ impl FileXferTask {
                     .validate::<_, futures::future::Ready<()>>(
                         tmp_loc,
                         None::<fn(u64) -> futures::future::Ready<()>>,
+                        None,
                     )
                     .await?;
             }
@@ -846,6 +853,7 @@ impl FileXferTask {
         events: &FileEventTx<IncomingTransfer>,
         tmp_location: &Hidden<PathBuf>,
         emit_checksum_events: bool,
+        checksum_events_granularity: u64,
     ) -> Option<TmpFileState> {
         // TODO: we load the file's metadata to check if we should emit checksum events
         // based on size threshold. However TmpFileState::load also does the
@@ -861,13 +869,19 @@ impl FileXferTask {
             let size = tmp_size.unwrap_or(0);
             events.checksum_start(size).await;
 
-            Some(|progress| events.checksum_progress(progress))
+            Some(|progress_bytes| events.checksum_progress(progress_bytes))
         } else {
             None
         };
 
         // Check if we can resume the temporary file
-        let tmp_file_state = match TmpFileState::load(&tmp_location.0, cb).await {
+        let tmp_file_state = match TmpFileState::load(
+            &tmp_location.0,
+            cb,
+            Some(checksum_events_granularity),
+        )
+        .await
+        {
             Ok(tmp_file_state) => {
                 debug!(
                     logger,
@@ -911,6 +925,7 @@ impl FileXferTask {
                     false
                 }
             };
+            let checksum_events_granularity = state.config.checksum_events_granularity;
 
             events.preflight().await;
 
@@ -920,7 +935,13 @@ impl FileXferTask {
             );
 
             let tmp_file_state = self
-                .handle_tmp_file(&logger, &events, &tmp_location, emit_checksum_events)
+                .handle_tmp_file(
+                    &logger,
+                    &events,
+                    &tmp_location,
+                    emit_checksum_events,
+                    checksum_events_granularity,
+                )
                 .await;
 
             let init_res = downloader.init(&self, tmp_file_state).await?;
@@ -951,6 +972,7 @@ impl FileXferTask {
                         &mut downloader,
                         offset,
                         emit_checksum_events,
+                        checksum_events_granularity,
                     )
                     .await
                 }
@@ -1024,7 +1046,11 @@ impl FileXferTask {
 
 impl TmpFileState {
     // Blocking operation
-    async fn load<F, Fut>(path: &Path, progress_cb: Option<F>) -> io::Result<Self>
+    async fn load<F, Fut>(
+        path: &Path,
+        progress_cb: Option<F>,
+        event_granularity: Option<u64>,
+    ) -> io::Result<Self>
     where
         F: Fn(u64) -> Fut + Sync + Send,
         Fut: Future<Output = ()>,
@@ -1033,7 +1059,7 @@ impl TmpFileState {
 
         let meta = file.metadata()?;
 
-        let csum = file::checksum(file, progress_cb).await?;
+        let csum = file::checksum(file, progress_cb, event_granularity).await?;
         Ok(TmpFileState { meta, csum })
     }
 }

--- a/drop-transfer/src/ws/server/v2.rs
+++ b/drop-transfer/src/ws/server/v2.rs
@@ -455,7 +455,12 @@ impl handler::Downloader for Downloader {
         .await
     }
 
-    async fn validate<F, Fut>(&mut self, _path: &Hidden<PathBuf>, _: Option<F>) -> crate::Result<()>
+    async fn validate<F, Fut>(
+        &mut self,
+        _path: &Hidden<PathBuf>,
+        _: Option<F>,
+        _: Option<u64>,
+    ) -> crate::Result<()>
     where
         F: FnMut(u64) -> Fut + Send + Sync,
         Fut: Future<Output = ()>,

--- a/drop-transfer/src/ws/server/v4.rs
+++ b/drop-transfer/src/ws/server/v4.rs
@@ -594,13 +594,14 @@ impl handler::Downloader for Downloader {
         &mut self,
         path: &Hidden<PathBuf>,
         progress_cb: Option<F>,
+        event_granularity: Option<u64>,
     ) -> crate::Result<()>
     where
         F: FnMut(u64) -> Fut + Send + Sync,
         Fut: Future<Output = ()> + Send + Sync,
     {
         let file = std::fs::File::open(&path.0)?;
-        let csum = file::checksum(file, progress_cb).await?;
+        let csum = file::checksum(file, progress_cb, event_granularity).await?;
 
         if self.full_csum.get().await != csum {
             return Err(crate::Error::ChecksumMismatch);

--- a/drop-transfer/src/ws/server/v6.rs
+++ b/drop-transfer/src/ws/server/v6.rs
@@ -653,13 +653,14 @@ impl handler::Downloader for Downloader {
         &mut self,
         path: &Hidden<PathBuf>,
         progress_cb: Option<F>,
+        event_granularity: Option<u64>,
     ) -> crate::Result<()>
     where
         F: FnMut(u64) -> Fut + Send + Sync,
         Fut: Future<Output = ()> + Send,
     {
         let file = std::fs::File::open(&path.0)?;
-        let csum = file::checksum(file, progress_cb).await?;
+        let csum = file::checksum(file, progress_cb, event_granularity).await?;
 
         if self.full_csum.get().await != csum {
             return Err(crate::Error::ChecksumMismatch);

--- a/norddrop/src/device/types.rs
+++ b/norddrop/src/device/types.rs
@@ -156,6 +156,12 @@ pub struct Config {
     #[serde(rename = "checksum_events_size_threshold_bytes")]
     pub checksum_events_size_threshold: Option<usize>,
 
+    #[serde(
+        rename = "checksum_events_granularity_bytes",
+        default = "Config::default_checksum_events_granularity"
+    )]
+    pub checksum_events_granularity: u64,
+
     #[serde(default = "Config::default_connection_retries")]
     pub connection_retries: u32,
 }
@@ -163,6 +169,10 @@ pub struct Config {
 impl Config {
     const fn default_connection_retries() -> u32 {
         5
+    }
+
+    const fn default_checksum_events_granularity() -> u64 {
+        256 * 1024
     }
 }
 
@@ -413,6 +423,7 @@ impl From<Config> for drop_config::Config {
             moose_prod,
             storage_path,
             checksum_events_size_threshold,
+            checksum_events_granularity,
             connection_retries,
         } = val;
 
@@ -423,6 +434,7 @@ impl From<Config> for drop_config::Config {
                 storage_path,
                 checksum_events_size_threshold,
                 connection_retries,
+                checksum_events_granularity,
             },
             moose: drop_config::MooseConfig {
                 event_path: moose_event_path,
@@ -450,7 +462,8 @@ mod tests {
           "storage_path": ":memory:",
           "max_uploads_in_flight": 16,
           "max_requests_per_sec": 15,
-          "checksum_events_size_threshold_bytes": 1234
+          "checksum_events_size_threshold_bytes": 1234,
+          "checksum_events_granularity_bytes": 1024
         }
         "#;
 
@@ -463,6 +476,7 @@ mod tests {
                     transfer_file_limit,
                     storage_path,
                     checksum_events_size_threshold: checksum_events_size_threshold_bytes,
+                    checksum_events_granularity: checksum_events_granularity_bytes,
                     connection_retries,
                 },
             moose: drop_config::MooseConfig { event_path, prod },
@@ -474,6 +488,7 @@ mod tests {
         assert_eq!(storage_path, ":memory:");
         assert!(prod);
         assert_eq!(checksum_events_size_threshold_bytes, Some(1234));
+        assert_eq!(checksum_events_granularity_bytes, 1024);
         assert_eq!(connection_retries, 5);
     }
 }

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -740,16 +740,19 @@ class Start(Action):
         addr: str,
         dbpath: str = ":memory:",
         checksum_events_size_threshold=2**32,  # don't emit events for existing tests
+        checksum_events_granularity=None,
     ):
         self._addr = addr
         self._dbpath = dbpath
         self._checksum_events_size_threshold = checksum_events_size_threshold
+        self._checksum_events_granularity = checksum_events_granularity
 
     async def run(self, drop: ffi.Drop):
         drop.start(
             peer_resolver.resolve(self._addr),
             self._dbpath,
             self._checksum_events_size_threshold,
+            self._checksum_events_granularity,
         )
 
     def __str__(self):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -562,7 +562,13 @@ class Drop:
                 f"remove_transfer_file has failed with code: {err}({err_type})", err
             )
 
-    def start(self, addr: str, dbpath: str, checksum_events_size_threshold=None):
+    def start(
+        self,
+        addr: str,
+        dbpath: str,
+        checksum_events_size_threshold=None,
+        checksum_events_granularity=None,
+    ):
         cfg = {
             "dir_depth_limit": 5,
             "transfer_file_limit": 1000,
@@ -574,6 +580,9 @@ class Drop:
 
         if checksum_events_size_threshold is not None:
             cfg["checksum_events_size_threshold_bytes"] = checksum_events_size_threshold
+
+        if checksum_events_granularity is not None:
+            cfg["checksum_events_granularity_bytes"] = checksum_events_granularity
 
         err = self._lib.norddrop_start(
             self._instance,

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -12317,4 +12317,313 @@ scenarios = [
             ),
         },
     ),
+    Scenario(
+        "scenario53-1",
+        "Send one file to a peer, expect it to be transferred, checksum events should be present on receiver side with the expected granularity (default)",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.Start("DROP_PEER_REN", checksum_events_size_threshold=0),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            "DROP_PEER_STIMPY",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            0,
+                            FILES["testfile-small"].id,
+                        )
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start("DROP_PEER_STIMPY", checksum_events_size_threshold=0),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-small"].id,
+                        "/tmp/received/53-1",
+                    ),
+                    action.Wait(event.Pending(0, FILES["testfile-small"].id)),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.ChecksumStarted(0, FILES["testfile-small"].id, 1048576)
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-small"].id, checksummed_bytes=262144
+                        )
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-small"].id, checksummed_bytes=524288
+                        )
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-small"].id, checksummed_bytes=786432
+                        )
+                    ),
+                    action.Wait(event.ChecksumFinished(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileDownloaded(
+                            0,
+                            FILES["testfile-small"].id,
+                            "/tmp/received/53-1/testfile-small",
+                        )
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File("/tmp/received/53-1/testfile-small", 1048576),
+                        ],
+                    ),
+                    action.CancelTransferRequest([0]),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario53-2",
+        "Send one file to a peer, expect it to be transferred, checksum events should be present on receiver side with the expected granularity",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.Start("DROP_PEER_REN", checksum_events_size_threshold=0),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-small"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            "DROP_PEER_STIMPY",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileUploaded(
+                            0,
+                            FILES["testfile-small"].id,
+                        )
+                    ),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start(
+                        "DROP_PEER_STIMPY",
+                        checksum_events_size_threshold=0,
+                        checksum_events_granularity=256 * 1024 * 2,
+                    ),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-small"].id,
+                                    "testfile-small",
+                                    1048576,
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-small"].id,
+                        "/tmp/received/53-2",
+                    ),
+                    action.Wait(event.Pending(0, FILES["testfile-small"].id)),
+                    action.Wait(event.Start(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.ChecksumStarted(0, FILES["testfile-small"].id, 1048576)
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-small"].id, checksummed_bytes=524288
+                        )
+                    ),
+                    action.Wait(event.ChecksumFinished(0, FILES["testfile-small"].id)),
+                    action.Wait(
+                        event.FinishFileDownloaded(
+                            0,
+                            FILES["testfile-small"].id,
+                            "/tmp/received/53-2/testfile-small",
+                        )
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File("/tmp/received/53-2/testfile-small", 1048576),
+                        ],
+                    ),
+                    action.CancelTransferRequest([0]),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
+    Scenario(
+        "scenario53-3",
+        "Stop the file transfer in flight from the receiver side by going offline, then download it again. Expect to resume using the temporary file with specified checksum events granularity",
+        {
+            "DROP_PEER_REN": ActionList(
+                [
+                    action.Start("DROP_PEER_REN"),
+                    action.ConfigureNetwork(latency="0.5s"),
+                    action.WaitForAnotherPeer("DROP_PEER_STIMPY"),
+                    action.NewTransfer("DROP_PEER_STIMPY", ["/tmp/testfile-big"]),
+                    action.Wait(
+                        event.Queued(
+                            0,
+                            "DROP_PEER_STIMPY",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
+                    action.Sleep(0.3),
+                    action.NetworkRefresh(),
+                    action.Wait(
+                        event.Start(0, FILES["testfile-big"].id, transferred=None)
+                    ),
+                    action.Wait(event.FinishFileUploaded(0, FILES["testfile-big"].id)),
+                    action.ExpectCancel([0], True),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+            "DROP_PEER_STIMPY": ActionList(
+                [
+                    action.Start(
+                        "DROP_PEER_STIMPY",
+                        dbpath="/tmp/db/53-3-stimpy.sqlite",
+                        checksum_events_size_threshold=0,
+                        checksum_events_granularity=256 * 1024,
+                    ),
+                    action.Wait(
+                        event.Receive(
+                            0,
+                            "DROP_PEER_REN",
+                            {
+                                event.File(
+                                    FILES["testfile-big"].id, "testfile-big", 10485760
+                                ),
+                            },
+                        )
+                    ),
+                    action.Download(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/53-3",
+                    ),
+                    action.Wait(event.Pending(0, FILES["testfile-big"].id)),
+                    action.Wait(event.Start(0, FILES["testfile-big"].id)),
+                    # wait for the initial progress indicating that we start from the beginning
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id, 0)),
+                    # make sure we have received something, so that we have non-empty tmp file
+                    action.Wait(event.Progress(0, FILES["testfile-big"].id)),
+                    action.Stop(),
+                    action.Wait(event.Paused(0, FILES["testfile-big"].id)),
+                    action.Start(
+                        "DROP_PEER_STIMPY",
+                        dbpath="/tmp/db/53-3-stimpy.sqlite",
+                        checksum_events_size_threshold=0,
+                        checksum_events_granularity=256 * 1024,
+                    ),
+                    action.WaitForResume(
+                        0,
+                        FILES["testfile-big"].id,
+                        "/tmp/received/53-3/*.dropdl-part",
+                        True,
+                    ),
+                    action.Wait(
+                        event.ChecksumStarted(0, FILES["testfile-big"].id, 10485760)
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-big"].id, checksummed_bytes=262144
+                        )
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-big"].id, checksummed_bytes=524288
+                        )
+                    ),
+                    action.Wait(
+                        event.ChecksumProgress(
+                            0, FILES["testfile-big"].id, checksummed_bytes=786432
+                        )
+                    ),
+                    # ... The file is big
+                    action.Wait(
+                        event.ChecksumFinished(
+                            0,
+                            FILES["testfile-big"].id,
+                        )
+                    ),
+                    action.Wait(
+                        event.FinishFileDownloaded(
+                            0,
+                            FILES["testfile-big"].id,
+                            "/tmp/received/53-3/testfile-big",
+                        )
+                    ),
+                    action.CheckDownloadedFiles(
+                        [
+                            action.File("/tmp/received/53-3/testfile-big", 10485760),
+                        ],
+                    ),
+                    action.CancelTransferRequest([0]),
+                    action.ExpectCancel([0], False),
+                    action.NoEvent(),
+                    action.Stop(),
+                ]
+            ),
+        },
+    ),
 ]


### PR DESCRIPTION
The problem consists in the fact that while transferring files libdrop will generate ChecksumProgress events for every chunk of data received (256KB) which can be a lot if the file is large.

Setting the checksum_events_granularity config makes the event generation to occur at every checksum_events_granularity chunks of data.