### PR TITLE
Implement auto retries under a config feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -103,7 +103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -921,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1193,13 +1193,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1260,16 +1261,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.3",
- "libc",
 ]
 
 [[package]]
@@ -1569,7 +1560,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1816,12 +1807,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1891,7 +1882,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1992,27 +1983,26 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2587,6 +2577,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 * Update moose tracker to v13.1.0
     * Adds the `transfer_intent_received` event
 * Added private key retrieval on demand instead of caching it
+* Add internal retries and put under a config feature `auto_retry_interval_ms`
 
 ---
 <br>

--- a/drop-config/src/lib.rs
+++ b/drop-config/src/lib.rs
@@ -17,6 +17,7 @@ pub struct DropConfig {
     // Default value is 256KB.
     pub checksum_events_granularity: u64,
     pub connection_retries: u32,
+    pub auto_retry_interval: Option<Duration>,
 }
 
 impl Default for DropConfig {
@@ -28,6 +29,7 @@ impl Default for DropConfig {
             checksum_events_size_threshold: None,
             checksum_events_granularity: 256 * 1024,
             connection_retries: 5,
+            auto_retry_interval: None,
         }
     }
 }

--- a/norddrop/src/config.rs
+++ b/norddrop/src/config.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 #[derive(Debug)]
 pub struct Config {
     pub dir_depth_limit: u64,
@@ -8,6 +10,7 @@ pub struct Config {
     pub checksum_events_size_threshold: Option<u64>,
     pub checksum_events_granularity: Option<u64>,
     pub connection_retries: Option<u32>,
+    pub auto_retry_interval_ms: Option<u32>,
 }
 
 impl Config {
@@ -31,6 +34,7 @@ impl From<Config> for drop_config::Config {
             checksum_events_size_threshold,
             checksum_events_granularity,
             connection_retries,
+            auto_retry_interval_ms,
         } = val;
 
         drop_config::Config {
@@ -43,6 +47,8 @@ impl From<Config> for drop_config::Config {
                     .unwrap_or(Config::default_checksum_granularity() as _),
                 connection_retries: connection_retries
                     .unwrap_or(Config::default_connection_retries()),
+                auto_retry_interval: auto_retry_interval_ms
+                    .map(|ms| Duration::from_millis(ms as _)),
             },
             moose: drop_config::MooseConfig {
                 event_path: moose_event_path,

--- a/norddrop/src/norddrop.udl
+++ b/norddrop/src/norddrop.udl
@@ -58,8 +58,29 @@ dictionary Config {
     /// Emit checksum events at set granularity
     u64? checksum_events_granularity;
 
-    /// Limits the number of connection retries afer the `network_refresh()` call.
+    /// Limits the number of burst connection retries after the
+    /// `network_refresh()` call. Setting this to `0` or `1` gives an effect of
+    /// only one retry after `network_refresh()` call.
+    /// When set to `n > 1` the retry happens in a burst of `n` times and the
+    /// interval between burst retries is increased by the power of 2 starting
+    /// from 1-second interval. For example for `n = 5` the retries happen
+    /// * 1st burst retry immediately
+    /// * 2nd burst retry after 1s the previous burst retry
+    /// * 3rd burst retry after 2s the previous burst retry
+    /// * 4th burst retry after 4s the previous burst retry
+    /// * 5th burst retry after 8s the previous burst retry
+    /// When set to `null` the default of 5 burst retries is used.
     u32? connection_retries;
+
+    /// Enable auto retry loop inside libdrop. Conceptually this means that
+    /// libdrop is calling `network_refresh()` automatically with the given
+    /// period in milliseconds. When set to `null` the feature is disabled and
+    /// the application needs to call  `network_refresh()` manually.
+    /// Note the setting `connection_retries` still applies, meaning the retry
+    /// is executed in burst with this number of counts.
+    /// For example for a single retry every 5 seconds the application needs to
+    /// set `connection_retries` to `1` or `0` and `auto_retry_interval_ms = 5000`.
+    u32? auto_retry_interval_ms;
 };
 
 /// Posible log levels.

--- a/test/drop_test/action.py
+++ b/test/drop_test/action.py
@@ -974,11 +974,13 @@ class Start(Action):
         dbpath: str = ":memory:",
         checksum_events_size_threshold=2**32,  # don't emit events for existing tests
         checksum_events_granularity=None,
+        auto_retry_interval_ms=None,
     ):
         self._addr = addr
         self._dbpath = dbpath
         self._checksum_events_size_threshold = checksum_events_size_threshold
         self._checksum_events_granularity = checksum_events_granularity
+        self._auto_retry_interval_ms = auto_retry_interval_ms
 
     async def run(self, drop: ffi.Drop):
         drop.start(
@@ -986,6 +988,7 @@ class Start(Action):
             self._dbpath,
             self._checksum_events_size_threshold,
             self._checksum_events_granularity,
+            self._auto_retry_interval_ms,
         )
 
     def __str__(self):

--- a/test/drop_test/ffi.py
+++ b/test/drop_test/ffi.py
@@ -322,6 +322,7 @@ class Drop:
         dbpath: str,
         checksum_events_size_threshold=None,
         checksum_events_granularity=None,
+        auto_retry_interval_ms=None,
     ):
         cfg = norddrop.Config(
             dir_depth_limit=5,
@@ -332,6 +333,7 @@ class Drop:
             checksum_events_size_threshold=checksum_events_size_threshold,
             checksum_events_granularity=checksum_events_granularity,
             connection_retries=1,
+            auto_retry_interval_ms=auto_retry_interval_ms,
         )
 
         self._instance.start(addr, cfg)


### PR DESCRIPTION
As in the title. I've needed to update tokio crate to leverage the `tokio::sync::watch::Sender` `Clone` implementation, which was not available in the version we were using before