### PR TITLE
FILE-613: retrieve private key always

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 * Add `base_dir` field to the `FilePending` event
 * Update moose tracker to v13.1.0
     * Adds the `transfer_intent_received` event
+* Added private key retrieval on demand instead of caching it
 
 ---
 <br>

--- a/drop-transfer/examples/udrop.rs
+++ b/drop-transfer/examples/udrop.rs
@@ -315,7 +315,12 @@ async fn main() -> anyhow::Result<()> {
 
     let auth = {
         let pubkey = drop_auth::PublicKey::from(PUB_KEY);
-        auth::Context::new(drop_auth::SecretKey::from(PRIV_KEY), move |_| Some(pubkey))
+        let privkey = move || {
+            let privkey = drop_auth::SecretKey::from(PRIV_KEY);
+            Some(privkey)
+        };
+
+        auth::Context::new(privkey, move |_| Some(pubkey))
     };
 
     let storage_file = matches.get_one::<String>("storage").unwrap();

--- a/drop-transfer/src/ws/server/v6.rs
+++ b/drop-transfer/src/ws/server/v6.rs
@@ -97,7 +97,7 @@ impl<'a> handler::HandlerInit for HandlerInit<'a> {
             .context("Failed to receive transfer request")?;
 
         // print msg as ascii
-        debug!(self.logger, "************** msg:\n\t{msg:?}");
+        debug!(self.logger, "msg:\n\t{msg:?}");
 
         let msg = msg.to_str().ok().context("Expected JSON message")?;
         debug!(self.logger, "Request received:\n\t{msg}");

--- a/norddrop/src/uni.rs
+++ b/norddrop/src/uni.rs
@@ -1,7 +1,5 @@
 use std::sync::Mutex;
 
-use drop_auth::{PublicKey, SecretKey, PUBLIC_KEY_LENGTH};
-
 use crate::{device::NordDropFFI, Event, TransferDescriptor, TransferInfo};
 
 pub type Result<T> = std::result::Result<T, crate::LibdropError>;
@@ -36,20 +34,9 @@ impl NordDrop {
     ) -> Result<Self> {
         let logger = super::log::create(logger);
 
-        let privkey = key_store.privkey();
-        let privkey: [u8; PUBLIC_KEY_LENGTH] = privkey
-            .try_into()
-            .map_err(|_| crate::LibdropError::InvalidPrivkey)?;
-        let privkey = SecretKey::from(privkey);
-
         let dev = NordDropFFI::new(
             move |ev| event_callback.on_event(ev),
-            move |peer_ip| {
-                let pubkey = key_store.on_pubkey(peer_ip.to_string())?;
-                let pubkey: [u8; PUBLIC_KEY_LENGTH] = pubkey.try_into().ok()?;
-                Some(PublicKey::from(pubkey))
-            },
-            privkey,
+            key_store.into(),
             logger,
         )?;
 

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -68,7 +68,7 @@ class EventQueue(norddrop.EventCallback):
     def on_event(self, event: norddrop.Event):
         event = new_event(event)
         if DEBUG_PRINT_EVENT:
-            tprint(bcolors.HEADER + "--- event: ", event, bcolors.ENDC, flush=True)
+            tprint(bcolors.HEADER + "event: ", event, bcolors.ENDC, flush=True)
 
         with self._lock:
             self._events.append(event)

--- a/test/runner.py
+++ b/test/runner.py
@@ -4,6 +4,8 @@ import math
 import os
 import re
 import time
+import sys
+from datetime import timedelta
 from threading import Semaphore
 from typing import Tuple
 
@@ -132,6 +134,7 @@ def run():
     for s in scenarios:
         total_containers += len(s.runners())
 
+    start_time = time.time()
     while True:
         if len(already_done) == len(scenarios):
             break
@@ -202,8 +205,6 @@ def run():
                     info = ContainerHolder(container, scenario.id(), TESTCASE_TIMEOUT)
                     scenario_results[scenario.id()].append(info)
 
-        curr_time = time.strftime("%H:%M:%S", time.localtime())
-
         done_containers = 0
         failed_container_count = 0
         for scenario in scenarios:
@@ -214,11 +215,11 @@ def run():
                         success, reason = container.success()
                         if not success:
                             failed_container_count += 1
-
-        print(
-            f"*** Test suite progress: {curr_time}: {done_containers}/{total_containers} containers finished, {failed_container_count} failed",
-            flush=True,
+        elapsed_time = str(timedelta(seconds=(round(time.time() - start_time))))
+        sys.stdout.write(
+            f"Testing in progress. Elapsed time: {elapsed_time}. Container exit stats: {done_containers}/{total_containers}, of those failed: {failed_container_count}\r"
         )
+        sys.stdout.flush()
 
         time.sleep(1)
 


### PR DESCRIPTION
Private key retrieval was previously done on `device::new()` once and stored, however API users sometimes hcange the private key and need to recreate libdrop instance. However it's no tthe ideal way of doing things and thus this PR just queries for the private key each time it needs.