### PR TITLE
Implement automatic transfer cancelation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ---
 * Remove support for deprecated, unsecure protocols V1, V2, V4 and V5
 * Sanitize file ID before downloading a file, to prevent the temporary file from being allowed to traverse parent dirs
+* Implement automatic transfer cancellation when all files reach the terminal state
 
 ---
 <br>

--- a/drop-transfer/src/service.rs
+++ b/drop-transfer/src/service.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 use crate::{
     auth,
     error::ResultExt,
-    manager,
+    manager::{self},
     tasks::AliveWaiter,
     transfer::Transfer,
     ws::{self, EventTxFactory},
@@ -226,7 +226,8 @@ impl Service {
                 .await
             {
                 Ok(res) => {
-                    res.events.rejected(false).await;
+                    res.file_events.rejected(false).await;
+                    super::ws::client::handle_finish_xfer_state(res.xfer_state, false).await;
                     return Ok(());
                 }
                 Err(crate::Error::BadTransfer) => (),
@@ -254,7 +255,8 @@ impl Service {
                         tmp_bases.into_iter().map(|base| (base, &file)),
                     );
 
-                    res.events.rejected(false).await;
+                    res.file_events.rejected(false).await;
+                    super::ws::server::handle_finish_xfer_state(res.xfer_state, false).await;
                     return Ok(());
                 }
                 Err(crate::Error::BadTransfer) => (),

--- a/drop-transfer/src/ws/client/handler.rs
+++ b/drop-transfer/src/ws/client/handler.rs
@@ -29,7 +29,12 @@ pub trait HandlerInit {
 #[async_trait::async_trait]
 pub trait HandlerLoop {
     async fn issue_reject(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
-    async fn issue_failure(&mut self, ws: &mut WebSocket, file_id: FileId) -> anyhow::Result<()>;
+    async fn issue_failure(
+        &mut self,
+        ws: &mut WebSocket,
+        file_id: FileId,
+        msg: String,
+    ) -> anyhow::Result<()>;
 
     async fn on_close(&mut self);
     async fn on_text_msg(
@@ -44,7 +49,6 @@ pub trait HandlerLoop {
 #[async_trait::async_trait]
 pub trait Uploader: Send + 'static {
     async fn chunk(&mut self, chunk: &[u8]) -> crate::Result<()>;
-    async fn error(&mut self, msg: String);
 
     // File stream offset
     fn offset(&self) -> u64;

--- a/drop-transfer/src/ws/server/v6.rs
+++ b/drop-transfer/src/ws/server/v6.rs
@@ -281,7 +281,8 @@ impl HandlerLoop<'_> {
                     tmp_bases.into_iter().map(|base| (base, &file_id)),
                 );
 
-                res.events.rejected(true).await;
+                res.file_events.rejected(true).await;
+                super::handle_finish_xfer_state(res.xfer_state, true).await;
             }
             Ok(None) => (),
         }
@@ -325,11 +326,13 @@ impl HandlerLoop<'_> {
                     warn!(self.logger, "Failed to accept failure: {err}");
                 }
                 Ok(Some(res)) => {
-                    res.events
+                    res.file_events
                         .failed(crate::Error::BadTransferState(format!(
                             "Sender reported an error: {msg}"
                         )))
                         .await;
+
+                    super::handle_finish_xfer_state(res.xfer_state, true).await;
                 }
                 Ok(None) => (),
             }


### PR DESCRIPTION
This PR adds the automatic cancelation feature. This is done by checking on each file reaching any terminal state to see if there's any file not yet in the terminal state. If there isn't, the transfer is automatically canceled by the peer who receives the notification about the file state change.
Additionally, I've implemented a check upon establishing the connection to see if the transfer should be canceled based on file states to account for transfers created by old libdrop versions and to be double sure the mechanism works.