### PR TITLE
Address typos and types feedback

### DIFF
--- a/drop-core/src/status.rs
+++ b/drop-core/src/status.rs
@@ -35,3 +35,38 @@ impl serde::Serialize for Status {
         (*self as u32).serialize(serializer)
     }
 }
+
+impl From<u32> for Status {
+    fn from(value: u32) -> Self {
+        use Status::*;
+
+        match value {
+            1 => Finalized,
+            2 => BadPath,
+            3 => BadFile,
+            7 => BadTransfer,
+            8 => BadTransferState,
+            9 => BadFileId,
+            15 => IoError,
+            20 => TransferLimitsExceeded,
+            21 => MismatchedSize,
+            23 => InvalidArgument,
+            27 => AddrInUse,
+            28 => FileModified,
+            29 => FilenameTooLong,
+            30 => AuthenticationFailed,
+            31 => StorageError,
+            32 => DbLost,
+            33 => FileChecksumMismatch,
+            34 => FileRejected,
+            35 => FileFailed,
+            36 => FileFinished,
+            37 => EmptyTransfer,
+            38 => ConnectionClosedByPeer,
+            39 => TooManyRequests,
+            40 => PermissionDenied,
+            _unknown => IoError, /* Use IO error because we have no clue what it is. This
+                                  * shouldn't happen */
+        }
+    }
+}

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -146,8 +146,8 @@ fn print_event(ev: &Event) {
         Event::FileUploadThrottled {
             transfer_id,
             file_id,
-            transfered,
-        } => info!("[EVENT] FileUploadThrottled {transfer_id}: {file_id}, progress: {transfered}"),
+            transferred,
+        } => info!("[EVENT] FileUploadThrottled {transfer_id}: {file_id}, progress: {transferred}"),
         Event::FinalizeChecksumStarted {
             transfer_id,
             file_id,

--- a/drop-transfer/src/event.rs
+++ b/drop-transfer/src/event.rs
@@ -61,7 +61,7 @@ pub enum Event {
     FileUploadThrottled {
         transfer_id: Uuid,
         file_id: FileId,
-        transfered: u64,
+        transferred: u64,
     },
 
     IncomingTransferCanceled(Arc<IncomingTransfer>, bool),

--- a/drop-transfer/src/ws/events.rs
+++ b/drop-transfer/src/ws/events.rs
@@ -421,7 +421,7 @@ impl FileEventTx<OutgoingTransfer> {
         .await
     }
 
-    pub async fn throttled(&self, transfered: u64) {
+    pub async fn throttled(&self, transferred: u64) {
         let mut lock = self.inner.lock().await;
 
         match lock.state {
@@ -429,7 +429,7 @@ impl FileEventTx<OutgoingTransfer> {
                 lock.tx.emit(crate::Event::FileUploadThrottled {
                     transfer_id: self.xfer.id(),
                     file_id: self.file_id.clone(),
-                    transfered,
+                    transferred,
                 });
 
                 lock.state = FileState::Throttled;

--- a/norddrop/src/dump.rs
+++ b/norddrop/src/dump.rs
@@ -2,7 +2,7 @@ use drop_storage::types as db;
 
 pub enum TransferStateKind {
     Cancel { by_peer: bool },
-    Failed { status: i64 },
+    Failed { status: crate::StatusCode },
 }
 
 pub struct TransferState {
@@ -11,12 +11,26 @@ pub struct TransferState {
 }
 
 pub enum IncomingPathStateKind {
-    Pending { base_dir: String },
-    Started { bytes_received: u64 },
-    Failed { status: i64, bytes_received: u64 },
-    Completed { final_path: String },
-    Rejected { by_peer: bool, bytes_received: u64 },
-    Paused { bytes_received: u64 },
+    Pending {
+        base_dir: String,
+    },
+    Started {
+        bytes_received: u64,
+    },
+    Failed {
+        status: crate::StatusCode,
+        bytes_received: u64,
+    },
+    Completed {
+        final_path: String,
+    },
+    Rejected {
+        by_peer: bool,
+        bytes_received: u64,
+    },
+    Paused {
+        bytes_received: u64,
+    },
 }
 
 pub struct IncomingPathState {
@@ -33,11 +47,21 @@ pub struct IncomingPath {
 }
 
 pub enum OutgoingPathStateKind {
-    Started { bytes_sent: u64 },
-    Failed { status: i64, bytes_sent: u64 },
+    Started {
+        bytes_sent: u64,
+    },
+    Failed {
+        status: crate::StatusCode,
+        bytes_sent: u64,
+    },
     Completed,
-    Rejected { by_peer: bool, bytes_sent: u64 },
-    Paused { bytes_sent: u64 },
+    Rejected {
+        by_peer: bool,
+        bytes_sent: u64,
+    },
+    Paused {
+        bytes_sent: u64,
+    },
 }
 
 pub struct OutgoingPathState {
@@ -77,7 +101,7 @@ impl From<db::TransferStateEventData> for TransferStateKind {
         match value {
             db::TransferStateEventData::Cancel { by_peer } => Self::Cancel { by_peer },
             db::TransferStateEventData::Failed { status_code } => Self::Failed {
-                status: status_code,
+                status: crate::StatusCode::from(status_code as u32),
             },
         }
     }
@@ -119,7 +143,7 @@ impl From<db::IncomingPathStateEventData> for IncomingPathStateKind {
                 status_code,
                 bytes_received,
             } => IncomingPathStateKind::Failed {
-                status: status_code,
+                status: crate::StatusCode::from(status_code as u32),
                 bytes_received: bytes_received as _,
             },
             db::IncomingPathStateEventData::Completed { final_path } => {
@@ -178,7 +202,7 @@ impl From<db::OutgoingPathStateEventData> for OutgoingPathStateKind {
                 status_code,
                 bytes_sent,
             } => OutgoingPathStateKind::Failed {
-                status: status_code,
+                status: crate::StatusCode::from(status_code as u32),
                 bytes_sent: bytes_sent as _,
             },
             db::OutgoingPathStateEventData::Completed => OutgoingPathStateKind::Completed,

--- a/norddrop/src/event.rs
+++ b/norddrop/src/event.rs
@@ -40,12 +40,12 @@ pub enum EventKind {
     FileStarted {
         transfer_id: String,
         file_id: String,
-        transfered: u64,
+        transferred: u64,
     },
     FileProgress {
         transfer_id: String,
         file_id: String,
-        transfered: u64,
+        transferred: u64,
     },
     FileDownloaded {
         transfer_id: String,
@@ -73,7 +73,7 @@ pub enum EventKind {
     FileThrottled {
         transfer_id: String,
         file_id: String,
-        transfered: u64,
+        transferred: u64,
     },
     FilePending {
         transfer_id: String,
@@ -177,25 +177,25 @@ impl From<drop_transfer::Event> for EventKind {
                 transfer_id: tx.id().to_string(),
                 files: tx.files().values().map(From::from).collect(),
             },
-            FileUploadStarted(tx, fid, transfered) => Self::FileStarted {
+            FileUploadStarted(tx, fid, transferred) => Self::FileStarted {
                 transfer_id: tx.id().to_string(),
                 file_id: fid.to_string(),
-                transfered,
+                transferred,
             },
-            FileDownloadStarted(tx, fid, _, transfered) => Self::FileStarted {
+            FileDownloadStarted(tx, fid, _, transferred) => Self::FileStarted {
                 transfer_id: tx.id().to_string(),
                 file_id: fid.to_string(),
-                transfered,
+                transferred,
             },
             FileUploadProgress(tx, fid, progress) => Self::FileProgress {
                 transfer_id: tx.id().to_string(),
                 file_id: fid.to_string(),
-                transfered: progress,
+                transferred: progress,
             },
             FileDownloadProgress(tx, fid, progress) => Self::FileProgress {
                 transfer_id: tx.id().to_string(),
                 file_id: fid.to_string(),
-                transfered: progress,
+                transferred: progress,
             },
             FileUploadSuccess(tx, fid) => Self::FileUploaded {
                 transfer_id: tx.id().to_string(),
@@ -264,11 +264,11 @@ impl From<drop_transfer::Event> for EventKind {
             FileUploadThrottled {
                 transfer_id,
                 file_id,
-                transfered,
+                transferred,
             } => Self::FileThrottled {
                 transfer_id: transfer_id.to_string(),
                 file_id: file_id.to_string(),
-                transfered,
+                transferred,
             },
 
             FinalizeChecksumStarted {

--- a/norddrop/src/norddrop.udl
+++ b/norddrop/src/norddrop.udl
@@ -262,11 +262,11 @@ interface EventKind {
 
     /// Emitted when a file transfer is started. Valid for both sending and
     /// receiving peers.
-    FileStarted    (string transfer_id, string file_id, u64 transfered);
+    FileStarted    (string transfer_id, string file_id, u64 transferred);
 
     /// Emitted whenever an amount of data for a single file is transferred between
     /// peers. Valid for both sending and receiving peers.
-    FileProgress   (string transfer_id, string file_id, u64 transfered);
+    FileProgress   (string transfer_id, string file_id, u64 transferred);
 
     /// The file has been successfully downloaded.
     FileDownloaded (string transfer_id, string file_id, string final_path);
@@ -288,7 +288,7 @@ interface EventKind {
     /// of a delayed transfer because of too many active outgoing files in flight.
     /// Whenever the number of active files decreases the file will proceed with the
     /// TransferStarted event. Valid for sending peers.
-    FileThrottled  (string transfer_id, string file_id, u64 transfered);
+    FileThrottled  (string transfer_id, string file_id, u64 transferred);
 
     /// Indicates that the file transfer is registered and ready. It is emitted as a
     /// response to the `download()` call.
@@ -355,9 +355,8 @@ interface TransferStateKind {
     /// Contains indicator of who canceled the transfer.
     Cancel(boolean by_peer);
 
-    /// Contains status code of failure. Regular error table should be
-    /// consulted for errors.
-    Failed(i64 status);
+    /// Contains status code of failure.
+    Failed(StatusCode status);
 };
 
 /// A single change in the transfer state
@@ -382,10 +381,9 @@ interface IncomingPathStateKind {
     /// directory of the file.
     Started(u64 bytes_received);
 
-    /// Contains status code of failure. Regular error table should be
-    /// consulted for errors.
+    /// Contains status code of failure. 
     /// This is a **terminal** state.
-    Failed(i64 status, u64 bytes_received);
+    Failed(StatusCode status, u64 bytes_received);
 
     /// The file was successfully received and saved to the disk.
     /// Contains the final path of the file.
@@ -438,10 +436,9 @@ interface OutgoingPathStateKind {
     /// directory of the file.
     Started(u64 bytes_sent);
 
-    /// Contains status code of failure. Regular error table should be
-    /// consulted for errors.
+    /// Contains status code of failure.
     /// This is a **terminal** state.
-    Failed(i64 status, u64 bytes_sent);
+    Failed(StatusCode status, u64 bytes_sent);
 
     /// The file was successfully received and saved to the disk.
     /// Contains the final path of the file.
@@ -491,7 +488,7 @@ dictionary OutgoingPath {
     /// File size
     u64 bytes;
 
-    /// Curently transfered file bytes
+    /// Curently transferred file bytes
     u64 bytes_sent;
 
     /// The source of the file data

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -114,7 +114,9 @@ def compare_json_to_incoming_path_state(
             expected, "IncomingPathState", "bytes_received", actual.kind.bytes_received
         )
         keys.append("status_code")
-        compare_value(expected, "IncomingPathState", "status_code", actual.kind.status)
+        compare_value(
+            expected, "IncomingPathState", "status_code", str(actual.kind.status)
+        )
     elif actual.kind.is_completed():
         compare_value(expected, "IncomingPathState", "state", "completed")
         keys.append("final_path")
@@ -179,7 +181,9 @@ def compare_json_to_outgoing_path_state(
             expected, "OutgoingPathState", "bytes_sent", actual.kind.bytes_sent
         )
         keys.append("status_code")
-        compare_value(expected, "OutgoingPathState", "status_code", actual.kind.status)
+        compare_value(
+            expected, "OutgoingPathState", "status_code", str(actual.kind.status)
+        )
     elif actual.kind.is_completed():
         compare_value(expected, "OutgoingPathState", "state", "completed")
     elif actual.kind.is_rejected():
@@ -240,7 +244,7 @@ def compare_json_to_transfer_state(expected: dict, actual: norddrop.TransferStat
     else:
         compare_value(expected, "TranfserState", "state", "failed")
         keys.append("status_code")
-        compare_value(expected, "TranfserState", "status_code", actual.kind.status)
+        compare_value(expected, "TranfserState", "status_code", str(actual.kind.status))
 
     for key in expected:
         if key not in keys:

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -389,9 +389,9 @@ def new_event(ev: norddrop.Event) -> event.Event:
         return event.Queued(transfer_slot, ev.peer, ev.files)
 
     elif ev.is_file_started():
-        return event.Start(transfer_slot, ev.file_id, ev.transfered)
+        return event.Start(transfer_slot, ev.file_id, ev.transferred)
     elif ev.is_file_progress():
-        return event.Progress(transfer_slot, ev.file_id, ev.transfered)
+        return event.Progress(transfer_slot, ev.file_id, ev.transferred)
     elif ev.is_file_downloaded():
         return event.FinishFileDownloaded(transfer_slot, ev.file_id, ev.final_path)
     elif ev.is_file_uploaded():
@@ -408,7 +408,7 @@ def new_event(ev: norddrop.Event) -> event.Event:
     elif ev.is_file_paused():
         return event.Paused(transfer_slot, ev.file_id)
     elif ev.is_file_throttled():
-        return event.Throttled(transfer_slot, ev.file_id, ev.transfered)
+        return event.Throttled(transfer_slot, ev.file_id, ev.transferred)
     elif ev.is_file_pending():
         return event.Pending(transfer_slot, ev.file_id)
 

--- a/test/scenarios.py
+++ b/test/scenarios.py
@@ -3802,37 +3802,37 @@ scenarios = [
                     action.ExpectCancel([0], True),
                     action.AssertTransfers(
                         [
-                            """{
+                            f"""{{
                         "id": "*",
                         "created_at": "*",
                         "states": [
-                            {
+                            {{
                                 "created_at": "*",
                                 "state": "cancel",
                                 "by_peer": true
-                            }
+                            }}
                         ],
                         "type": "outgoing",
                         "paths": [
-                            {
+                            {{
                                 "relative_path": "testfile-big",
                                 "base_path": "/tmp",
                                 "bytes": 10485760,
                                 "states": [
-                                    {
+                                    {{
                                         "created_at": "*",
                                         "state": "started",
                                         "bytes_sent": 0
-                                    },
-                                    {
+                                    }},
+                                    {{
                                         "created_at": "*",
                                         "state": "failed",
-                                        "status_code": 28
-                                    }
+                                        "status_code": "{norddrop.StatusCode.FILE_MODIFIED}"
+                                    }}
                                 ]
-                            }
+                            }}
                         ]
-                    }"""
+                    }}"""
                         ]
                     ),
                     action.NoEvent(),
@@ -3872,41 +3872,41 @@ scenarios = [
                     action.ExpectCancel([0], False),
                     action.AssertTransfers(
                         [
-                            """{
+                            f"""{{
                         "id": "*",
                         "created_at": "*",
                         "states": [
-                            {
+                            {{
                                 "created_at": "*",
                                 "state": "cancel",
                                 "by_peer": false
-                            }
+                            }}
                         ],
                         "type": "incoming",
                         "paths": [
-                            {
+                            {{
                                 "relative_path": "testfile-big",
                                 "bytes": 10485760,
                                 "states": [
-                                    {
+                                    {{
                                         "created_at": "*",
                                         "state": "pending",
                                         "base_dir": "/tmp/received"
-                                    },
-                                    {
+                                    }},
+                                    {{
                                         "created_at": "*",
                                         "state": "started",
                                         "bytes_received": 0
-                                    },
-                                    {
+                                    }},
+                                    {{
                                         "created_at": "*",
                                         "state": "failed",
-                                        "status_code": 8
-                                    }
+                                        "status_code": "{norddrop.StatusCode.BAD_TRANSFER_STATE}"
+                                    }}
                                 ]
-                            }
+                            }}
                         ]
-                    }"""
+                    }}"""
                         ]
                     ),
                     action.NoEvent(),


### PR DESCRIPTION
This PR contains typo fixes `transfered -> transferred` and the second change is using strongly typed statutes for DB dump and subsequent tests fixes