### PR TITLE
LLT-5682: Android update the page size to 16kB

### DIFF
--- a/norddrop/build.rs
+++ b/norddrop/build.rs
@@ -88,7 +88,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     if target_os == "android" {
         let pkg_name = env!("CARGO_PKG_NAME");
         let soname = format!("lib{}.so", pkg_name);
-        println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{}", soname);
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-z,max-page-size=16384,-soname,{}", soname);
     }
 
     Ok(())


### PR DESCRIPTION
Due to the researching the Page Size has been updated to 16kB:
https://developer.android.com/guide/practices/page-sizes
"Beginning with Android 15, AOSP supports devices that are configured to use a page size of 16 KB (16 KB devices). If your app uses any [NDK](https://developer.android.com/ndk) libraries, either directly or indirectly through an SDK, then you will need to rebuild your app for it to work on these 16 KB devices."
"Adding support for 16 KB page size devices enables your app to run on these devices and helps your app benefit from the associated performance improvements. Without recompiling, apps might not work on 16 KB devices when they are productionized in future Android releases."

Now a reseaching has been started to verify the potential issues etc.